### PR TITLE
feat(python): add arcis scan CLI for security vulnerability scanning

### DIFF
--- a/packages/arcis-node/.claude/settings.local.json
+++ b/packages/arcis-node/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cd \"D:\\\\Projects\\\\cyber-security\\\\arcis\\\\packages\\\\arcis-python\" && pip install -e . -q && arcis --help)",
+      "Bash(arcis scan:*)"
+    ]
+  }
+}

--- a/packages/arcis-python/arcis/cli/__init__.py
+++ b/packages/arcis-python/arcis/cli/__init__.py
@@ -1,0 +1,31 @@
+"""
+Arcis CLI — command dispatcher.
+
+Usage:
+    arcis scan <url> [options]
+"""
+
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print("Usage: arcis <command> [options]")
+        print()
+        print("Commands:")
+        print("  scan    Scan HTTP endpoints for injection vulnerabilities")
+        print()
+        print("Run 'arcis <command> --help' for command-specific help.")
+        sys.exit(0)
+
+    command = sys.argv[1]
+    # Remove the subcommand so the sub-parser sees clean argv
+    sys.argv = [f"arcis {command}"] + sys.argv[2:]
+
+    if command == "scan":
+        from arcis.cli.scan import main as scan_main
+        scan_main()
+    else:
+        print(f"arcis: unknown command '{command}'")
+        print("Run 'arcis --help' for available commands.")
+        sys.exit(1)

--- a/packages/arcis-python/arcis/cli/payloads.py
+++ b/packages/arcis-python/arcis/cli/payloads.py
@@ -1,0 +1,61 @@
+"""
+Attack payload definitions for arcis scan.
+Each category maps to a list of (label, payload) tuples.
+The first payload in each category is the primary test vector.
+"""
+
+ATTACK_CATEGORIES = {
+    "XSS": [
+        ("script tag",          "<script>alert(1)</script>"),
+        ("img onerror",         "<img src=x onerror=alert(1)>"),
+        ("javascript URI",      "javascript:alert(document.cookie)"),
+        ("svg onload",          "<svg onload=alert(1)>"),
+    ],
+    "SQL Injection": [
+        ("OR bypass",           "' OR '1'='1' --"),
+        ("UNION select",        "' UNION SELECT null,null,null--"),
+        ("stacked query",       "'; DROP TABLE users--"),
+        ("comment bypass",      "1/**/OR/**/1=1"),
+    ],
+    "SQL Blind": [
+        ("SLEEP",               "'; SLEEP(5)--"),
+        ("BENCHMARK",           "'; BENCHMARK(1000000,MD5(1))--"),
+        ("WAITFOR",             "1; WAITFOR DELAY '0:0:5'--"),
+    ],
+    "NoSQL Injection": [
+        ("$gt operator",        '{"$gt": ""}'),
+        ("$where operator",     '{"$where": "1==1"}'),
+        ("$ne operator",        '{"$ne": null}'),
+        ("$regex operator",     '{"$regex": ".*"}'),
+    ],
+    "Path Traversal": [
+        ("unix passwd",         "../../etc/passwd"),
+        ("windows system32",    "..\\..\\windows\\system32\\cmd.exe"),
+        ("url encoded",         "%2e%2e%2f%2e%2e%2fetc%2fpasswd"),
+        ("null byte",           "../../etc/passwd%00"),
+    ],
+    "Command Injection": [
+        ("semicolon",           "; ls -la"),
+        ("pipe",                "| whoami"),
+        ("backtick",            "`id`"),
+        ("ampersand",           "&& cat /etc/passwd"),
+    ],
+    "Prototype Pollution": [
+        ("__proto__",           '{"__proto__": {"admin": true}}'),
+        ("constructor",         '{"constructor": {"prototype": {"admin": true}}}'),
+    ],
+    "LDAP Injection": [
+        ("wildcard",            "*)(uid=*))(|(uid=*"),
+        ("OR bypass",           "admin)(&(password=*)"),
+    ],
+}
+
+# Common field names to inject into, tried in order
+DEFAULT_FIELDS = [
+    "q", "query", "search", "input",
+    "name", "username", "email",
+    "data", "value", "text", "id",
+]
+
+# Status codes that indicate the request was blocked/rejected
+BLOCKED_STATUS_CODES = {400, 403, 422, 429}

--- a/packages/arcis-python/arcis/cli/report.py
+++ b/packages/arcis-python/arcis/cli/report.py
@@ -1,0 +1,138 @@
+"""
+Terminal output formatting for arcis scan.
+"""
+
+from __future__ import annotations
+import sys
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+# Use unicode box chars when the terminal supports it, ASCII otherwise
+_SUPPORTS_UNICODE = bool(sys.stdout.encoding and sys.stdout.encoding.lower().startswith("utf"))
+LINE_CHAR  = "─" if _SUPPORTS_UNICODE else "-"
+TICK       = "✓" if _SUPPORTS_UNICODE else "[OK]"
+CROSS      = "✗" if _SUPPORTS_UNICODE else "[!]"
+
+# ── ANSI colours ──────────────────────────────────────────────────────────────
+
+RESET  = "\033[0m"
+BOLD   = "\033[1m"
+DIM    = "\033[2m"
+GREEN  = "\033[92m"
+RED    = "\033[91m"
+YELLOW = "\033[93m"
+CYAN   = "\033[96m"
+WHITE  = "\033[97m"
+
+
+def _c(*codes: str, text: str, no_color: bool) -> str:
+    if no_color:
+        return text
+    return "".join(codes) + text + RESET
+
+
+# ── Data models ───────────────────────────────────────────────────────────────
+
+@dataclass
+class VectorResult:
+    category: str
+    label: str
+    payload: str
+    status: int
+    blocked: bool
+    note: str = ""
+
+
+@dataclass
+class RouteResult:
+    method: str
+    path: str
+    reachable: bool
+    vectors: List[VectorResult] = field(default_factory=list)
+    error: str = ""
+
+    @property
+    def protected_count(self) -> int:
+        return sum(1 for v in self.vectors if v.blocked)
+
+    @property
+    def vulnerable_count(self) -> int:
+        return sum(1 for v in self.vectors if not v.blocked)
+
+
+# ── Printer ───────────────────────────────────────────────────────────────────
+
+WIDTH = 56
+
+
+def print_report(
+    base_url: str,
+    route_results: List[RouteResult],
+    duration: float,
+    no_color: bool = False,
+) -> None:
+    line = LINE_CHAR * WIDTH
+    c = lambda text, *codes: _c(*codes, text=text, no_color=no_color)
+
+    print()
+    print(c("  Arcis Security Scan", BOLD, CYAN))
+    print(c(f"  Target: {base_url}", DIM))
+    print(c(line, DIM))
+
+    total_vectors = 0
+    total_blocked = 0
+    total_vulnerable = 0
+
+    for rr in route_results:
+        print()
+        route_label = f"  {rr.method}  {rr.path}"
+        print(c(route_label, BOLD, WHITE))
+
+        if not rr.reachable:
+            print(c(f"    {CROSS}  {rr.error}", RED))
+            continue
+
+        # Group by category for clean output
+        current_category = None
+        for v in rr.vectors:
+            total_vectors += 1
+
+            if v.category != current_category:
+                current_category = v.category
+                print(c(f"\n    {v.category}", DIM))
+
+            if v.blocked:
+                total_blocked += 1
+                status_str = c(f"{TICK}  PROTECTED", GREEN, BOLD)
+            else:
+                total_vulnerable += 1
+                status_str = c(f"{CROSS}  VULNERABLE", RED, BOLD)
+
+            label = v.label.ljust(24)
+            note  = c(f"  {v.note}", DIM)
+            print(f"      {label} {status_str}{note}")
+
+    # ── Summary ───────────────────────────────────────────────────────────────
+    print()
+    print(c(line, DIM))
+    print()
+
+    routes_scanned = sum(1 for r in route_results if r.reachable)
+    print(f"  Routes scanned    {routes_scanned}")
+    print(f"  Attack vectors    {total_vectors}")
+
+    if total_vectors == 0:
+        print(c("  No routes were reachable. Is the server running?", YELLOW))
+    elif total_vulnerable == 0:
+        protected_str = c(f"{total_blocked}  {TICK}  All vectors protected", GREEN, BOLD)
+        print(f"  Protected         {protected_str}")
+        print(f"  Vulnerable        0")
+    else:
+        print(f"  Protected         {total_blocked}")
+        vuln_str = c(f"{total_vulnerable}  {CROSS}  Add Arcis middleware to fix", RED, BOLD)
+        print(f"  Vulnerable        {vuln_str}")
+
+    print(f"  Duration          {duration:.1f}s")
+    print()
+    print(c(line, DIM))
+    print()

--- a/packages/arcis-python/arcis/cli/scan.py
+++ b/packages/arcis-python/arcis/cli/scan.py
@@ -1,0 +1,280 @@
+"""
+arcis scan — HTTP security vulnerability scanner.
+
+Usage:
+    arcis scan http://localhost:5000
+    arcis scan http://localhost:3000 --route POST:/api/users --route GET:/search
+    arcis scan http://localhost:8080 --route /api/login --field username --field password
+    arcis scan http://localhost:5000 --categories xss sql nosql
+    arcis scan http://localhost:5000 --no-color
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import sys
+import time
+import urllib.parse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List, Optional, Tuple
+
+from arcis.cli.payloads import ATTACK_CATEGORIES, BLOCKED_STATUS_CODES, DEFAULT_FIELDS
+from arcis.cli.report import RouteResult, VectorResult, print_report
+
+
+# ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+def _parse_url(url: str) -> Tuple[str, int, str, bool]:
+    """Return (host, port, path, is_https)."""
+    parsed = urllib.parse.urlparse(url)
+    is_https = parsed.scheme == "https"
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if is_https else 80)
+    path = parsed.path or "/"
+    if parsed.query:
+        path += "?" + parsed.query
+    return host, port, path, is_https
+
+
+def _send(
+    url: str,
+    method: str,
+    field: str,
+    payload: str,
+    timeout: int,
+) -> Tuple[int, str]:
+    """
+    Send one request with the given payload injected into `field`.
+    Returns (status_code, response_body). Status 0 means connection error.
+    Uses http.client for persistent connections (faster on Windows).
+    """
+    try:
+        # NoSQL payloads are JSON objects — keep them nested
+        try:
+            value: object = json.loads(payload)
+        except (json.JSONDecodeError, ValueError):
+            value = payload
+
+        host, port, base_path, is_https = _parse_url(url)
+        ConnClass = http.client.HTTPSConnection if is_https else http.client.HTTPConnection
+        conn = ConnClass(host, port, timeout=timeout)
+
+        if method == "GET":
+            encoded = urllib.parse.quote(str(payload), safe="")
+            path = f"{base_path}{'&' if '?' in base_path else '?'}{field}={encoded}"
+            conn.request("GET", path, headers={"Connection": "close"})
+        else:
+            body_bytes = json.dumps({field: value}).encode()
+            conn.request(
+                method,
+                base_path,
+                body=body_bytes,
+                headers={
+                    "Content-Type": "application/json",
+                    "Content-Length": str(len(body_bytes)),
+                    "Connection": "close",
+                },
+            )
+
+        resp = conn.getresponse()
+        body = resp.read().decode(errors="replace")
+        conn.close()
+        return resp.status, body
+
+    except Exception:
+        return 0, ""
+
+
+def _classify(status: int, body: str, payload: str) -> Tuple[bool, str]:
+    """
+    Decide if the payload was blocked.
+    Returns (blocked: bool, note: str).
+    """
+    if status == 0:
+        return False, "connection error"
+
+    if status in BLOCKED_STATUS_CODES:
+        return True, f"rejected ({status})"
+
+    # Payload reflected verbatim → not sanitised
+    if payload.strip().lower() in body.lower():
+        return False, f"reflected in response ({status})"
+
+    # 2xx but payload absent from body → sanitised / stripped
+    if 200 <= status < 300:
+        return True, f"sanitised ({status})"
+
+    return False, f"status {status}"
+
+
+# ── Route scanner ─────────────────────────────────────────────────────────────
+
+def scan_route(
+    base_url: str,
+    method: str,
+    path: str,
+    fields: List[str],
+    timeout: int,
+    categories: Optional[List[str]],
+    thorough: bool = False,
+) -> RouteResult:
+    url = base_url.rstrip("/") + "/" + path.lstrip("/")
+    result = RouteResult(method=method, path=path, reachable=False)
+
+    # Probe the route with a harmless payload first; also find working field
+    working_field = fields[0]
+    for field in fields:
+        probe_status, _ = _send(url, method, field, "hello", timeout)
+        if probe_status == 0:
+            result.error = "unreachable — is the server running?"
+            return result
+        if probe_status != 404:
+            working_field = field
+            break
+    else:
+        result.error = "404 not found"
+        return result
+
+    result.reachable = True
+
+    active = {
+        k: v for k, v in ATTACK_CATEGORIES.items()
+        if categories is None or k.lower().replace(" ", "") in [c.lower().replace(" ", "") for c in categories]
+    }
+
+    # Build the full list of (category, label, payload) to test
+    tasks: List[Tuple[str, str, str]] = []
+    for category, vectors in active.items():
+        test_vectors = vectors if thorough else [vectors[0]]
+        for label, payload in test_vectors:
+            tasks.append((category, label, payload))
+
+    # Run all vectors in parallel (up to 10 concurrent requests)
+    results_map: dict = {}
+
+    def _test(idx: int, category: str, label: str, payload: str) -> Tuple[int, str, str, int, str]:
+        status, body = _send(url, method, working_field, payload, timeout)
+        blocked, note = _classify(status, body, payload)
+        return idx, category, label, status, payload, blocked, note  # type: ignore[return-value]
+
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        futures = {
+            executor.submit(_test, i, cat, lbl, pay): i
+            for i, (cat, lbl, pay) in enumerate(tasks)
+        }
+        for future in as_completed(futures):
+            idx, category, label, status, payload, blocked, note = future.result()
+            results_map[idx] = VectorResult(
+                category=category,
+                label=label,
+                payload=payload,
+                status=status,
+                blocked=blocked,
+                note=note,
+            )
+
+    # Preserve original order
+    result.vectors = [results_map[i] for i in range(len(tasks))]
+    return result
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="arcis scan",
+        description="Scan HTTP endpoints for common injection vulnerabilities.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+examples:
+  arcis scan http://localhost:5000
+  arcis scan http://localhost:3000 --route POST:/api/users --route GET:/search
+  arcis scan http://localhost:8080 --route /api/login --field username --field password
+  arcis scan http://localhost:5000 --categories xss sql nosql
+        """,
+    )
+
+    parser.add_argument(
+        "url",
+        help="Base URL of the running server (e.g. http://localhost:5000)",
+    )
+    parser.add_argument(
+        "--route", "-r",
+        action="append",
+        dest="routes",
+        metavar="[METHOD:]PATH",
+        help=(
+            "Route to test. Format: 'POST:/api/users' or just '/api/users' (defaults to POST). "
+            "Repeat to test multiple routes."
+        ),
+    )
+    parser.add_argument(
+        "--field", "-f",
+        action="append",
+        dest="fields",
+        metavar="NAME",
+        help=(
+            "JSON field name to inject payloads into (default: tries common names). "
+            "Repeat for multiple fields."
+        ),
+    )
+    parser.add_argument(
+        "--categories", "-c",
+        nargs="+",
+        metavar="CATEGORY",
+        help=(
+            f"Attack categories to test (default: all). "
+            f"Choices: {', '.join(ATTACK_CATEGORIES.keys())}"
+        ),
+    )
+    parser.add_argument(
+        "--timeout", "-t",
+        type=int,
+        default=5,
+        help="Per-request timeout in seconds (default: 5)",
+    )
+    parser.add_argument(
+        "--thorough",
+        action="store_true",
+        help="Test all payloads per category instead of just the primary one (slower)",
+    )
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable coloured terminal output",
+    )
+
+    args = parser.parse_args()
+
+    # Parse routes — default to scanning / if none provided
+    raw_routes = args.routes or ["POST:/"]
+    routes: List[Tuple[str, str]] = []
+    for r in raw_routes:
+        if ":" in r and not r.startswith("http"):
+            method, path = r.split(":", 1)
+            routes.append((method.upper(), path))
+        else:
+            routes.append(("POST", r))
+
+    fields = args.fields or DEFAULT_FIELDS
+    categories = args.categories  # None = all
+
+    start = time.time()
+    route_results: List[RouteResult] = []
+
+    for method, path in routes:
+        rr = scan_route(args.url, method, path, fields, args.timeout, categories, thorough=args.thorough)
+        route_results.append(rr)
+
+    duration = time.time() - start
+    print_report(args.url, route_results, duration, no_color=args.no_color)
+
+    # Exit 1 if any vulnerabilities found (useful for CI)
+    any_vulnerable = any(
+        not v.blocked
+        for rr in route_results
+        for v in rr.vectors
+    )
+    sys.exit(1 if any_vulnerable else 0)

--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -48,6 +48,9 @@ dev = [
     "httpx>=0.24.0",
 ]
 
+[project.scripts]
+arcis = "arcis.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/GagancM/arcis"
 Documentation = "https://arcis.dev"
@@ -56,7 +59,7 @@ Issues = "https://github.com/GagancM/arcis/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["arcis*", "arcis.stores*"]
+include = ["arcis*"]
 
 [tool.setuptools.package-data]
 arcis = ["data/*.json"]


### PR DESCRIPTION
Adds a network-based security scanner that works against any running                                                                                                                                            HTTP server regardless of language or framework (Flask, FastAPI, Django,                                                                                                                                      
  Express, Spring, Go, etc.).                                                                                                                                                                                                                                                                                                                                                                                                     Usage:                                                                                                                                                                                                            arcis scan http://localhost:5000                                                                                                                                                                                arcis scan http://localhost:3000 --route POST:/api/login --route GET:/search                                                                                                                                    arcis scan http://localhost:8080 --field username --field email                                                                                                                                                 arcis scan http://localhost:5000 --thorough   # all payload variants                                                                                                                                        
    arcis scan http://localhost:5000 --no-color   # CI/CD friendly

  New files:
    arcis/cli/__init__.py   — command dispatcher (arcis <subcommand>)
    arcis/cli/payloads.py   — 8 attack categories, 30+ payloads
                              (XSS, SQL, SQL Blind, NoSQL, Path Traversal,
                               Command Injection, Prototype Pollution, LDAP)
    arcis/cli/scan.py       — parallel HTTP scanner + argparse CLI
    arcis/cli/report.py     — terminal output with colour + ASCII fallback

  pyproject.toml: register `arcis` as console_scripts entry point.