### PR TITLE
feat: add file upload validation and filename sanitization (Node + Py…

### DIFF
--- a/packages/arcis-node/src/index.ts
+++ b/packages/arcis-node/src/index.ts
@@ -62,6 +62,7 @@ export { sanitizeHeaderValue, sanitizeHeaders, detectHeaderInjection } from './s
 export { validate, createValidator } from './validation/schema';
 export { validateUrl, isUrlSafe } from './validation/url';
 export { validateRedirect, isRedirectSafe } from './validation/redirect';
+export { validateFile, sanitizeFilename, isDangerousExtension } from './validation/file';
 
 // =============================================================================
 // LOGGING
@@ -114,6 +115,7 @@ export type {
 export type { ValidateUrlOptions, ValidateUrlResult } from './validation/url';
 export type { CorsOptions } from './middleware/cors';
 export type { SecureCookieOptions } from './middleware/cookies';
+export type { ValidateFileOptions, FileInput, ValidateFileResult } from './validation/file';
 export type { ValidateRedirectOptions, ValidateRedirectResult } from './validation/redirect';
 
 // Redis store types

--- a/packages/arcis-node/src/validation/file.ts
+++ b/packages/arcis-node/src/validation/file.ts
@@ -1,0 +1,311 @@
+/**
+ * @module @arcis/node/validation/file
+ * File upload validation and filename sanitization
+ */
+
+// =============================================================================
+// MAGIC BYTES — first bytes of common file types
+// =============================================================================
+
+const MAGIC_BYTES: Record<string, Buffer[]> = {
+  // Images
+  'image/jpeg': [Buffer.from([0xFF, 0xD8, 0xFF])],
+  'image/png': [Buffer.from([0x89, 0x50, 0x4E, 0x47])],
+  'image/gif': [Buffer.from('GIF87a'), Buffer.from('GIF89a')],
+  'image/webp': [Buffer.from('RIFF')], // RIFF....WEBP
+  'image/bmp': [Buffer.from([0x42, 0x4D])],
+  'image/svg+xml': [], // text-based, check separately
+
+  // Documents
+  'application/pdf': [Buffer.from('%PDF')],
+  'application/zip': [Buffer.from([0x50, 0x4B, 0x03, 0x04])],
+
+  // Audio/Video
+  'audio/mpeg': [Buffer.from([0xFF, 0xFB]), Buffer.from([0xFF, 0xF3]), Buffer.from([0x49, 0x44, 0x33])],
+  'video/mp4': [], // ftyp at offset 4
+};
+
+// =============================================================================
+// DANGEROUS EXTENSIONS — files that can execute code
+// =============================================================================
+
+const DANGEROUS_EXTENSIONS = new Set([
+  // Scripts
+  '.exe', '.bat', '.cmd', '.com', '.msi', '.scr', '.pif',
+  '.vbs', '.vbe', '.js', '.jse', '.ws', '.wsf', '.wsc', '.wsh',
+  '.ps1', '.ps1xml', '.ps2', '.ps2xml', '.psc1', '.psc2',
+  '.sh', '.bash', '.csh', '.ksh',
+  // Server-side
+  '.php', '.php3', '.php4', '.php5', '.phtml', '.pht',
+  '.asp', '.aspx', '.ashx', '.asmx', '.cer',
+  '.jsp', '.jspx', '.jsw', '.jsv',
+  '.cgi', '.pl', '.py', '.rb',
+  // Java
+  '.jar', '.war', '.ear', '.class',
+  // Config that can execute
+  '.htaccess', '.htpasswd',
+  // Template engines
+  '.ejs', '.pug', '.hbs', '.handlebars', '.njk', '.twig',
+  // Shortcuts/links
+  '.lnk', '.inf', '.reg', '.url',
+  // Office macros
+  '.docm', '.xlsm', '.pptm', '.dotm',
+]);
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/** File upload validation options */
+export interface ValidateFileOptions {
+  /** Maximum file size in bytes. Default: 5MB */
+  maxSize?: number;
+  /** Allowed MIME types (e.g., ['image/jpeg', 'image/png']) */
+  allowedTypes?: string[];
+  /** Allowed file extensions (e.g., ['.jpg', '.png']). Includes dot. */
+  allowedExtensions?: string[];
+  /** Block dangerous/executable extensions. Default: true */
+  blockExecutables?: boolean;
+  /** Validate magic bytes match the claimed MIME type. Default: true */
+  validateMagicBytes?: boolean;
+  /** Block files with no extension. Default: true */
+  blockNoExtension?: boolean;
+  /** Block double extensions (e.g., file.php.jpg). Default: true */
+  blockDoubleExtensions?: boolean;
+}
+
+/** File metadata for validation */
+export interface FileInput {
+  /** Original filename */
+  filename: string;
+  /** MIME type (as claimed by client) */
+  mimetype: string;
+  /** File size in bytes */
+  size: number;
+  /** File content buffer (for magic byte validation) */
+  buffer?: Buffer;
+}
+
+/** File validation result */
+export interface ValidateFileResult {
+  /** Whether the file passed validation */
+  valid: boolean;
+  /** Validation errors (empty if valid) */
+  errors: string[];
+  /** Sanitized filename (safe for storage) */
+  sanitizedFilename: string;
+}
+
+// =============================================================================
+// DEFAULTS
+// =============================================================================
+
+const DEFAULT_MAX_SIZE = 5 * 1024 * 1024; // 5MB
+
+// =============================================================================
+// FILENAME SANITIZATION
+// =============================================================================
+
+/**
+ * Sanitize a filename for safe storage.
+ *
+ * Strips path traversal, null bytes, control characters, and special characters.
+ * Preserves the extension and converts to a filesystem-safe name.
+ *
+ * @param filename - The original filename
+ * @returns A sanitized filename safe for storage
+ *
+ * @example
+ * sanitizeFilename('../../etc/passwd')          // 'etc_passwd'
+ * sanitizeFilename('file<name>.jpg')            // 'filename.jpg'
+ * sanitizeFilename('photo (1).jpg')             // 'photo_1.jpg'
+ * sanitizeFilename('.htaccess')                 // 'htaccess'
+ */
+export function sanitizeFilename(filename: string): string {
+  let name = filename;
+
+  // Strip null bytes
+  name = name.replace(/\0/g, '');
+
+  // Strip path components (both Unix and Windows)
+  name = name.replace(/^.*[/\\]/, '');
+
+  // Strip control characters
+  name = name.replace(/[\x00-\x1F\x7F]/g, '');
+
+  // Strip characters unsafe for filesystems
+  name = name.replace(/[<>:"/\\|?*]/g, '');
+
+  // Replace spaces and parens with underscores
+  name = name.replace(/[\s()]+/g, '_');
+
+  // Strip leading dots (hidden files / .htaccess)
+  name = name.replace(/^\.+/, '');
+
+  // Collapse multiple underscores/dots
+  name = name.replace(/_{2,}/g, '_');
+  name = name.replace(/\.{2,}/g, '.');
+
+  // Trim underscores before dots (e.g., "photo_1_.jpg" → "photo_1.jpg")
+  name = name.replace(/_+\./g, '.');
+
+  // Trim underscores from edges
+  name = name.replace(/^_+|_+$/g, '');
+
+  // Fallback for empty name
+  if (!name || name === '.') {
+    name = 'unnamed';
+  }
+
+  return name;
+}
+
+// =============================================================================
+// MAGIC BYTE VALIDATION
+// =============================================================================
+
+/**
+ * Check if file content matches the claimed MIME type via magic bytes.
+ */
+function matchesMagicBytes(buffer: Buffer, mimetype: string): boolean {
+  const signatures = MAGIC_BYTES[mimetype];
+  if (!signatures || signatures.length === 0) return true; // no signature to check
+
+  return signatures.some(sig => {
+    if (buffer.length < sig.length) return false;
+    return buffer.subarray(0, sig.length).equals(sig);
+  });
+}
+
+// =============================================================================
+// EXTENSION HELPERS
+// =============================================================================
+
+/**
+ * Get the extension from a filename (lowercase, with dot).
+ */
+function getExtension(filename: string): string {
+  const lastDot = filename.lastIndexOf('.');
+  if (lastDot < 1) return '';
+  return filename.slice(lastDot).toLowerCase();
+}
+
+/**
+ * Check if a filename has double extensions (e.g., file.php.jpg).
+ */
+function hasDoubleExtension(filename: string): boolean {
+  const parts = filename.split('.');
+  if (parts.length < 3) return false;
+
+  // Check if any non-final extension is dangerous
+  for (let i = 1; i < parts.length - 1; i++) {
+    const ext = '.' + parts[i].toLowerCase();
+    if (DANGEROUS_EXTENSIONS.has(ext)) return true;
+  }
+  return false;
+}
+
+// =============================================================================
+// FILE VALIDATION
+// =============================================================================
+
+/**
+ * Validate a file upload for security.
+ *
+ * Checks file size, MIME type, extension, magic bytes, and dangerous patterns.
+ * Returns a result with validation errors and a sanitized filename.
+ *
+ * @param file - File metadata and optional content
+ * @param options - Validation options
+ * @returns Validation result
+ *
+ * @example
+ * const result = validateFile(
+ *   { filename: 'photo.jpg', mimetype: 'image/jpeg', size: 1024, buffer },
+ *   { allowedTypes: ['image/jpeg', 'image/png'], maxSize: 2 * 1024 * 1024 }
+ * );
+ * if (!result.valid) {
+ *   return res.status(400).json({ errors: result.errors });
+ * }
+ * // Use result.sanitizedFilename for storage
+ *
+ * @example
+ * // Block executables only (no whitelist)
+ * const result = validateFile(file, { blockExecutables: true });
+ */
+export function validateFile(
+  file: FileInput,
+  options: ValidateFileOptions = {}
+): ValidateFileResult {
+  const {
+    maxSize = DEFAULT_MAX_SIZE,
+    allowedTypes,
+    allowedExtensions,
+    blockExecutables = true,
+    validateMagicBytes = true,
+    blockNoExtension = true,
+    blockDoubleExtensions = true,
+  } = options;
+
+  const errors: string[] = [];
+  const sanitizedFilename = sanitizeFilename(file.filename);
+  const extension = getExtension(sanitizedFilename);
+
+  // Size check
+  if (file.size > maxSize) {
+    errors.push(`File size ${file.size} exceeds maximum ${maxSize} bytes`);
+  }
+
+  if (file.size === 0) {
+    errors.push('File is empty');
+  }
+
+  // Extension checks
+  if (blockNoExtension && !extension) {
+    errors.push('File has no extension');
+  }
+
+  if (blockExecutables && extension && DANGEROUS_EXTENSIONS.has(extension)) {
+    errors.push(`Executable extension "${extension}" is not allowed`);
+  }
+
+  if (blockDoubleExtensions && hasDoubleExtension(sanitizedFilename)) {
+    errors.push('Double extensions with executable types are not allowed');
+  }
+
+  if (allowedExtensions && extension) {
+    const normalizedAllowed = allowedExtensions.map(e => e.toLowerCase());
+    if (!normalizedAllowed.includes(extension)) {
+      errors.push(`Extension "${extension}" is not allowed. Allowed: ${normalizedAllowed.join(', ')}`);
+    }
+  }
+
+  // MIME type check
+  if (allowedTypes && !allowedTypes.includes(file.mimetype)) {
+    errors.push(`MIME type "${file.mimetype}" is not allowed. Allowed: ${allowedTypes.join(', ')}`);
+  }
+
+  // Magic bytes validation
+  if (validateMagicBytes && file.buffer && file.buffer.length > 0) {
+    if (!matchesMagicBytes(file.buffer, file.mimetype)) {
+      errors.push(`File content does not match claimed MIME type "${file.mimetype}"`);
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    sanitizedFilename,
+  };
+}
+
+/**
+ * Check if a file extension is considered dangerous/executable.
+ *
+ * @param filename - Filename or extension to check
+ * @returns true if the extension is dangerous
+ */
+export function isDangerousExtension(filename: string): boolean {
+  const ext = getExtension(filename);
+  return ext !== '' && DANGEROUS_EXTENSIONS.has(ext);
+}

--- a/packages/arcis-node/src/validation/index.ts
+++ b/packages/arcis-node/src/validation/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { validate, createValidator } from './schema';
+export { validateFile, sanitizeFilename, isDangerousExtension } from './file';

--- a/packages/arcis-node/tests/validation/file.test.ts
+++ b/packages/arcis-node/tests/validation/file.test.ts
@@ -1,0 +1,261 @@
+/**
+ * File Upload Validation Tests
+ * Tests for src/validation/file.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sanitizeFilename, validateFile, isDangerousExtension } from '../../src/validation/file';
+import type { FileInput } from '../../src/validation/file';
+
+describe('sanitizeFilename', () => {
+  it('should strip path traversal', () => {
+    expect(sanitizeFilename('../../etc/passwd')).toBe('passwd');
+    expect(sanitizeFilename('..\\..\\windows\\system32')).toBe('system32');
+  });
+
+  it('should strip null bytes', () => {
+    expect(sanitizeFilename('file\0name.jpg')).toBe('filename.jpg');
+  });
+
+  it('should strip control characters', () => {
+    expect(sanitizeFilename('file\x01\x02name.jpg')).toBe('filename.jpg');
+  });
+
+  it('should strip unsafe filesystem characters', () => {
+    expect(sanitizeFilename('file<name>.jpg')).toBe('filename.jpg');
+    expect(sanitizeFilename('file:name.jpg')).toBe('filename.jpg');
+    expect(sanitizeFilename('file"name".jpg')).toBe('filename.jpg');
+    expect(sanitizeFilename('file|name.jpg')).toBe('filename.jpg');
+    expect(sanitizeFilename('file?name.jpg')).toBe('filename.jpg');
+    expect(sanitizeFilename('file*name.jpg')).toBe('filename.jpg');
+  });
+
+  it('should replace spaces and parens with underscores', () => {
+    expect(sanitizeFilename('photo (1).jpg')).toBe('photo_1.jpg');
+    expect(sanitizeFilename('my file name.jpg')).toBe('my_file_name.jpg');
+  });
+
+  it('should strip leading dots', () => {
+    expect(sanitizeFilename('.htaccess')).toBe('htaccess');
+    expect(sanitizeFilename('..hidden')).toBe('hidden');
+    expect(sanitizeFilename('.env')).toBe('env');
+  });
+
+  it('should collapse multiple underscores and dots', () => {
+    expect(sanitizeFilename('file___name.jpg')).toBe('file_name.jpg');
+    expect(sanitizeFilename('file...jpg')).toBe('file.jpg');
+  });
+
+  it('should return unnamed for empty input', () => {
+    expect(sanitizeFilename('')).toBe('unnamed');
+    expect(sanitizeFilename('...')).toBe('unnamed');
+    expect(sanitizeFilename('\0')).toBe('unnamed');
+  });
+
+  it('should preserve valid filenames', () => {
+    expect(sanitizeFilename('photo.jpg')).toBe('photo.jpg');
+    expect(sanitizeFilename('document-v2.pdf')).toBe('document-v2.pdf');
+    expect(sanitizeFilename('report_2024.xlsx')).toBe('report_2024.xlsx');
+  });
+
+  it('should handle Windows paths', () => {
+    expect(sanitizeFilename('C:\\Users\\admin\\photo.jpg')).toBe('photo.jpg');
+  });
+
+  it('should handle Unix paths', () => {
+    expect(sanitizeFilename('/home/user/photo.jpg')).toBe('photo.jpg');
+  });
+});
+
+describe('isDangerousExtension', () => {
+  it('should flag executable extensions', () => {
+    expect(isDangerousExtension('file.exe')).toBe(true);
+    expect(isDangerousExtension('file.bat')).toBe(true);
+    expect(isDangerousExtension('file.sh')).toBe(true);
+    expect(isDangerousExtension('file.php')).toBe(true);
+    expect(isDangerousExtension('file.jsp')).toBe(true);
+    expect(isDangerousExtension('file.ps1')).toBe(true);
+  });
+
+  it('should flag server-side extensions', () => {
+    expect(isDangerousExtension('file.asp')).toBe(true);
+    expect(isDangerousExtension('file.aspx')).toBe(true);
+    expect(isDangerousExtension('file.phtml')).toBe(true);
+    expect(isDangerousExtension('file.cgi')).toBe(true);
+  });
+
+  it('should flag template engine extensions', () => {
+    expect(isDangerousExtension('file.ejs')).toBe(true);
+    expect(isDangerousExtension('file.pug')).toBe(true);
+    expect(isDangerousExtension('file.hbs')).toBe(true);
+  });
+
+  it('should flag office macro extensions', () => {
+    expect(isDangerousExtension('file.docm')).toBe(true);
+    expect(isDangerousExtension('file.xlsm')).toBe(true);
+  });
+
+  it('should allow safe extensions', () => {
+    expect(isDangerousExtension('file.jpg')).toBe(false);
+    expect(isDangerousExtension('file.png')).toBe(false);
+    expect(isDangerousExtension('file.pdf')).toBe(false);
+    expect(isDangerousExtension('file.txt')).toBe(false);
+    expect(isDangerousExtension('file.docx')).toBe(false);
+    expect(isDangerousExtension('file.csv')).toBe(false);
+  });
+
+  it('should be case insensitive', () => {
+    expect(isDangerousExtension('file.EXE')).toBe(true);
+    expect(isDangerousExtension('file.Php')).toBe(true);
+  });
+});
+
+describe('validateFile', () => {
+  const makeFile = (overrides: Partial<FileInput> = {}): FileInput => ({
+    filename: 'photo.jpg',
+    mimetype: 'image/jpeg',
+    size: 1024,
+    buffer: Buffer.from([0xFF, 0xD8, 0xFF, 0xE0]),
+    ...overrides,
+  });
+
+  describe('Size Validation', () => {
+    it('should accept files within size limit', () => {
+      const result = validateFile(makeFile({ size: 1024 }), { maxSize: 2048 });
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject files exceeding size limit', () => {
+      const result = validateFile(makeFile({ size: 10_000_000 }), { maxSize: 5_000_000 });
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('exceeds maximum');
+    });
+
+    it('should reject empty files', () => {
+      const result = validateFile(makeFile({ size: 0 }));
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('File is empty');
+    });
+  });
+
+  describe('Extension Validation', () => {
+    it('should block executable extensions', () => {
+      const result = validateFile(makeFile({ filename: 'shell.php' }));
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('.php');
+    });
+
+    it('should allow safe extensions', () => {
+      const result = validateFile(makeFile({ filename: 'photo.jpg' }));
+      expect(result.valid).toBe(true);
+    });
+
+    it('should enforce allowed extensions whitelist', () => {
+      const result = validateFile(makeFile({ filename: 'doc.pdf' }), {
+        allowedExtensions: ['.jpg', '.png'],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('.pdf');
+    });
+
+    it('should block files with no extension', () => {
+      const result = validateFile(makeFile({ filename: 'noext' }));
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('File has no extension');
+    });
+
+    it('should allow files with no extension when configured', () => {
+      const result = validateFile(makeFile({ filename: 'noext' }), { blockNoExtension: false });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('Double Extension Blocking', () => {
+    it('should block dangerous double extensions', () => {
+      const result = validateFile(makeFile({ filename: 'shell.php.jpg' }));
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('Double extensions');
+    });
+
+    it('should allow safe double extensions', () => {
+      const result = validateFile(makeFile({ filename: 'archive.tar.gz' }));
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('MIME Type Validation', () => {
+    it('should enforce allowed MIME types', () => {
+      const result = validateFile(
+        makeFile({ mimetype: 'application/pdf' }),
+        { allowedTypes: ['image/jpeg', 'image/png'] }
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('application/pdf');
+    });
+
+    it('should accept allowed MIME types', () => {
+      const result = validateFile(
+        makeFile({ mimetype: 'image/jpeg' }),
+        { allowedTypes: ['image/jpeg', 'image/png'] }
+      );
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('Magic Bytes Validation', () => {
+    it('should accept matching magic bytes', () => {
+      const result = validateFile(makeFile({
+        mimetype: 'image/jpeg',
+        buffer: Buffer.from([0xFF, 0xD8, 0xFF, 0xE0]),
+      }));
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject mismatched magic bytes', () => {
+      const result = validateFile(makeFile({
+        mimetype: 'image/jpeg',
+        buffer: Buffer.from([0x89, 0x50, 0x4E, 0x47]), // PNG magic bytes
+      }));
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('does not match');
+    });
+
+    it('should accept PNG with correct magic bytes', () => {
+      const result = validateFile(makeFile({
+        filename: 'image.png',
+        mimetype: 'image/png',
+        buffer: Buffer.from([0x89, 0x50, 0x4E, 0x47]),
+      }));
+      expect(result.valid).toBe(true);
+    });
+
+    it('should accept GIF with correct magic bytes', () => {
+      const result = validateFile(makeFile({
+        filename: 'anim.gif',
+        mimetype: 'image/gif',
+        buffer: Buffer.from('GIF89a'),
+      }));
+      expect(result.valid).toBe(true);
+    });
+
+    it('should skip magic bytes when no buffer provided', () => {
+      const result = validateFile(makeFile({ buffer: undefined }));
+      expect(result.valid).toBe(true);
+    });
+
+    it('should skip magic bytes when disabled', () => {
+      const result = validateFile(
+        makeFile({ mimetype: 'image/jpeg', buffer: Buffer.from([0x00, 0x00]) }),
+        { validateMagicBytes: false }
+      );
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('Sanitized Filename', () => {
+    it('should return sanitized filename in result', () => {
+      const result = validateFile(makeFile({ filename: '../../evil.jpg' }));
+      expect(result.sanitizedFilename).toBe('evil.jpg');
+    });
+  });
+});

--- a/packages/arcis-python/arcis/validation/__init__.py
+++ b/packages/arcis-python/arcis/validation/__init__.py
@@ -6,6 +6,7 @@ from .validators import Validator, ValidationError, validate_email, validate_url
 from .schema import SchemaValidator, create_validator
 from .url import validate_url_ssrf, is_url_safe, ValidateUrlOptions, ValidateUrlResult
 from .redirect import validate_redirect, is_redirect_safe, ValidateRedirectOptions, ValidateRedirectResult
+from .file import validate_file, sanitize_filename, is_dangerous_extension, ValidateFileResult
 
 __all__ = [
     "Validator",
@@ -23,4 +24,8 @@ __all__ = [
     "is_redirect_safe",
     "ValidateRedirectOptions",
     "ValidateRedirectResult",
+    "validate_file",
+    "sanitize_filename",
+    "is_dangerous_extension",
+    "ValidateFileResult",
 ]

--- a/packages/arcis-python/arcis/validation/file.py
+++ b/packages/arcis-python/arcis/validation/file.py
@@ -1,0 +1,264 @@
+"""
+Arcis Validation - File Upload
+
+Validates file uploads and sanitizes filenames.
+Prevents unrestricted upload, executable upload, MIME bypass, and path traversal via filenames.
+"""
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Set
+
+# =============================================================================
+# MAGIC BYTES — first bytes of common file types
+# =============================================================================
+
+MAGIC_BYTES: Dict[str, List[bytes]] = {
+    # Images
+    "image/jpeg": [b"\xFF\xD8\xFF"],
+    "image/png": [b"\x89PNG"],
+    "image/gif": [b"GIF87a", b"GIF89a"],
+    "image/webp": [b"RIFF"],  # RIFF....WEBP
+    "image/bmp": [b"BM"],
+    "image/svg+xml": [],  # text-based, check separately
+
+    # Documents
+    "application/pdf": [b"%PDF"],
+    "application/zip": [b"PK\x03\x04"],
+
+    # Audio/Video
+    "audio/mpeg": [b"\xFF\xFB", b"\xFF\xF3", b"ID3"],
+}
+
+# =============================================================================
+# DANGEROUS EXTENSIONS — files that can execute code
+# =============================================================================
+
+DANGEROUS_EXTENSIONS: Set[str] = {
+    # Scripts
+    ".exe", ".bat", ".cmd", ".com", ".msi", ".scr", ".pif",
+    ".vbs", ".vbe", ".js", ".jse", ".ws", ".wsf", ".wsc", ".wsh",
+    ".ps1", ".ps1xml", ".ps2", ".ps2xml", ".psc1", ".psc2",
+    ".sh", ".bash", ".csh", ".ksh",
+    # Server-side
+    ".php", ".php3", ".php4", ".php5", ".phtml", ".pht",
+    ".asp", ".aspx", ".ashx", ".asmx", ".cer",
+    ".jsp", ".jspx", ".jsw", ".jsv",
+    ".cgi", ".pl", ".py", ".rb",
+    # Java
+    ".jar", ".war", ".ear", ".class",
+    # Config that can execute
+    ".htaccess", ".htpasswd",
+    # Template engines
+    ".ejs", ".pug", ".hbs", ".handlebars", ".njk", ".twig",
+    # Shortcuts/links
+    ".lnk", ".inf", ".reg", ".url",
+    # Office macros
+    ".docm", ".xlsm", ".pptm", ".dotm",
+}
+
+DEFAULT_MAX_SIZE = 5 * 1024 * 1024  # 5MB
+
+
+# =============================================================================
+# TYPES
+# =============================================================================
+
+@dataclass
+class ValidateFileResult:
+    """Result of file validation."""
+    valid: bool
+    errors: List[str] = field(default_factory=list)
+    sanitized_filename: str = ""
+
+
+# =============================================================================
+# FILENAME SANITIZATION
+# =============================================================================
+
+def sanitize_filename(filename: str) -> str:
+    """
+    Sanitize a filename for safe storage.
+
+    Strips path traversal, null bytes, control characters, and special characters.
+
+    Example:
+        sanitize_filename('../../etc/passwd')    # 'etc_passwd'
+        sanitize_filename('file<name>.jpg')      # 'filename.jpg'
+        sanitize_filename('.htaccess')            # 'htaccess'
+    """
+    name = filename
+
+    # Strip null bytes
+    name = name.replace("\0", "")
+
+    # Strip path components (both Unix and Windows)
+    name = re.sub(r"^.*[/\\]", "", name)
+
+    # Strip control characters
+    name = re.sub(r"[\x00-\x1f\x7f]", "", name)
+
+    # Strip characters unsafe for filesystems
+    name = re.sub(r'[<>:"/\\|?*]', "", name)
+
+    # Replace spaces and parens with underscores
+    name = re.sub(r"[\s()]+", "_", name)
+
+    # Strip leading dots (hidden files / .htaccess)
+    name = re.sub(r"^\.+", "", name)
+
+    # Collapse multiple underscores/dots
+    name = re.sub(r"_{2,}", "_", name)
+    name = re.sub(r"\.{2,}", ".", name)
+
+    # Trim underscores before dots (e.g., "photo_1_.jpg" → "photo_1.jpg")
+    name = re.sub(r"_+\.", ".", name)
+
+    # Trim underscores from edges
+    name = name.strip("_")
+
+    # Fallback for empty name
+    if not name or name == ".":
+        name = "unnamed"
+
+    return name
+
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+def _get_extension(filename: str) -> str:
+    """Get the extension from a filename (lowercase, with dot)."""
+    _, ext = os.path.splitext(filename)
+    return ext.lower()
+
+
+def _has_double_extension(filename: str) -> bool:
+    """Check if a filename has double extensions with a dangerous inner extension."""
+    parts = filename.split(".")
+    if len(parts) < 3:
+        return False
+    for part in parts[1:-1]:
+        ext = "." + part.lower()
+        if ext in DANGEROUS_EXTENSIONS:
+            return True
+    return False
+
+
+def _matches_magic_bytes(content: bytes, mimetype: str) -> bool:
+    """Check if file content matches the claimed MIME type via magic bytes."""
+    signatures = MAGIC_BYTES.get(mimetype)
+    if signatures is None or len(signatures) == 0:
+        return True  # no signature to check
+
+    return any(
+        len(content) >= len(sig) and content[:len(sig)] == sig
+        for sig in signatures
+    )
+
+
+def is_dangerous_extension(filename: str) -> bool:
+    """
+    Check if a file extension is considered dangerous/executable.
+
+    Args:
+        filename: Filename or extension to check
+
+    Returns:
+        True if the extension is dangerous
+    """
+    ext = _get_extension(filename)
+    return ext != "" and ext in DANGEROUS_EXTENSIONS
+
+
+# =============================================================================
+# FILE VALIDATION
+# =============================================================================
+
+def validate_file(
+    filename: str,
+    mimetype: str,
+    size: int,
+    content: Optional[bytes] = None,
+    *,
+    max_size: int = DEFAULT_MAX_SIZE,
+    allowed_types: Optional[Sequence[str]] = None,
+    allowed_extensions: Optional[Sequence[str]] = None,
+    block_executables: bool = True,
+    validate_magic_bytes: bool = True,
+    block_no_extension: bool = True,
+    block_double_extensions: bool = True,
+) -> ValidateFileResult:
+    """
+    Validate a file upload for security.
+
+    Args:
+        filename: Original filename
+        mimetype: MIME type (as claimed by client)
+        size: File size in bytes
+        content: File content bytes (for magic byte validation)
+        max_size: Maximum file size in bytes. Default: 5MB
+        allowed_types: Whitelist of MIME types
+        allowed_extensions: Whitelist of extensions (with dot)
+        block_executables: Block dangerous extensions. Default: True
+        validate_magic_bytes: Validate magic bytes. Default: True
+        block_no_extension: Block files with no extension. Default: True
+        block_double_extensions: Block double extensions. Default: True
+
+    Returns:
+        ValidateFileResult with errors and sanitized filename
+
+    Example:
+        result = validate_file(
+            "photo.jpg", "image/jpeg", 1024, content,
+            allowed_types=["image/jpeg", "image/png"],
+        )
+        if not result.valid:
+            return {"errors": result.errors}, 400
+    """
+    errors: List[str] = []
+    sanitized = sanitize_filename(filename)
+    extension = _get_extension(sanitized)
+
+    # Size check
+    if size > max_size:
+        errors.append(f"File size {size} exceeds maximum {max_size} bytes")
+
+    if size == 0:
+        errors.append("File is empty")
+
+    # Extension checks
+    if block_no_extension and not extension:
+        errors.append("File has no extension")
+
+    if block_executables and extension and extension in DANGEROUS_EXTENSIONS:
+        errors.append(f'Executable extension "{extension}" is not allowed')
+
+    if block_double_extensions and _has_double_extension(sanitized):
+        errors.append("Double extensions with executable types are not allowed")
+
+    if allowed_extensions and extension:
+        normalized = [e.lower() for e in allowed_extensions]
+        if extension not in normalized:
+            errors.append(
+                f'Extension "{extension}" is not allowed. Allowed: {", ".join(normalized)}'
+            )
+
+    # MIME type check
+    if allowed_types and mimetype not in allowed_types:
+        errors.append(
+            f'MIME type "{mimetype}" is not allowed. Allowed: {", ".join(allowed_types)}'
+        )
+
+    # Magic bytes validation
+    if validate_magic_bytes and content and len(content) > 0:
+        if not _matches_magic_bytes(content, mimetype):
+            errors.append(f'File content does not match claimed MIME type "{mimetype}"')
+
+    return ValidateFileResult(
+        valid=len(errors) == 0,
+        errors=errors,
+        sanitized_filename=sanitized,
+    )

--- a/packages/arcis-python/tests/validation/test_file.py
+++ b/packages/arcis-python/tests/validation/test_file.py
@@ -1,0 +1,184 @@
+"""
+File upload validation tests.
+"""
+
+import pytest
+from arcis.validation.file import (
+    sanitize_filename,
+    validate_file,
+    is_dangerous_extension,
+)
+
+
+class TestSanitizeFilename:
+
+    def test_strips_path_traversal(self):
+        assert sanitize_filename("../../etc/passwd") == "passwd"
+        assert sanitize_filename("..\\..\\windows\\system32") == "system32"
+
+    def test_strips_null_bytes(self):
+        assert sanitize_filename("file\0name.jpg") == "filename.jpg"
+
+    def test_strips_control_characters(self):
+        assert sanitize_filename("file\x01\x02name.jpg") == "filename.jpg"
+
+    def test_strips_unsafe_characters(self):
+        assert sanitize_filename("file<name>.jpg") == "filename.jpg"
+        assert sanitize_filename('file"name".jpg') == "filename.jpg"
+        assert sanitize_filename("file|name.jpg") == "filename.jpg"
+
+    def test_replaces_spaces_and_parens(self):
+        assert sanitize_filename("photo (1).jpg") == "photo_1.jpg"
+        assert sanitize_filename("my file name.jpg") == "my_file_name.jpg"
+
+    def test_strips_leading_dots(self):
+        assert sanitize_filename(".htaccess") == "htaccess"
+        assert sanitize_filename("..hidden") == "hidden"
+        assert sanitize_filename(".env") == "env"
+
+    def test_collapses_underscores_and_dots(self):
+        assert sanitize_filename("file___name.jpg") == "file_name.jpg"
+        assert sanitize_filename("file...jpg") == "file.jpg"
+
+    def test_unnamed_fallback(self):
+        assert sanitize_filename("") == "unnamed"
+        assert sanitize_filename("...") == "unnamed"
+        assert sanitize_filename("\0") == "unnamed"
+
+    def test_preserves_valid_filenames(self):
+        assert sanitize_filename("photo.jpg") == "photo.jpg"
+        assert sanitize_filename("document-v2.pdf") == "document-v2.pdf"
+
+    def test_handles_paths(self):
+        assert sanitize_filename("C:\\Users\\admin\\photo.jpg") == "photo.jpg"
+        assert sanitize_filename("/home/user/photo.jpg") == "photo.jpg"
+
+
+class TestIsDangerousExtension:
+
+    def test_flags_executables(self):
+        assert is_dangerous_extension("file.exe")
+        assert is_dangerous_extension("file.bat")
+        assert is_dangerous_extension("file.sh")
+        assert is_dangerous_extension("file.php")
+        assert is_dangerous_extension("file.jsp")
+
+    def test_flags_server_side(self):
+        assert is_dangerous_extension("file.asp")
+        assert is_dangerous_extension("file.aspx")
+        assert is_dangerous_extension("file.phtml")
+
+    def test_flags_template_engines(self):
+        assert is_dangerous_extension("file.ejs")
+        assert is_dangerous_extension("file.pug")
+        assert is_dangerous_extension("file.hbs")
+
+    def test_flags_office_macros(self):
+        assert is_dangerous_extension("file.docm")
+        assert is_dangerous_extension("file.xlsm")
+
+    def test_allows_safe_extensions(self):
+        assert not is_dangerous_extension("file.jpg")
+        assert not is_dangerous_extension("file.png")
+        assert not is_dangerous_extension("file.pdf")
+        assert not is_dangerous_extension("file.txt")
+        assert not is_dangerous_extension("file.csv")
+
+    def test_case_insensitive(self):
+        assert is_dangerous_extension("file.EXE")
+        assert is_dangerous_extension("file.Php")
+
+
+class TestValidateFile:
+
+    def test_accepts_valid_file(self):
+        result = validate_file(
+            "photo.jpg", "image/jpeg", 1024,
+            content=b"\xFF\xD8\xFF\xE0",
+        )
+        assert result.valid
+        assert result.errors == []
+
+    def test_rejects_oversized_file(self):
+        result = validate_file("photo.jpg", "image/jpeg", 10_000_000, max_size=5_000_000)
+        assert not result.valid
+        assert "exceeds maximum" in result.errors[0]
+
+    def test_rejects_empty_file(self):
+        result = validate_file("photo.jpg", "image/jpeg", 0)
+        assert not result.valid
+        assert "File is empty" in result.errors
+
+    def test_blocks_executable_extension(self):
+        result = validate_file("shell.php", "text/plain", 100)
+        assert not result.valid
+        assert ".php" in result.errors[0]
+
+    def test_allows_safe_extension(self):
+        result = validate_file("photo.jpg", "image/jpeg", 1024)
+        assert result.valid
+
+    def test_enforces_allowed_extensions(self):
+        result = validate_file(
+            "doc.pdf", "application/pdf", 1024,
+            allowed_extensions=[".jpg", ".png"],
+        )
+        assert not result.valid
+        assert ".pdf" in result.errors[0]
+
+    def test_blocks_no_extension(self):
+        result = validate_file("noext", "application/octet-stream", 100)
+        assert not result.valid
+        assert "no extension" in result.errors[0]
+
+    def test_allows_no_extension_when_configured(self):
+        result = validate_file("noext", "application/octet-stream", 100, block_no_extension=False)
+        assert result.valid
+
+    def test_blocks_double_extensions(self):
+        result = validate_file("shell.php.jpg", "image/jpeg", 100)
+        assert not result.valid
+        assert "Double extensions" in result.errors[0]
+
+    def test_allows_safe_double_extensions(self):
+        result = validate_file("archive.tar.gz", "application/gzip", 100)
+        assert result.valid
+
+    def test_enforces_allowed_mime_types(self):
+        result = validate_file(
+            "doc.pdf", "application/pdf", 1024,
+            allowed_types=["image/jpeg", "image/png"],
+        )
+        assert not result.valid
+        assert "application/pdf" in result.errors[0]
+
+    def test_validates_magic_bytes(self):
+        result = validate_file(
+            "photo.jpg", "image/jpeg", 1024,
+            content=b"\x89PNG",  # PNG magic bytes, not JPEG
+        )
+        assert not result.valid
+        assert "does not match" in result.errors[0]
+
+    def test_accepts_matching_magic_bytes(self):
+        result = validate_file(
+            "photo.jpg", "image/jpeg", 1024,
+            content=b"\xFF\xD8\xFF\xE0",
+        )
+        assert result.valid
+
+    def test_skips_magic_bytes_without_content(self):
+        result = validate_file("photo.jpg", "image/jpeg", 1024)
+        assert result.valid
+
+    def test_skips_magic_bytes_when_disabled(self):
+        result = validate_file(
+            "photo.jpg", "image/jpeg", 1024,
+            content=b"\x00\x00",
+            validate_magic_bytes=False,
+        )
+        assert result.valid
+
+    def test_returns_sanitized_filename(self):
+        result = validate_file("../../evil.jpg", "image/jpeg", 1024)
+        assert result.sanitized_filename == "evil.jpg"


### PR DESCRIPTION
…thon)

validateFile() checks size, MIME type, extension whitelist, magic bytes, double extensions, and executable blocking. sanitizeFilename() strips path traversal, null bytes, control chars, and unsafe filesystem chars.

Covers Tier 2 flaws #73-78: unrestricted upload, executable upload, MIME bypass, file name manipulation.

Node: 649 tests, Python: 462 tests.