### PR TITLE
ci: add GitHub Actions workflow for Node.js and Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  node:
+    name: Node.js
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/arcis-node
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: packages/arcis-node/package-lock.json
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test -- --run
+
+  python:
+    name: Python
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/arcis-python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]"
+      - run: pytest


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with two jobs: Node.js and Python
- **Node.js**: `npm ci` → `typecheck` → `vitest --run` in `packages/arcis-node`
- **Python**: `pip install -e .[dev]` → `pytest` in `packages/arcis-python`
- Runs on push to `main` and on pull requests

## Test plan
- [x] Verify Node.js job passes (564 tests)
- [x] Verify Python job passes (367 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)