### PR TITLE
rename: Shield → Arcis across Node.js, Python, and Go packages

### DIFF
--- a/packages/shield-go/echo/echo.go
+++ b/packages/shield-go/echo/echo.go
@@ -188,7 +188,7 @@ func Cleanup() {
 	activeInstances = nil
 }
 
-// Middleware returns an Echo middleware with default Shield configuration.
+// Middleware returns an Echo middleware with default Arcis configuration.
 func Middleware() echo.MiddlewareFunc {
 	return MiddlewareWithConfig(DefaultConfig())
 }
@@ -196,7 +196,7 @@ func Middleware() echo.MiddlewareFunc {
 // MiddlewareWithConfig returns an Echo middleware with custom configuration.
 func MiddlewareWithConfig(config Config) echo.MiddlewareFunc {
 	// Convert to core Arcis config
-	shieldConfig := arcis.Config{
+	arcisConfig := arcis.Config{
 		Sanitize:          config.Sanitize,
 		SanitizeXSS:       config.SanitizeXSS,
 		SanitizeSQL:       config.SanitizeSQL,
@@ -219,7 +219,7 @@ func MiddlewareWithConfig(config Config) echo.MiddlewareFunc {
 		IsDev:             config.IsDev,
 	}
 
-	sanitizer := arcis.NewSanitizer(shieldConfig)
+	sanitizer := arcis.NewSanitizer(arcisConfig)
 	instance := &arcisInstance{}
 
 	var rateLimiter *arcis.RateLimiter
@@ -234,7 +234,7 @@ func MiddlewareWithConfig(config Config) echo.MiddlewareFunc {
 
 	var securityHeaders *arcis.SecurityHeaders
 	if config.Headers {
-		securityHeaders = arcis.NewSecurityHeaders(shieldConfig)
+		securityHeaders = arcis.NewSecurityHeaders(arcisConfig)
 	}
 
 	activeInstances = append(activeInstances, instance)
@@ -286,7 +286,7 @@ func Headers() echo.MiddlewareFunc {
 
 // HeadersWithConfig returns a headers middleware with custom configuration.
 func HeadersWithConfig(config Config) echo.MiddlewareFunc {
-	shieldConfig := arcis.Config{
+	arcisConfig := arcis.Config{
 		CSP:               config.CSP,
 		FrameOptions:      config.FrameOptions,
 		HSTSMaxAge:        config.HSTSMaxAge,
@@ -297,7 +297,7 @@ func HeadersWithConfig(config Config) echo.MiddlewareFunc {
 		CacheControlValue: config.CacheControlValue,
 	}
 
-	headers := arcis.NewSecurityHeaders(shieldConfig)
+	headers := arcis.NewSecurityHeaders(arcisConfig)
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -387,7 +387,7 @@ func Sanitizer() echo.MiddlewareFunc {
 
 // SanitizerWithConfig returns a sanitizer middleware with custom configuration.
 func SanitizerWithConfig(config Config) echo.MiddlewareFunc {
-	shieldConfig := arcis.Config{
+	arcisConfig := arcis.Config{
 		SanitizeXSS:   config.SanitizeXSS,
 		SanitizeSQL:   config.SanitizeSQL,
 		SanitizeNoSQL: config.SanitizeNoSQL,
@@ -396,7 +396,7 @@ func SanitizerWithConfig(config Config) echo.MiddlewareFunc {
 		MaxInputSize:  config.MaxInputSize,
 	}
 
-	sanitizer := arcis.NewSanitizer(shieldConfig)
+	sanitizer := arcis.NewSanitizer(arcisConfig)
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {

--- a/packages/shield-go/echo/echo_test.go
+++ b/packages/shield-go/echo/echo_test.go
@@ -1,5 +1,5 @@
 /*
-Shield Echo Adapter Tests
+Arcis Echo Adapter Tests
 =========================
 
 Tests for Echo middleware integration aligned with TEST_VECTORS.json spec.
@@ -555,7 +555,7 @@ func TestMiddleware_RemovesFingerprintHeaders(t *testing.T) {
 	e := echo.New()
 	e.Use(Middleware())
 	e.GET("/", func(c echo.Context) error {
-		// Try to set these headers (Shield should remove them)
+		// Try to set these headers (Arcis should remove them)
 		c.Response().Header().Set("Server", "Apache/2.4.41")
 		c.Response().Header().Set("X-Powered-By", "PHP/7.4")
 		return c.String(http.StatusOK, "OK")
@@ -579,11 +579,11 @@ func TestMiddleware_RemovesFingerprintHeaders(t *testing.T) {
 // ============================================================================
 
 func TestContextKeys(t *testing.T) {
-	if SanitizerKey != "shield_sanitizer" {
-		t.Errorf("Expected SanitizerKey 'shield_sanitizer', got %s", SanitizerKey)
+	if SanitizerKey != "arcis_sanitizer" {
+		t.Errorf("Expected SanitizerKey 'arcis_sanitizer', got %s", SanitizerKey)
 	}
-	if ValidatedBodyKey != "shield_validated_body" {
-		t.Errorf("Expected ValidatedBodyKey 'shield_validated_body', got %s", ValidatedBodyKey)
+	if ValidatedBodyKey != "arcis_validated_body" {
+		t.Errorf("Expected ValidatedBodyKey 'arcis_validated_body', got %s", ValidatedBodyKey)
 	}
 }
 

--- a/packages/shield-go/gin/gin.go
+++ b/packages/shield-go/gin/gin.go
@@ -180,7 +180,7 @@ func Cleanup() {
 	activeInstances = nil
 }
 
-// Middleware returns a Gin middleware with default Shield configuration.
+// Middleware returns a Gin middleware with default Arcis configuration.
 func Middleware() gin.HandlerFunc {
 	return MiddlewareWithConfig(DefaultConfig())
 }
@@ -188,7 +188,7 @@ func Middleware() gin.HandlerFunc {
 // MiddlewareWithConfig returns a Gin middleware with custom configuration.
 func MiddlewareWithConfig(config Config) gin.HandlerFunc {
 	// Convert to core Arcis config
-	shieldConfig := arcis.Config{
+	arcisConfig := arcis.Config{
 		Sanitize:          config.Sanitize,
 		SanitizeXSS:       config.SanitizeXSS,
 		SanitizeSQL:       config.SanitizeSQL,
@@ -211,7 +211,7 @@ func MiddlewareWithConfig(config Config) gin.HandlerFunc {
 		IsDev:             config.IsDev,
 	}
 
-	sanitizer := arcis.NewSanitizer(shieldConfig)
+	sanitizer := arcis.NewSanitizer(arcisConfig)
 	instance := &arcisInstance{}
 
 	var rateLimiter *arcis.RateLimiter
@@ -226,7 +226,7 @@ func MiddlewareWithConfig(config Config) gin.HandlerFunc {
 
 	var securityHeaders *arcis.SecurityHeaders
 	if config.Headers {
-		securityHeaders = arcis.NewSecurityHeaders(shieldConfig)
+		securityHeaders = arcis.NewSecurityHeaders(arcisConfig)
 	}
 
 	activeInstances = append(activeInstances, instance)
@@ -277,7 +277,7 @@ func Headers() gin.HandlerFunc {
 
 // HeadersWithConfig returns a headers middleware with custom configuration.
 func HeadersWithConfig(config Config) gin.HandlerFunc {
-	shieldConfig := arcis.Config{
+	arcisConfig := arcis.Config{
 		CSP:               config.CSP,
 		FrameOptions:      config.FrameOptions,
 		HSTSMaxAge:        config.HSTSMaxAge,
@@ -288,7 +288,7 @@ func HeadersWithConfig(config Config) gin.HandlerFunc {
 		CacheControlValue: config.CacheControlValue,
 	}
 
-	headers := arcis.NewSecurityHeaders(shieldConfig)
+	headers := arcis.NewSecurityHeaders(arcisConfig)
 
 	return func(c *gin.Context) {
 		for key, value := range headers.GetHeaders() {
@@ -375,7 +375,7 @@ func Sanitizer() gin.HandlerFunc {
 
 // SanitizerWithConfig returns a sanitizer middleware with custom configuration.
 func SanitizerWithConfig(config Config) gin.HandlerFunc {
-	shieldConfig := arcis.Config{
+	arcisConfig := arcis.Config{
 		SanitizeXSS:   config.SanitizeXSS,
 		SanitizeSQL:   config.SanitizeSQL,
 		SanitizeNoSQL: config.SanitizeNoSQL,
@@ -384,7 +384,7 @@ func SanitizerWithConfig(config Config) gin.HandlerFunc {
 		MaxInputSize:  config.MaxInputSize,
 	}
 
-	sanitizer := arcis.NewSanitizer(shieldConfig)
+	sanitizer := arcis.NewSanitizer(arcisConfig)
 
 	return func(c *gin.Context) {
 		c.Set("arcis_sanitizer", sanitizer)

--- a/packages/shield-go/gin/gin_test.go
+++ b/packages/shield-go/gin/gin_test.go
@@ -1,5 +1,5 @@
 /*
-Shield Gin Adapter Tests
+Arcis Gin Adapter Tests
 ========================
 
 Tests for Gin middleware integration aligned with TEST_VECTORS.json spec.
@@ -554,7 +554,7 @@ func TestMiddleware_RemovesFingerprintHeaders(t *testing.T) {
 	r := gin.New()
 	r.Use(Middleware())
 	r.GET("/", func(c *gin.Context) {
-		// Try to set these headers (Shield should remove them)
+		// Try to set these headers (Arcis should remove them)
 		c.Writer.Header().Set("Server", "Apache/2.4.41")
 		c.Writer.Header().Set("X-Powered-By", "PHP/7.4")
 		c.String(http.StatusOK, "OK")

--- a/packages/shield-node/package.json
+++ b/packages/shield-node/package.json
@@ -55,12 +55,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/aspect-dev/shield"
+    "url": "https://github.com/GagancM/arcis"
   },
   "bugs": {
-    "url": "https://github.com/aspect-dev/shield/issues"
+    "url": "https://github.com/GagancM/arcis/issues"
   },
-  "homepage": "https://github.com/aspect-dev/shield#readme",
+  "homepage": "https://github.com/GagancM/arcis#readme",
   "engines": {
     "node": ">=18.0.0"
   }

--- a/packages/shield-node/tests/integration.test.ts
+++ b/packages/shield-node/tests/integration.test.ts
@@ -1,14 +1,14 @@
 /**
- * Integration Tests for @shield/node
- * 
+ * Integration Tests for @arcis/node
+ *
  * These tests spin up real Express servers and make actual HTTP requests
- * to verify Shield protections work correctly end-to-end.
+ * to verify Arcis protections work correctly end-to-end.
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import express, { Express, Request, Response, NextFunction } from 'express';
 import { createServer, Server } from 'http';
-import shield, {
+import arcis, {
   createSanitizer,
   createRateLimiter,
   createHeaders,
@@ -51,18 +51,18 @@ async function createTestServer(setupRoutes: (app: Express) => void): Promise<Te
 }
 
 // ============================================
-// FULL SHIELD MIDDLEWARE INTEGRATION
+// FULL ARCIS MIDDLEWARE INTEGRATION
 // ============================================
 
-describe('Integration: Full Shield Middleware', () => {
+describe('Integration: Full Arcis Middleware', () => {
   let testServer: TestServer;
-  let shieldMiddleware: ReturnType<typeof shield>;
+  let arcisMiddleware: ReturnType<typeof arcis>;
 
   beforeAll(async () => {
-    shieldMiddleware = shield({ rateLimit: { max: 100, windowMs: 60000 } });
-    
+    arcisMiddleware = arcis({ rateLimit: { max: 100, windowMs: 60000 } });
+
     testServer = await createTestServer((app) => {
-      app.use(...shieldMiddleware);
+      app.use(...arcisMiddleware);
       
       app.post('/echo', (req: Request, res: Response) => {
         res.json({ received: req.body });
@@ -75,7 +75,7 @@ describe('Integration: Full Shield Middleware', () => {
   });
 
   afterAll(async () => {
-    (shieldMiddleware as any).close?.();
+    (arcisMiddleware as any).close?.();
     await testServer.close();
   });
 

--- a/packages/shield-python/shield/__init__.py
+++ b/packages/shield-python/shield/__init__.py
@@ -6,7 +6,7 @@ One-line security for Flask, FastAPI, and Django applications.
 
 Usage:
     # Flask
-    from shield import Arcis
+    from arcis import Arcis
     app = Flask(__name__)
     arcis = Arcis(app)
 
@@ -18,7 +18,7 @@ Usage:
 
     # FastAPI
     from fastapi import FastAPI, Depends
-    from shield.fastapi import ArcisMiddleware, get_json
+    from arcis.fastapi import ArcisMiddleware, get_json
 
     app = FastAPI()
     app.add_middleware(ArcisMiddleware)
@@ -28,7 +28,7 @@ Usage:
         pass  # data is sanitized
 
     # FastAPI with async rate limiter (new!)
-    from shield.fastapi import AsyncRateLimiter, create_rate_limit_dependency
+    from arcis.fastapi import AsyncRateLimiter, create_rate_limit_dependency
 
     # Per-route rate limiting
     strict_limit = create_rate_limit_dependency(max_requests=10)
@@ -38,10 +38,10 @@ Usage:
         pass
 
     # Django (settings.py)
-    MIDDLEWARE = ['shield.django.ArcisMiddleware', ...]
+    MIDDLEWARE = ['arcis.django.ArcisMiddleware', ...]
 
     # In views:
-    from shield.django import get_json
+    from arcis.django import get_json
     def my_view(request):
         data = get_json(request)
 
@@ -151,7 +151,7 @@ if _HAS_ASYNC:
     ])
 
 # Redis store is available as a separate submodule (requires redis extra):
-#   from shield.stores.redis import RedisRateLimitStore       # sync (Flask/Django)
-#   from shield.stores.redis import AsyncRedisRateLimitStore  # async (FastAPI)
+#   from arcis.stores.redis import RedisRateLimitStore       # sync (Flask/Django)
+#   from arcis.stores.redis import AsyncRedisRateLimitStore  # async (FastAPI)
 #
 # Install with: pip install arcis[redis]

--- a/packages/shield-python/shield/core.py
+++ b/packages/shield-python/shield/core.py
@@ -895,7 +895,7 @@ class Arcis:
 
     Usage:
         # Flask
-        from shield import Arcis
+        from arcis import Arcis
         Arcis(app)
 
         # Or configure:

--- a/packages/shield-python/shield/django.py
+++ b/packages/shield-python/shield/django.py
@@ -1,18 +1,18 @@
 """
-Shield Django Integration
-=========================
+Arcis Django Integration
+========================
 
-Django middleware for Shield security.
+Django middleware for Arcis security.
 
 Usage:
     # settings.py
     MIDDLEWARE = [
-        'shield.django.ShieldMiddleware',
+        'arcis.django.ArcisMiddleware',
         # ... other middleware
     ]
-    
+
     # Optional configuration in settings.py
-    SHIELD_CONFIG = {
+    ARCIS_CONFIG = {
         'sanitize': True,
         'sanitize_xss': True,
         'sanitize_sql': True,
@@ -56,35 +56,35 @@ def get_client_ip(request: HttpRequest) -> str:
     return request.META.get('REMOTE_ADDR', 'unknown')
 
 
-class ShieldMiddleware(MiddlewareMixin):
+class ArcisMiddleware(MiddlewareMixin):
     """
     Django middleware that provides XSS/SQL/NoSQL/Path sanitization,
     rate limiting, security headers, and error handling.
-    
+
     Usage:
         # settings.py
         MIDDLEWARE = [
-            'shield.django.ShieldMiddleware',
+            'arcis.django.ArcisMiddleware',
             ...
         ]
-        
-        # Optional: Configure Shield
-        SHIELD_CONFIG = {
+
+        # Optional: Configure Arcis
+        ARCIS_CONFIG = {
             'rate_limit_max': 50,
             'sanitize_sql': False,  # Disable SQL sanitization
             'is_dev': True,  # Show error details
         }
     """
-    
+
     # Shared rate limiter store across all instances
     _rate_limit_store = InMemoryStore()
     _rate_limiter: Optional[RateLimiter] = None
-    
+
     def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
         self.get_response = get_response
-        
+
         # Load configuration from Django settings
-        config = getattr(settings, 'SHIELD_CONFIG', {})
+        config = getattr(settings, 'ARCIS_CONFIG', {})
         
         # Initialize sanitizer
         sanitize_enabled = config.get('sanitize', True)
@@ -100,14 +100,14 @@ class ShieldMiddleware(MiddlewareMixin):
         
         # Initialize rate limiter (shared across instances)
         rate_limit_enabled = config.get('rate_limit', True)
-        if rate_limit_enabled and ShieldMiddleware._rate_limiter is None:
-            ShieldMiddleware._rate_limiter = RateLimiter(
+        if rate_limit_enabled and ArcisMiddleware._rate_limiter is None:
+            ArcisMiddleware._rate_limiter = RateLimiter(
                 max_requests=config.get('rate_limit_max', 100),
                 window_ms=config.get('rate_limit_window_ms', 60000),
                 key_func=lambda req: get_client_ip(req),
                 store=self._rate_limit_store,
             )
-        self.rate_limiter = ShieldMiddleware._rate_limiter if rate_limit_enabled else None
+        self.rate_limiter = ArcisMiddleware._rate_limiter if rate_limit_enabled else None
         
         # Initialize security headers
         headers_enabled = config.get('headers', True)
@@ -146,9 +146,9 @@ class ShieldMiddleware(MiddlewareMixin):
             if 'application/json' in content_type:
                 try:
                     body = json.loads(request.body.decode('utf-8'))
-                    request._shield_sanitized_body = self.sanitizer(body)
-                    # Also accessible as request.shield_json
-                    request.shield_json = request._shield_sanitized_body
+                    request._arcis_sanitized_body = self.sanitizer(body)
+                    # Also accessible as request.arcis_json
+                    request.arcis_json = request._arcis_sanitized_body
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     pass
         
@@ -187,13 +187,13 @@ def get_sanitized_body(request: HttpRequest) -> Optional[Dict[str, Any]]:
     Get the sanitized request body from a Django request.
     
     Usage:
-        from shield.django import get_sanitized_body
+        from arcis.django import get_sanitized_body
         
         def my_view(request):
             data = get_sanitized_body(request)
             # data is sanitized
     """
-    return getattr(request, '_shield_sanitized_body', None)
+    return getattr(request, '_arcis_sanitized_body', None)
 
 
 def get_json(request: HttpRequest) -> Optional[Dict[str, Any]]:
@@ -201,7 +201,7 @@ def get_json(request: HttpRequest) -> Optional[Dict[str, Any]]:
     Alias for get_sanitized_body - more intuitive name.
     
     Usage:
-        from shield.django import get_json
+        from arcis.django import get_json
         
         def my_view(request):
             data = get_json(request)
@@ -210,21 +210,21 @@ def get_json(request: HttpRequest) -> Optional[Dict[str, Any]]:
     return get_sanitized_body(request)
 
 
-class ShieldSanitizeMiddleware(MiddlewareMixin):
+class ArcisSanitizeMiddleware(MiddlewareMixin):
     """
     Standalone sanitization middleware for Django.
     Use this if you only want sanitization without rate limiting.
-    
+
     Usage:
         MIDDLEWARE = [
-            'shield.django.ShieldSanitizeMiddleware',
+            'arcis.django.ArcisSanitizeMiddleware',
             ...
         ]
     """
-    
+
     def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
         self.get_response = get_response
-        config = getattr(settings, 'SHIELD_CONFIG', {})
+        config = getattr(settings, 'ARCIS_CONFIG', {})
         self.sanitizer = Sanitizer(
             xss=config.get('sanitize_xss', True),
             sql=config.get('sanitize_sql', True),
@@ -238,40 +238,40 @@ class ShieldSanitizeMiddleware(MiddlewareMixin):
             if 'application/json' in content_type:
                 try:
                     body = json.loads(request.body.decode('utf-8'))
-                    request._shield_sanitized_body = self.sanitizer(body)
-                    request.shield_json = request._shield_sanitized_body
+                    request._arcis_sanitized_body = self.sanitizer(body)
+                    request.arcis_json = request._arcis_sanitized_body
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     pass
         
         return self.get_response(request)
 
 
-class ShieldRateLimitMiddleware(MiddlewareMixin):
+class ArcisRateLimitMiddleware(MiddlewareMixin):
     """
     Standalone rate limiting middleware for Django.
-    
+
     Usage:
         MIDDLEWARE = [
-            'shield.django.ShieldRateLimitMiddleware',
+            'arcis.django.ArcisRateLimitMiddleware',
             ...
         ]
     """
-    
+
     _store = InMemoryStore()
     _rate_limiter: Optional[RateLimiter] = None
-    
+
     def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
         self.get_response = get_response
-        config = getattr(settings, 'SHIELD_CONFIG', {})
-        
-        if ShieldRateLimitMiddleware._rate_limiter is None:
-            ShieldRateLimitMiddleware._rate_limiter = RateLimiter(
+        config = getattr(settings, 'ARCIS_CONFIG', {})
+
+        if ArcisRateLimitMiddleware._rate_limiter is None:
+            ArcisRateLimitMiddleware._rate_limiter = RateLimiter(
                 max_requests=config.get('rate_limit_max', 100),
                 window_ms=config.get('rate_limit_window_ms', 60000),
                 key_func=lambda req: get_client_ip(req),
                 store=self._store,
             )
-        self.rate_limiter = ShieldRateLimitMiddleware._rate_limiter
+        self.rate_limiter = ArcisRateLimitMiddleware._rate_limiter
     
     def __call__(self, request: HttpRequest) -> HttpResponse:
         try:
@@ -293,20 +293,20 @@ class ShieldRateLimitMiddleware(MiddlewareMixin):
         return response
 
 
-class ShieldHeadersMiddleware(MiddlewareMixin):
+class ArcisHeadersMiddleware(MiddlewareMixin):
     """
     Standalone security headers middleware for Django.
-    
+
     Usage:
         MIDDLEWARE = [
-            'shield.django.ShieldHeadersMiddleware',
+            'arcis.django.ArcisHeadersMiddleware',
             ...
         ]
     """
-    
+
     def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
         self.get_response = get_response
-        config = getattr(settings, 'SHIELD_CONFIG', {})
+        config = getattr(settings, 'ARCIS_CONFIG', {})
         self.security_headers = SecurityHeaders(
             content_security_policy=config.get('csp'),
         )
@@ -326,21 +326,21 @@ class ShieldHeadersMiddleware(MiddlewareMixin):
         return response
 
 
-class ShieldErrorMiddleware(MiddlewareMixin):
+class ArcisErrorMiddleware(MiddlewareMixin):
     """
     Standalone error handling middleware for Django.
     Hides error details in production.
-    
+
     Usage:
         MIDDLEWARE = [
-            'shield.django.ShieldErrorMiddleware',
+            'arcis.django.ArcisErrorMiddleware',
             ...
         ]
     """
-    
+
     def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
         self.get_response = get_response
-        config = getattr(settings, 'SHIELD_CONFIG', {})
+        config = getattr(settings, 'ARCIS_CONFIG', {})
         is_dev = config.get('is_dev', settings.DEBUG)
         self.error_handler = ErrorHandler(is_dev=is_dev)
     

--- a/packages/shield-python/shield/fastapi.py
+++ b/packages/shield-python/shield/fastapi.py
@@ -142,7 +142,7 @@ class AsyncRateLimiter:
         result = await limiter.check(request)
         
         # With custom async store (e.g., Redis)
-        from shield.examples.redis_store import AsyncRedisRateLimitStore
+        from arcis.examples.redis_store import AsyncRedisRateLimitStore
         import redis.asyncio as redis
         
         redis_client = redis.Redis()
@@ -298,7 +298,7 @@ class ArcisMiddleware(BaseHTTPMiddleware):
     
     Usage:
         from fastapi import FastAPI
-        from shield.fastapi import ArcisMiddleware
+        from arcis.fastapi import ArcisMiddleware
         
         app = FastAPI()
         app.add_middleware(ArcisMiddleware)
@@ -311,7 +311,7 @@ class ArcisMiddleware(BaseHTTPMiddleware):
         )
         
         # With custom async store (e.g., Redis):
-        from shield.examples.redis_store import AsyncRedisRateLimitStore
+        from arcis.examples.redis_store import AsyncRedisRateLimitStore
         import redis.asyncio as redis
         
         redis_client = redis.Redis()
@@ -343,7 +343,7 @@ class ArcisMiddleware(BaseHTTPMiddleware):
         # Error handler options
         error_handling: bool = True,
         is_dev: bool = False,
-        # Pre-built components (for Shield class)
+        # Pre-built components (for Arcis class)
         sanitizer: Optional[Sanitizer] = None,
         rate_limiter: Optional[RateLimiter] = None,
         async_rate_limiter: Optional[AsyncRateLimiter] = None,  # NEW
@@ -462,7 +462,7 @@ def get_sanitized_body(request: Request) -> Optional[Dict[str, Any]]:
     
     Usage:
         from fastapi import Depends
-        from shield.fastapi import get_sanitized_body
+        from arcis.fastapi import get_sanitized_body
         
         @app.post("/users")
         async def create_user(body: dict = Depends(get_sanitized_body)):
@@ -478,7 +478,7 @@ def get_json(request: Request) -> Optional[Dict[str, Any]]:
     
     Usage:
         from fastapi import Depends
-        from shield.fastapi import get_json
+        from arcis.fastapi import get_json
         
         @app.post("/users")
         async def create_user(data: dict = Depends(get_json)):
@@ -494,7 +494,7 @@ async def get_rate_limit_info(request: Request) -> Optional[Dict[str, Any]]:
     
     Usage:
         from fastapi import Depends
-        from shield.fastapi import get_rate_limit_info
+        from arcis.fastapi import get_rate_limit_info
         
         @app.get("/status")
         async def status(rate_info: dict = Depends(get_rate_limit_info)):
@@ -521,7 +521,7 @@ def create_rate_limit_dependency(
     
     Usage:
         from fastapi import Depends
-        from shield.fastapi import create_rate_limit_dependency
+        from arcis.fastapi import create_rate_limit_dependency
         
         # Global rate limiter
         rate_limit = create_rate_limit_dependency(max_requests=100)

--- a/packages/shield-python/shield/stores/__init__.py
+++ b/packages/shield-python/shield/stores/__init__.py
@@ -2,5 +2,5 @@
 Arcis stores — pluggable rate limit store backends.
 
 Usage:
-    from shield.stores.redis import RedisRateLimitStore, AsyncRedisRateLimitStore
+    from arcis.stores.redis import RedisRateLimitStore, AsyncRedisRateLimitStore
 """

--- a/packages/shield-python/shield/stores/redis.py
+++ b/packages/shield-python/shield/stores/redis.py
@@ -7,8 +7,8 @@ Enables consistent rate limiting across multiple server instances.
 
 Usage (sync — Flask, Django):
     from redis import Redis
-    from shield.stores.redis import RedisRateLimitStore
-    from shield import RateLimiter
+    from arcis.stores.redis import RedisRateLimitStore
+    from arcis import RateLimiter
 
     redis_client = Redis(host='localhost', port=6379)
     store = RedisRateLimitStore(redis_client)
@@ -16,8 +16,8 @@ Usage (sync — Flask, Django):
 
 Usage (async — FastAPI):
     import redis.asyncio as redis
-    from shield.stores.redis import AsyncRedisRateLimitStore
-    from shield.fastapi import ArcisMiddleware
+    from arcis.stores.redis import AsyncRedisRateLimitStore
+    from arcis.fastapi import ArcisMiddleware
 
     redis_client = redis.Redis(host='localhost', port=6379)
     store = AsyncRedisRateLimitStore(redis_client)
@@ -87,8 +87,8 @@ class RedisRateLimitStore:
 
     Example:
         from redis import Redis
-        from shield.stores.redis import RedisRateLimitStore
-        from shield import RateLimiter
+        from arcis.stores.redis import RedisRateLimitStore
+        from arcis import RateLimiter
 
         store = RedisRateLimitStore(Redis(host='localhost', port=6379))
         limiter = RateLimiter(max_requests=100, window_ms=60000, store=store)
@@ -193,11 +193,11 @@ class AsyncRedisRateLimitStore:
 
     Example:
         import redis.asyncio as redis
-        from shield.stores.redis import AsyncRedisRateLimitStore
-        from shield.fastapi import ShieldMiddleware
+        from arcis.stores.redis import AsyncRedisRateLimitStore
+        from arcis.fastapi import ArcisMiddleware
 
         store = AsyncRedisRateLimitStore(redis.Redis(host='localhost', port=6379))
-        app.add_middleware(ShieldMiddleware, store=store)
+        app.add_middleware(ArcisMiddleware, store=store)
     """
 
     def __init__(

--- a/packages/shield-python/tests/test_benchmarks.py
+++ b/packages/shield-python/tests/test_benchmarks.py
@@ -12,7 +12,7 @@ Run with:
 """
 
 import pytest
-from shield.core import (
+from arcis.core import (
     Sanitizer,
     RateLimiter,
     SecurityHeaders,

--- a/packages/shield-python/tests/test_core.py
+++ b/packages/shield-python/tests/test_core.py
@@ -8,7 +8,7 @@ Run with: pytest tests/ -v
 
 import pytest
 import time
-from shield.core import (
+from arcis.core import (
     Sanitizer,
     RateLimiter,
     RateLimitExceeded,

--- a/packages/shield-python/tests/test_django.py
+++ b/packages/shield-python/tests/test_django.py
@@ -1,5 +1,5 @@
 """
-Shield Django Integration Tests
+Arcis Django Integration Tests
 ================================
 
 Tests for Django middleware integration.
@@ -16,7 +16,7 @@ pytest.importorskip("django")
 import django
 from django.conf import settings
 
-# Configure Django settings before importing Shield Django module
+# Configure Django settings before importing Arcis Django module
 if not settings.configured:
     settings.configure(
         DEBUG=True,
@@ -34,11 +34,11 @@ if not settings.configured:
 from django.test import RequestFactory, override_settings
 from django.http import JsonResponse
 
-from shield.django import (
-    ShieldMiddleware,
-    ShieldSanitizeMiddleware,
-    ShieldRateLimitMiddleware,
-    ShieldHeadersMiddleware,
+from arcis.django import (
+    ArcisMiddleware,
+    ArcisSanitizeMiddleware,
+    ArcisRateLimitMiddleware,
+    ArcisHeadersMiddleware,
     get_sanitized_body,
     get_client_ip,
 )
@@ -64,8 +64,8 @@ def simple_view():
 
 @pytest.fixture
 def middleware(simple_view):
-    """Shield middleware instance."""
-    return ShieldMiddleware(simple_view)
+    """Arcis middleware instance."""
+    return ArcisMiddleware(simple_view)
 
 
 # ============================================================================
@@ -103,33 +103,33 @@ class TestGetClientIP:
 # MAIN MIDDLEWARE TESTS
 # ============================================================================
 
-class TestShieldMiddleware:
-    """Test the main ShieldMiddleware."""
-    
+class TestArcisMiddleware:
+    """Test the main ArcisMiddleware."""
+
     def test_adds_security_headers(self, rf, middleware):
         request = rf.get('/')
         response = middleware(request)
-        
+
         assert 'Content-Security-Policy' in response
         assert response['X-Content-Type-Options'] == 'nosniff'
         assert response['X-Frame-Options'] == 'DENY'
-    
+
     def test_adds_rate_limit_headers(self, rf, middleware):
         request = rf.get('/')
         response = middleware(request)
-        
+
         assert 'X-RateLimit-Limit' in response
         assert 'X-RateLimit-Remaining' in response
         assert 'X-RateLimit-Reset' in response
-    
+
     def test_returns_200_for_normal_request(self, rf, middleware):
         request = rf.get('/')
         response = middleware(request)
-        
+
         assert response.status_code == 200
-    
+
     def test_sanitizes_json_body(self, rf, simple_view):
-        middleware = ShieldMiddleware(simple_view)
+        middleware = ArcisMiddleware(simple_view)
         
         request = rf.post(
             '/',
@@ -144,12 +144,12 @@ class TestShieldMiddleware:
         assert '<script>' not in sanitized['name']
 
 
-class TestShieldMiddlewareRateLimiting:
-    """Test rate limiting in Shield middleware."""
-    
-    @override_settings(SHIELD_CONFIG={'rate_limit_max': 3, 'rate_limit_window_ms': 60000})
+class TestArcisMiddlewareRateLimiting:
+    """Test rate limiting in Arcis middleware."""
+
+    @override_settings(ARCIS_CONFIG={'rate_limit_max': 3, 'rate_limit_window_ms': 60000})
     def test_blocks_over_limit(self, rf, simple_view):
-        middleware = ShieldMiddleware(simple_view)
+        middleware = ArcisMiddleware(simple_view)
         
         # Make 3 requests (all should pass)
         for i in range(3):
@@ -169,11 +169,11 @@ class TestShieldMiddlewareRateLimiting:
     
     def test_different_ips_have_separate_limits(self, rf, simple_view):
         # Create fresh middleware for this test
-        middleware = ShieldMiddleware.__new__(ShieldMiddleware)
+        middleware = ArcisMiddleware.__new__(ArcisMiddleware)
         middleware.get_response = simple_view
-        
+
         # Configure with low limit
-        from shield.core import Sanitizer, RateLimiter, SecurityHeaders, InMemoryStore
+        from arcis.core import Sanitizer, RateLimiter, SecurityHeaders, InMemoryStore
         middleware.sanitizer = Sanitizer()
         middleware.rate_limiter = RateLimiter(max_requests=2, window_ms=60000)
         middleware.security_headers = SecurityHeaders()
@@ -191,11 +191,11 @@ class TestShieldMiddlewareRateLimiting:
 # STANDALONE MIDDLEWARE TESTS
 # ============================================================================
 
-class TestShieldSanitizeMiddleware:
+class TestArcisSanitizeMiddleware:
     """Test standalone sanitization middleware."""
-    
+
     def test_sanitizes_xss(self, rf, simple_view):
-        middleware = ShieldSanitizeMiddleware(simple_view)
+        middleware = ArcisSanitizeMiddleware(simple_view)
         
         request = rf.post(
             '/',
@@ -209,7 +209,7 @@ class TestShieldSanitizeMiddleware:
         assert '<script>' not in sanitized['html']
     
     def test_sanitizes_sql(self, rf, simple_view):
-        middleware = ShieldSanitizeMiddleware(simple_view)
+        middleware = ArcisSanitizeMiddleware(simple_view)
         
         request = rf.post(
             '/',
@@ -223,7 +223,7 @@ class TestShieldSanitizeMiddleware:
         assert 'DROP' not in sanitized['query'].upper()
     
     def test_ignores_non_json_requests(self, rf, simple_view):
-        middleware = ShieldSanitizeMiddleware(simple_view)
+        middleware = ArcisSanitizeMiddleware(simple_view)
         
         request = rf.post('/', data={'name': '<script>xss</script>'})
         response = middleware(request)
@@ -232,11 +232,11 @@ class TestShieldSanitizeMiddleware:
         assert get_sanitized_body(request) is None
 
 
-class TestShieldRateLimitMiddleware:
+class TestArcisRateLimitMiddleware:
     """Test standalone rate limiting middleware."""
-    
+
     def test_adds_rate_limit_headers(self, rf, simple_view):
-        middleware = ShieldRateLimitMiddleware(simple_view)
+        middleware = ArcisRateLimitMiddleware(simple_view)
         
         request = rf.get('/')
         response = middleware(request)
@@ -245,11 +245,11 @@ class TestShieldRateLimitMiddleware:
         assert 'X-RateLimit-Remaining' in response
 
 
-class TestShieldHeadersMiddleware:
+class TestArcisHeadersMiddleware:
     """Test standalone security headers middleware."""
-    
+
     def test_adds_all_security_headers(self, rf, simple_view):
-        middleware = ShieldHeadersMiddleware(simple_view)
+        middleware = ArcisHeadersMiddleware(simple_view)
         
         request = rf.get('/')
         response = middleware(request)
@@ -265,7 +265,7 @@ class TestShieldHeadersMiddleware:
             response['Server'] = 'Apache/2.4.41'
             return response
         
-        middleware = ShieldHeadersMiddleware(view_with_server_header)
+        middleware = ArcisHeadersMiddleware(view_with_server_header)
         
         request = rf.get('/')
         response = middleware(request)
@@ -277,27 +277,27 @@ class TestShieldHeadersMiddleware:
 # CONFIGURATION TESTS
 # ============================================================================
 
-class TestShieldConfiguration:
+class TestArcisConfiguration:
     """Test middleware configuration via Django settings."""
-    
-    @override_settings(SHIELD_CONFIG={'sanitize': False})
+
+    @override_settings(ARCIS_CONFIG={'sanitize': False})
     def test_can_disable_sanitization(self, rf, simple_view):
-        middleware = ShieldMiddleware(simple_view)
+        middleware = ArcisMiddleware(simple_view)
         assert middleware.sanitizer is None
-    
-    @override_settings(SHIELD_CONFIG={'rate_limit': False})
+
+    @override_settings(ARCIS_CONFIG={'rate_limit': False})
     def test_can_disable_rate_limiting(self, rf, simple_view):
-        middleware = ShieldMiddleware(simple_view)
+        middleware = ArcisMiddleware(simple_view)
         assert middleware.rate_limiter is None
-    
-    @override_settings(SHIELD_CONFIG={'headers': False})
+
+    @override_settings(ARCIS_CONFIG={'headers': False})
     def test_can_disable_headers(self, rf, simple_view):
-        middleware = ShieldMiddleware(simple_view)
+        middleware = ArcisMiddleware(simple_view)
         assert middleware.security_headers is None
-    
-    @override_settings(SHIELD_CONFIG={'csp': "default-src 'none'"})
+
+    @override_settings(ARCIS_CONFIG={'csp': "default-src 'none'"})
     def test_custom_csp(self, rf, simple_view):
-        middleware = ShieldMiddleware(simple_view)
+        middleware = ArcisMiddleware(simple_view)
         
         request = rf.get('/')
         response = middleware(request)

--- a/packages/shield-python/tests/test_fastapi.py
+++ b/packages/shield-python/tests/test_fastapi.py
@@ -19,7 +19,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
 
-from shield.fastapi import ArcisMiddleware, get_sanitized_body
+from arcis.fastapi import ArcisMiddleware, get_sanitized_body
 
 
 # ============================================================================
@@ -219,7 +219,7 @@ class TestFastAPICustomConfig:
 # ASYNC RATE LIMITER TESTS
 # ============================================================================
 
-from shield.fastapi import (
+from arcis.fastapi import (
     AsyncInMemoryStore,
     AsyncRateLimiter,
     AsyncRateLimitExceeded,

--- a/packages/shield-python/tests/test_flask.py
+++ b/packages/shield-python/tests/test_flask.py
@@ -1,6 +1,6 @@
 """
-Shield Flask Integration Tests
-===============================
+Arcis Flask Integration Tests
+==============================
 
 Tests for Flask middleware integration.
 Run with: pytest tests/test_flask.py -v
@@ -15,8 +15,8 @@ pytest.importorskip("flask")
 
 from flask import Flask, jsonify, request, g
 
-from shield.core import (
-    Shield,
+from arcis.core import (
+    Arcis,
     Sanitizer,
     RateLimiter,
     RateLimitExceeded,
@@ -34,11 +34,11 @@ from shield.core import (
 
 @pytest.fixture
 def app():
-    """Create a Flask app with Shield protection."""
+    """Create a Flask app with Arcis protection."""
     app = Flask(__name__)
     app.config['TESTING'] = True
     
-    shield = Shield(app)
+    arcis = Arcis(app)
     
     @app.route('/')
     def index():
@@ -54,13 +54,13 @@ def app():
     def health():
         return jsonify({"status": "ok"})
     
-    # Store shield instance for cleanup
-    app.shield = shield
+    # Store arcis instance for cleanup
+    app.arcis = arcis
     
     yield app
     
     # Cleanup
-    shield.close()
+    arcis.close()
 
 
 @pytest.fixture
@@ -75,7 +75,7 @@ def rate_limited_app():
     app = Flask(__name__)
     app.config['TESTING'] = True
     
-    shield = Shield(app, rate_limit_max=3, rate_limit_window_ms=60000)
+    arcis = Arcis(app, rate_limit_max=3, rate_limit_window_ms=60000)
     
     @app.route('/')
     def index():
@@ -85,11 +85,11 @@ def rate_limited_app():
     def health():
         return jsonify({"status": "ok"})
     
-    app.shield = shield
+    app.arcis = arcis
     
     yield app
     
-    shield.close()
+    arcis.close()
 
 
 @pytest.fixture
@@ -353,12 +353,12 @@ class TestFlaskSanitization:
 # ============================================================================
 
 class TestFlaskCustomConfig:
-    """Test custom Shield configuration."""
+    """Test custom Arcis configuration."""
     
     def test_custom_csp(self):
         app = Flask(__name__)
         app.config['TESTING'] = True
-        shield = Shield(app, csp="default-src 'none'")
+        arcis = Arcis(app, csp="default-src 'none'")
         
         @app.route('/')
         def index():
@@ -368,12 +368,12 @@ class TestFlaskCustomConfig:
         response = client.get('/')
         
         assert response.headers.get('Content-Security-Policy') == "default-src 'none'"
-        shield.close()
+        arcis.close()
     
     def test_disable_sanitization(self):
         app = Flask(__name__)
         app.config['TESTING'] = True
-        shield = Shield(app, sanitize=False)
+        arcis = Arcis(app, sanitize=False)
         
         @app.route('/echo', methods=['POST'])
         def echo():
@@ -387,12 +387,12 @@ class TestFlaskCustomConfig:
         result = response.get_json()
         # Without sanitization, script tag should remain
         assert '<script>' in result['received']['name']
-        shield.close()
+        arcis.close()
     
     def test_disable_rate_limiting(self):
         app = Flask(__name__)
         app.config['TESTING'] = True
-        shield = Shield(app, rate_limit=False)
+        arcis = Arcis(app, rate_limit=False)
         
         @app.route('/')
         def index():
@@ -403,12 +403,12 @@ class TestFlaskCustomConfig:
         
         # Rate limit headers should not be present
         assert 'X-RateLimit-Limit' not in response.headers
-        shield.close()
+        arcis.close()
     
     def test_disable_headers(self):
         app = Flask(__name__)
         app.config['TESTING'] = True
-        shield = Shield(app, headers=False)
+        arcis = Arcis(app, headers=False)
         
         @app.route('/')
         def index():
@@ -419,12 +419,12 @@ class TestFlaskCustomConfig:
         
         # CSP header should not be present
         assert 'Content-Security-Policy' not in response.headers
-        shield.close()
+        arcis.close()
     
     def test_custom_rate_limit_max(self):
         app = Flask(__name__)
         app.config['TESTING'] = True
-        shield = Shield(app, rate_limit_max=50)
+        arcis = Arcis(app, rate_limit_max=50)
         
         @app.route('/')
         def index():
@@ -434,13 +434,13 @@ class TestFlaskCustomConfig:
         response = client.get('/')
         
         assert response.headers.get('X-RateLimit-Limit') == '50'
-        shield.close()
+        arcis.close()
     
     def test_disable_specific_sanitizers(self):
         app = Flask(__name__)
         app.config['TESTING'] = True
         # Disable SQL sanitization only
-        shield = Shield(app, sanitize_sql=False, sanitize_xss=True)
+        arcis = Arcis(app, sanitize_sql=False, sanitize_xss=True)
         
         @app.route('/echo', methods=['POST'])
         def echo():
@@ -454,7 +454,7 @@ class TestFlaskCustomConfig:
         result = response.get_json()
         assert '<script>' not in result['received']['name']
         
-        shield.close()
+        arcis.close()
 
 
 # ============================================================================
@@ -467,7 +467,7 @@ class TestFlaskErrorHandler:
     def test_error_handler_production_mode(self):
         app = Flask(__name__)
         app.config['TESTING'] = True
-        shield = Shield(app, is_dev=False)
+        arcis = Arcis(app, is_dev=False)
         
         @app.route('/error')
         def error_route():
@@ -482,12 +482,12 @@ class TestFlaskErrorHandler:
         assert 'stack' not in data
         assert '10.0.0.1' not in str(data)
         
-        shield.close()
+        arcis.close()
     
     def test_error_handler_development_mode(self):
         app = Flask(__name__)
         app.config['TESTING'] = True
-        shield = Shield(app, is_dev=True)
+        arcis = Arcis(app, is_dev=True)
         
         @app.route('/error')
         def error_route():
@@ -501,7 +501,7 @@ class TestFlaskErrorHandler:
         assert 'stack' in data
         assert 'Something broke' in str(data.get('details', ''))
         
-        shield.close()
+        arcis.close()
 
 
 # ============================================================================
@@ -514,7 +514,7 @@ class TestFlaskRateLimitingPerIP:
     def test_different_ips_have_separate_limits(self):
         app = Flask(__name__)
         app.config['TESTING'] = True
-        shield = Shield(app, rate_limit_max=2)
+        arcis = Arcis(app, rate_limit_max=2)
         
         @app.route('/')
         def index():
@@ -532,7 +532,7 @@ class TestFlaskRateLimitingPerIP:
         response = client.get('/')
         assert response.status_code == 429
         
-        shield.close()
+        arcis.close()
 
 
 # ============================================================================
@@ -545,7 +545,7 @@ class TestFlaskCombinedScenarios:
     def test_protected_api_endpoint(self):
         app = Flask(__name__)
         app.config['TESTING'] = True
-        shield = Shield(app, rate_limit_max=100)
+        arcis = Arcis(app, rate_limit_max=100)
         
         @app.route('/api/comments', methods=['POST'])
         def create_comment():
@@ -578,12 +578,12 @@ class TestFlaskCombinedScenarios:
         
         assert response.status_code == 201
         
-        shield.close()
+        arcis.close()
     
     def test_all_protections_work_together(self):
         app = Flask(__name__)
         app.config['TESTING'] = True
-        shield = Shield(app, rate_limit_max=100)
+        arcis = Arcis(app, rate_limit_max=100)
         
         @app.route('/api/users', methods=['POST'])
         def create_user():
@@ -620,7 +620,7 @@ class TestFlaskCombinedScenarios:
         assert 'X-RateLimit-Limit' in response.headers
         assert 'X-RateLimit-Remaining' in response.headers
         
-        shield.close()
+        arcis.close()
 
 
 # ============================================================================
@@ -633,7 +633,7 @@ class TestFlaskSchemaValidation:
     def test_schema_validation_integration(self):
         app = Flask(__name__)
         app.config['TESTING'] = True
-        shield = Shield(app)
+        arcis = Arcis(app)
         
         user_schema = {
             'email': {'type': 'email', 'required': True},
@@ -700,7 +700,7 @@ class TestFlaskSchemaValidation:
         assert 'isAdmin' not in data['user']
         assert 'secretField' not in data['user']
         
-        shield.close()
+        arcis.close()
 
 
 # ============================================================================
@@ -711,7 +711,7 @@ class TestFlaskSafeLogger:
     """Test safe logger with Flask."""
     
     def test_logger_redacts_sensitive_data(self):
-        from shield.core import SafeLogger
+        from arcis.core import SafeLogger
         
         logger = SafeLogger()
         
@@ -737,10 +737,10 @@ class TestFlaskSafeLogger:
 class TestFlaskCleanup:
     """Test proper cleanup of resources."""
     
-    def test_shield_close(self):
+    def test_arcis_close(self):
         app = Flask(__name__)
         app.config['TESTING'] = True
-        shield = Shield(app)
+        arcis = Arcis(app)
         
         @app.route('/')
         def index():
@@ -751,7 +751,7 @@ class TestFlaskCleanup:
         assert response.status_code == 200
         
         # Close should not raise
-        shield.close()
+        arcis.close()
         
         # Requests should still work after close (fail-open)
         response = client.get('/')


### PR DESCRIPTION
  Node.js (packages/shield-node):                                                                                                                                                                - package.json: update GitHub URLs to GagancM/arcis
  - tests/integration.test.ts: rename import, variables, describe labels                                                                                                                       
  
  Python (packages/shield-python):
  - shield/django.py: rename module, all middleware classes
    (ShieldMiddleware → ArcisMiddleware, etc.), SHIELD_CONFIG → ARCIS_CONFIG,
    _shield_sanitized_body → _arcis_sanitized_body, shield_json → arcis_json
  - shield/__init__.py, core.py, fastapi.py: update docstring import examples
  - shield/stores/redis.py, stores/__init__.py: update import examples
  - tests/test_flask.py: Shield class → Arcis, all shield variables → arcis
  - tests/test_django.py: all middleware class refs, SHIELD_CONFIG → ARCIS_CONFIG
  - tests/test_core.py, test_benchmarks.py, test_fastapi.py: update imports

  Go (packages/shield-go):
  - gin/gin.go, echo/echo.go: shieldConfig → arcisConfig, update comments
  - gin/gin_test.go, echo/echo_test.go: update package comments, inline comments
  - echo/echo_test.go: fix TestContextKeys to assert arcis_sanitizer /
    arcis_validated_body (was checking stale shield_* values)

  Content changes only — directory/file renames handled separately.