### PR TITLE
Go SDK: multi-file refactor + 5 new security features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.25"
+          cache: false
       - run: go mod tidy
       - run: go test -v -race ./...

--- a/packages/arcis-go/arcis.go
+++ b/packages/arcis-go/arcis.go
@@ -46,76 +46,141 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
-	"time"
+
+	"github.com/GagancM/arcis/core"
+	"github.com/GagancM/arcis/logging"
+	"github.com/GagancM/arcis/middleware"
+	"github.com/GagancM/arcis/sanitizers"
+	"github.com/GagancM/arcis/utils"
+	"github.com/GagancM/arcis/validation"
 )
 
-// Version is the current version of Arcis.
-const Version = "1.1.0"
+// ─── Type aliases (backward compatibility) ──────────────────────────────────
 
-// MaxRecursionDepth is the maximum depth for recursive operations.
-const MaxRecursionDepth = 10
+// Core types
+type Config = core.Config
+type RateLimitResult = core.RateLimitResult
+type RateLimitEntry = core.RateLimitEntry
+type RateLimitStore = core.RateLimitStore
+type InputTooLargeError = core.InputTooLargeError
 
-// DefaultMaxInputSize is the default maximum input size in bytes (1MB).
-const DefaultMaxInputSize = 1_000_000
+// Sanitizer types
+type Sanitizer = sanitizers.Sanitizer
 
-// Config holds Arcis configuration options.
-type Config struct {
-	// Sanitizer options
-	Sanitize      bool
-	SanitizeXSS   bool
-	SanitizeSQL   bool
-	SanitizeNoSQL bool
-	SanitizePath  bool
-	SanitizeCmd   bool // Command injection protection
-	MaxInputSize  int  // Maximum input size in bytes (default: 1MB)
+// Middleware types
+type RateLimiter = middleware.RateLimiter
+type SecurityHeaders = middleware.SecurityHeaders
+type ErrorHandler = middleware.ErrorHandler
 
-	// Rate limiter options
-	RateLimit       bool
-	RateLimitMax    int
-	RateLimitWindow time.Duration
-	RateLimitSkip   func(*http.Request) bool // Skip rate limiting for certain requests
-	RateLimitStore  RateLimitStore           // Optional external store (e.g. Redis)
+// Logging types
+type SafeLogger = logging.SafeLogger
 
-	// Security headers options
-	Headers           bool
-	CSP               string
-	FrameOptions      string // DENY, SAMEORIGIN, or empty to disable
-	HSTSMaxAge        int    // Max age in seconds, 0 to disable
-	HSTSSubdomains    bool
-	ReferrerPolicy    string
-	PermissionsPolicy string
-	CacheControl      bool   // Enable cache-control headers (default: true)
-	CacheControlValue string // Custom Cache-Control value. Empty = use secure default.
+// Validation types
+type FieldType = validation.FieldType
+type FieldRule = validation.FieldRule
+type ValidationSchema = validation.ValidationSchema
+type ValidationError = validation.ValidationError
+type Validator = validation.Validator
 
-	// Error handler options
-	IsDev bool // Show error details in development mode
-}
+// URL/Redirect types
+type ValidateURLOptions = utils.ValidateURLOptions
+type ValidateURLResult = utils.ValidateURLResult
+type ValidateRedirectOptions = utils.ValidateRedirectOptions
+type ValidateRedirectResult = utils.ValidateRedirectResult
+
+// ─── Constants (re-exported) ────────────────────────────────────────────────
+
+const Version = core.Version
+const MaxRecursionDepth = core.MaxRecursionDepth
+const DefaultMaxInputSize = core.DefaultMaxInputSize
+
+// Validation field type constants
+const (
+	TypeString  = validation.TypeString
+	TypeNumber  = validation.TypeNumber
+	TypeBoolean = validation.TypeBoolean
+	TypeEmail   = validation.TypeEmail
+	TypeURL     = validation.TypeURL
+	TypeUUID    = validation.TypeUUID
+	TypeArray   = validation.TypeArray
+	TypeObject  = validation.TypeObject
+)
+
+// ─── Constructor re-exports ─────────────────────────────────────────────────
 
 // DefaultConfig returns the default Arcis configuration.
-// All protections are enabled with sensible defaults.
-func DefaultConfig() Config {
-	return Config{
-		Sanitize:          true,
-		SanitizeXSS:       true,
-		SanitizeSQL:       true,
-		SanitizeNoSQL:     true,
-		SanitizePath:      true,
-		SanitizeCmd:       true,
-		MaxInputSize:      DefaultMaxInputSize,
-		RateLimit:         true,
-		RateLimitMax:      100,
-		RateLimitWindow:   time.Minute,
-		Headers:           true,
-		CSP:               "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; object-src 'none'; frame-ancestors 'none';",
-		FrameOptions:      "DENY",
-		HSTSMaxAge:        31536000,
-		HSTSSubdomains:    true,
-		ReferrerPolicy:    "strict-origin-when-cross-origin",
-		PermissionsPolicy: "geolocation=(), microphone=(), camera=()",
-		CacheControl:      true,
-		IsDev:             false,
-	}
-}
+var DefaultConfig = core.DefaultConfig
+
+// NewSanitizer creates a new Sanitizer with the given configuration.
+var NewSanitizer = sanitizers.NewSanitizer
+
+// NewSanitizerWithOptions creates a sanitizer with explicit options.
+var NewSanitizerWithOptions = sanitizers.NewSanitizerWithOptions
+
+// NewRateLimiter creates a new RateLimiter with the given limit and window.
+var NewRateLimiter = middleware.NewRateLimiter
+
+// NewRateLimiterWithStore creates a new RateLimiter backed by the provided store.
+var NewRateLimiterWithStore = middleware.NewRateLimiterWithStore
+
+// NewSecurityHeaders creates a new SecurityHeaders with the given configuration.
+var NewSecurityHeaders = middleware.NewSecurityHeaders
+
+// NewErrorHandler creates a new ErrorHandler.
+var NewErrorHandler = middleware.NewErrorHandler
+
+// NewErrorHandlerWithLogger creates an ErrorHandler with a custom logger.
+var NewErrorHandlerWithLogger = middleware.NewErrorHandlerWithLogger
+
+// ContainsSensitiveInfo checks if an error message contains sensitive info.
+var ContainsSensitiveInfo = middleware.ContainsSensitiveInfo
+
+// NewSafeLogger creates a new SafeLogger with default settings.
+var NewSafeLogger = logging.NewSafeLogger
+
+// NewSafeLoggerWithKeys creates a SafeLogger with custom sensitive keys.
+var NewSafeLoggerWithKeys = logging.NewSafeLoggerWithKeys
+
+// NewSafeLoggerOnlyKeys creates a SafeLogger with ONLY the specified keys.
+var NewSafeLoggerOnlyKeys = logging.NewSafeLoggerOnlyKeys
+
+// NewValidator creates a new Validator with the given schema.
+var NewValidator = validation.NewValidator
+
+// ValidateHandler creates middleware that validates request body.
+var ValidateHandler = validation.ValidateHandler
+
+// GetValidatedBody retrieves the validated body from request context.
+var GetValidatedBody = validation.GetValidatedBody
+
+// Float is a helper for creating FieldRule with Min/Max.
+var Float = validation.Float
+
+// SanitizeHeaderValue strips CRLF/null bytes from a header value.
+var SanitizeHeaderValue = sanitizers.SanitizeHeaderValue
+
+// SanitizeHeaders sanitizes a map of HTTP header key-value pairs.
+var SanitizeHeaders = sanitizers.SanitizeHeaders
+
+// DetectHeaderInjection checks if a string contains header injection patterns.
+var DetectHeaderInjection = sanitizers.DetectHeaderInjection
+
+// ValidateURL checks a URL for SSRF safety.
+var ValidateURL = utils.ValidateURL
+
+// IsURLSafe is a convenience wrapper that returns true/false.
+var IsURLSafe = utils.IsURLSafe
+
+// ValidateRedirect checks a redirect URL for open redirect attacks.
+var ValidateRedirect = utils.ValidateRedirect
+
+// IsRedirectSafe is a convenience wrapper that returns true/false.
+var IsRedirectSafe = utils.IsRedirectSafe
+
+// GetClientIP extracts the client IP address from the request.
+var GetClientIP = utils.GetClientIP
+
+// ─── Arcis main struct ──────────────────────────────────────────────────────
 
 // Arcis is the main security middleware.
 type Arcis struct {

--- a/packages/arcis-go/arcis_test.go
+++ b/packages/arcis-go/arcis_test.go
@@ -2,7 +2,7 @@
 Arcis Go — Integration & Middleware Tests
 
 Tests the main Arcis facade and HTTP middleware behavior.
-Unit tests for individual components are in their respective *_test.go files.
+Unit tests for individual components are in their respective subpackages.
 Run with: go test -v ./...
 */
 package arcis
@@ -130,4 +130,23 @@ func TestMiddleware_RemovesFingerprintHeaders(t *testing.T) {
 	rec.Header().Set("X-Powered-By", "PHP/7.4")
 
 	s.Handler(handler).ServeHTTP(rec, req)
+}
+
+func TestRateLimiter_SkipFunction(t *testing.T) {
+	config := DefaultConfig()
+	config.RateLimitMax = 1
+	config.RateLimitSkip = func(r *http.Request) bool {
+		return true
+	}
+
+	s := NewWithConfig(config)
+	defer s.Close()
+
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("GET", "/", nil)
+		result := s.rateLimiter.Check(req)
+		if !result.Allowed {
+			t.Errorf("Request %d should be allowed (skipped)", i+1)
+		}
+	}
 }

--- a/packages/arcis-go/core/config.go
+++ b/packages/arcis-go/core/config.go
@@ -1,0 +1,110 @@
+package core
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Version is the current version of Arcis.
+const Version = "1.1.0"
+
+// MaxRecursionDepth is the maximum depth for recursive operations.
+const MaxRecursionDepth = 10
+
+// DefaultMaxInputSize is the default maximum input size in bytes (1MB).
+const DefaultMaxInputSize = 1_000_000
+
+// Config holds Arcis configuration options.
+type Config struct {
+	// Sanitizer options
+	Sanitize      bool
+	SanitizeXSS   bool
+	SanitizeSQL   bool
+	SanitizeNoSQL bool
+	SanitizePath  bool
+	SanitizeCmd   bool // Command injection protection
+	MaxInputSize  int  // Maximum input size in bytes (default: 1MB)
+
+	// Rate limiter options
+	RateLimit       bool
+	RateLimitMax    int
+	RateLimitWindow time.Duration
+	RateLimitSkip   func(*http.Request) bool // Skip rate limiting for certain requests
+	RateLimitStore  RateLimitStore           // Optional external store (e.g. Redis)
+
+	// Security headers options
+	Headers           bool
+	CSP               string
+	FrameOptions      string // DENY, SAMEORIGIN, or empty to disable
+	HSTSMaxAge        int    // Max age in seconds, 0 to disable
+	HSTSSubdomains    bool
+	ReferrerPolicy    string
+	PermissionsPolicy string
+	CacheControl      bool   // Enable cache-control headers (default: true)
+	CacheControlValue string // Custom Cache-Control value. Empty = use secure default.
+
+	// Error handler options
+	IsDev bool // Show error details in development mode
+}
+
+// DefaultConfig returns the default Arcis configuration.
+// All protections are enabled with sensible defaults.
+func DefaultConfig() Config {
+	return Config{
+		Sanitize:          true,
+		SanitizeXSS:       true,
+		SanitizeSQL:       true,
+		SanitizeNoSQL:     true,
+		SanitizePath:      true,
+		SanitizeCmd:       true,
+		MaxInputSize:      DefaultMaxInputSize,
+		RateLimit:         true,
+		RateLimitMax:      100,
+		RateLimitWindow:   time.Minute,
+		Headers:           true,
+		CSP:               "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; object-src 'none'; frame-ancestors 'none';",
+		FrameOptions:      "DENY",
+		HSTSMaxAge:        31536000,
+		HSTSSubdomains:    true,
+		ReferrerPolicy:    "strict-origin-when-cross-origin",
+		PermissionsPolicy: "geolocation=(), microphone=(), camera=()",
+		CacheControl:      true,
+		IsDev:             false,
+	}
+}
+
+// RateLimitResult holds the result of a rate limit check.
+type RateLimitResult struct {
+	Allowed   bool
+	Limit     int
+	Remaining int
+	Reset     time.Duration
+}
+
+// RateLimitEntry holds the data for a single rate limit record.
+// Used by RateLimitStore implementations.
+type RateLimitEntry struct {
+	Count     int
+	ResetTime time.Time
+}
+
+// RateLimitStore defines the interface for pluggable rate limit store backends.
+// The default implementation is an in-memory store. Implement this interface
+// to use a distributed backend such as Redis for multi-instance deployments.
+type RateLimitStore interface {
+	Get(key string) *RateLimitEntry
+	Set(key string, entry *RateLimitEntry)
+	Increment(key string) int
+	Cleanup()
+}
+
+// InputTooLargeError is returned when input exceeds the maximum size.
+type InputTooLargeError struct {
+	Size    int
+	MaxSize int
+}
+
+func (e *InputTooLargeError) Error() string {
+	return fmt.Sprintf("input size %d exceeds maximum of %d bytes", e.Size, e.MaxSize)
+}

--- a/packages/arcis-go/echo/echo.go
+++ b/packages/arcis-go/echo/echo.go
@@ -280,14 +280,16 @@ func MiddlewareWithConfig(config Config) echo.MiddlewareFunc {
 				}
 			}
 
-			// Remove fingerprinting headers
-			c.Response().Header().Del("Server")
-			c.Response().Header().Del("X-Powered-By")
-
 			// Store sanitizer in context for use in handlers
 			c.Set(SanitizerKey, sanitizer)
 
-			return next(c)
+			err := next(c)
+
+			// Remove fingerprinting headers after handler runs
+			c.Response().Header().Del("Server")
+			c.Response().Header().Del("X-Powered-By")
+
+			return err
 		}
 	}
 }
@@ -317,9 +319,10 @@ func HeadersWithConfig(config Config) echo.MiddlewareFunc {
 			for key, value := range headers.GetHeaders() {
 				c.Response().Header().Set(key, value)
 			}
+			err := next(c)
 			c.Response().Header().Del("Server")
 			c.Response().Header().Del("X-Powered-By")
-			return next(c)
+			return err
 		}
 	}
 }

--- a/packages/arcis-go/gin/gin.go
+++ b/packages/arcis-go/gin/gin.go
@@ -272,14 +272,14 @@ func MiddlewareWithConfig(config Config) gin.HandlerFunc {
 			}
 		}
 
-		// Remove fingerprinting headers
-		c.Writer.Header().Del("Server")
-		c.Writer.Header().Del("X-Powered-By")
-
 		// Store sanitizer in context for use in handlers
 		c.Set("arcis_sanitizer", sanitizer)
 
 		c.Next()
+
+		// Remove fingerprinting headers after handler runs
+		c.Writer.Header().Del("Server")
+		c.Writer.Header().Del("X-Powered-By")
 	}
 }
 
@@ -307,9 +307,9 @@ func HeadersWithConfig(config Config) gin.HandlerFunc {
 		for key, value := range headers.GetHeaders() {
 			c.Header(key, value)
 		}
+		c.Next()
 		c.Writer.Header().Del("Server")
 		c.Writer.Header().Del("X-Powered-By")
-		c.Next()
 	}
 }
 

--- a/packages/arcis-go/logging/safe_logger.go
+++ b/packages/arcis-go/logging/safe_logger.go
@@ -1,6 +1,10 @@
-package arcis
+package logging
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/GagancM/arcis/core"
+)
 
 // SafeLogger provides safe logging with automatic redaction of sensitive data.
 type SafeLogger struct {
@@ -63,7 +67,7 @@ func (l *SafeLogger) Redact(data map[string]interface{}) map[string]interface{} 
 }
 
 func (l *SafeLogger) redactDepth(data map[string]interface{}, depth int) map[string]interface{} {
-	if depth > MaxRecursionDepth || data == nil {
+	if depth > core.MaxRecursionDepth || data == nil {
 		return data
 	}
 
@@ -92,7 +96,7 @@ func (l *SafeLogger) redactDepth(data map[string]interface{}, depth int) map[str
 }
 
 func (l *SafeLogger) redactSlice(data []interface{}, depth int) []interface{} {
-	if depth > MaxRecursionDepth || data == nil {
+	if depth > core.MaxRecursionDepth || data == nil {
 		return data
 	}
 

--- a/packages/arcis-go/logging/safe_logger_test.go
+++ b/packages/arcis-go/logging/safe_logger_test.go
@@ -1,4 +1,4 @@
-package arcis
+package logging
 
 import (
 	"strings"

--- a/packages/arcis-go/middleware/error_handler.go
+++ b/packages/arcis-go/middleware/error_handler.go
@@ -1,9 +1,11 @@
-package arcis
+package middleware
 
 import (
 	"encoding/json"
 	"net/http"
 	"regexp"
+
+	"github.com/GagancM/arcis/logging"
 )
 
 // Patterns that indicate database or infrastructure internals in error messages.
@@ -34,7 +36,7 @@ func ContainsSensitiveInfo(message string) bool {
 type ErrorHandler struct {
 	isDev     bool
 	logErrors bool
-	logger    *SafeLogger
+	logger    *logging.SafeLogger
 }
 
 // NewErrorHandler creates a new ErrorHandler.
@@ -43,12 +45,12 @@ func NewErrorHandler(isDev bool) *ErrorHandler {
 	return &ErrorHandler{
 		isDev:     isDev,
 		logErrors: true,
-		logger:    NewSafeLogger(),
+		logger:    logging.NewSafeLogger(),
 	}
 }
 
 // NewErrorHandlerWithLogger creates an ErrorHandler with a custom logger.
-func NewErrorHandlerWithLogger(isDev bool, logger *SafeLogger) *ErrorHandler {
+func NewErrorHandlerWithLogger(isDev bool, logger *logging.SafeLogger) *ErrorHandler {
 	return &ErrorHandler{
 		isDev:     isDev,
 		logErrors: true,

--- a/packages/arcis-go/middleware/error_handler_test.go
+++ b/packages/arcis-go/middleware/error_handler_test.go
@@ -1,4 +1,4 @@
-package arcis
+package middleware
 
 import (
 	"encoding/json"

--- a/packages/arcis-go/middleware/rate_limit.go
+++ b/packages/arcis-go/middleware/rate_limit.go
@@ -1,43 +1,21 @@
-package arcis
+package middleware
 
 import (
 	"context"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/GagancM/arcis/core"
+	"github.com/GagancM/arcis/utils"
 )
-
-// RateLimitResult holds the result of a rate limit check.
-type RateLimitResult struct {
-	Allowed   bool
-	Limit     int
-	Remaining int
-	Reset     time.Duration
-}
-
-// RateLimitEntry holds the data for a single rate limit record.
-// Used by RateLimitStore implementations.
-type RateLimitEntry struct {
-	Count     int
-	ResetTime time.Time
-}
-
-// RateLimitStore defines the interface for pluggable rate limit store backends.
-// The default implementation is an in-memory store. Implement this interface
-// to use a distributed backend such as Redis for multi-instance deployments.
-type RateLimitStore interface {
-	Get(key string) *RateLimitEntry
-	Set(key string, entry *RateLimitEntry)
-	Increment(key string) int
-	Cleanup()
-}
 
 // RateLimiter handles rate limiting with configurable limits and windows.
 type RateLimiter struct {
 	max         int
 	window      time.Duration
 	store       map[string]*rateLimitEntry
-	customStore RateLimitStore
+	customStore core.RateLimitStore
 	mu          sync.RWMutex
 	skipFunc    func(*http.Request) bool
 	ctx         context.Context
@@ -78,7 +56,7 @@ func NewRateLimiter(max int, window time.Duration) *RateLimiter {
 }
 
 // NewRateLimiterWithStore creates a new RateLimiter backed by the provided store.
-func NewRateLimiterWithStore(max int, window time.Duration, store RateLimitStore) *RateLimiter {
+func NewRateLimiterWithStore(max int, window time.Duration, store core.RateLimitStore) *RateLimiter {
 	ctx, cancel := context.WithCancel(context.Background())
 	rl := &RateLimiter{
 		max:         max,
@@ -110,9 +88,9 @@ func (rl *RateLimiter) SetSkipFunc(fn func(*http.Request) bool) {
 }
 
 // Check checks if a request is within the rate limit.
-func (rl *RateLimiter) Check(r *http.Request) RateLimitResult {
+func (rl *RateLimiter) Check(r *http.Request) core.RateLimitResult {
 	if rl.skipFunc != nil && rl.skipFunc(r) {
-		return RateLimitResult{
+		return core.RateLimitResult{
 			Allowed:   true,
 			Limit:     rl.max,
 			Remaining: rl.max,
@@ -120,12 +98,12 @@ func (rl *RateLimiter) Check(r *http.Request) RateLimitResult {
 		}
 	}
 
-	key := getClientIP(r)
+	key := utils.GetClientIP(r)
 	return rl.CheckKey(key)
 }
 
 // CheckKey checks rate limit for a specific key.
-func (rl *RateLimiter) CheckKey(key string) RateLimitResult {
+func (rl *RateLimiter) CheckKey(key string) core.RateLimitResult {
 	if rl.customStore != nil {
 		return rl.checkKeyWithStore(key)
 	}
@@ -141,7 +119,7 @@ func (rl *RateLimiter) CheckKey(key string) RateLimitResult {
 			count:     1,
 			resetTime: now.Add(rl.window),
 		}
-		return RateLimitResult{
+		return core.RateLimitResult{
 			Allowed:   true,
 			Limit:     rl.max,
 			Remaining: rl.max - 1,
@@ -156,7 +134,7 @@ func (rl *RateLimiter) CheckKey(key string) RateLimitResult {
 	}
 	reset := entry.resetTime.Sub(now)
 
-	return RateLimitResult{
+	return core.RateLimitResult{
 		Allowed:   entry.count <= rl.max,
 		Limit:     rl.max,
 		Remaining: remaining,
@@ -164,14 +142,14 @@ func (rl *RateLimiter) CheckKey(key string) RateLimitResult {
 	}
 }
 
-func (rl *RateLimiter) checkKeyWithStore(key string) RateLimitResult {
+func (rl *RateLimiter) checkKeyWithStore(key string) core.RateLimitResult {
 	now := time.Now()
 
 	entry := rl.customStore.Get(key)
 	if entry == nil {
 		resetTime := now.Add(rl.window)
-		rl.customStore.Set(key, &RateLimitEntry{Count: 1, ResetTime: resetTime})
-		return RateLimitResult{
+		rl.customStore.Set(key, &core.RateLimitEntry{Count: 1, ResetTime: resetTime})
+		return core.RateLimitResult{
 			Allowed:   true,
 			Limit:     rl.max,
 			Remaining: rl.max - 1,
@@ -186,7 +164,7 @@ func (rl *RateLimiter) checkKeyWithStore(key string) RateLimitResult {
 	}
 	reset := entry.ResetTime.Sub(now)
 
-	return RateLimitResult{
+	return core.RateLimitResult{
 		Allowed:   count <= rl.max,
 		Limit:     rl.max,
 		Remaining: remaining,

--- a/packages/arcis-go/middleware/rate_limit_test.go
+++ b/packages/arcis-go/middleware/rate_limit_test.go
@@ -1,8 +1,6 @@
-package arcis
+package middleware
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -64,25 +62,6 @@ func TestRateLimiter_DifferentIPsSeparateLimits(t *testing.T) {
 			if !result.Allowed {
 				t.Errorf("Request from %s should be allowed", key)
 			}
-		}
-	}
-}
-
-func TestRateLimiter_SkipFunction(t *testing.T) {
-	config := DefaultConfig()
-	config.RateLimitMax = 1
-	config.RateLimitSkip = func(r *http.Request) bool {
-		return true
-	}
-
-	s := NewWithConfig(config)
-	defer s.Close()
-
-	for i := 0; i < 5; i++ {
-		req := httptest.NewRequest("GET", "/", nil)
-		result := s.rateLimiter.Check(req)
-		if !result.Allowed {
-			t.Errorf("Request %d should be allowed (skipped)", i+1)
 		}
 	}
 }

--- a/packages/arcis-go/middleware/security_headers.go
+++ b/packages/arcis-go/middleware/security_headers.go
@@ -1,6 +1,10 @@
-package arcis
+package middleware
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/GagancM/arcis/core"
+)
 
 // SecurityHeaders handles security header configuration and application.
 type SecurityHeaders struct {
@@ -8,7 +12,7 @@ type SecurityHeaders struct {
 }
 
 // NewSecurityHeaders creates a new SecurityHeaders with the given configuration.
-func NewSecurityHeaders(config Config) *SecurityHeaders {
+func NewSecurityHeaders(config core.Config) *SecurityHeaders {
 	headers := make(map[string]string)
 
 	if config.CSP != "" {

--- a/packages/arcis-go/middleware/security_headers_test.go
+++ b/packages/arcis-go/middleware/security_headers_test.go
@@ -1,12 +1,14 @@
-package arcis
+package middleware
 
 import (
 	"strings"
 	"testing"
+
+	"github.com/GagancM/arcis/core"
 )
 
 func TestSecurityHeaders_DefaultHeaders(t *testing.T) {
-	config := DefaultConfig()
+	config := core.DefaultConfig()
 	headers := NewSecurityHeaders(config)
 	h := headers.GetHeaders()
 
@@ -31,7 +33,7 @@ func TestSecurityHeaders_DefaultHeaders(t *testing.T) {
 }
 
 func TestSecurityHeaders_CustomCSP(t *testing.T) {
-	config := DefaultConfig()
+	config := core.DefaultConfig()
 	config.CSP = "default-src 'none'"
 	headers := NewSecurityHeaders(config)
 
@@ -42,7 +44,7 @@ func TestSecurityHeaders_CustomCSP(t *testing.T) {
 }
 
 func TestSecurityHeaders_CacheControl(t *testing.T) {
-	config := DefaultConfig()
+	config := core.DefaultConfig()
 	headers := NewSecurityHeaders(config)
 	h := headers.GetHeaders()
 

--- a/packages/arcis-go/sanitizers/headers.go
+++ b/packages/arcis-go/sanitizers/headers.go
@@ -1,4 +1,4 @@
-package arcis
+package sanitizers
 
 import "regexp"
 

--- a/packages/arcis-go/sanitizers/headers_test.go
+++ b/packages/arcis-go/sanitizers/headers_test.go
@@ -1,4 +1,4 @@
-package arcis
+package sanitizers
 
 import "testing"
 
@@ -30,9 +30,9 @@ func TestSanitizeHeaderValue(t *testing.T) {
 func TestSanitizeHeaders(t *testing.T) {
 	t.Run("sanitizes keys and values", func(t *testing.T) {
 		headers := map[string]string{
-			"X-Custom":       "safe",
-			"X-Bad\r\n":     "value\r\ninjected",
-			"Content-Type":   "text/html",
+			"X-Custom":     "safe",
+			"X-Bad\r\n":   "value\r\ninjected",
+			"Content-Type": "text/html",
 		}
 		result := SanitizeHeaders(headers)
 		if result["X-Custom"] != "safe" {

--- a/packages/arcis-go/sanitizers/sanitize.go
+++ b/packages/arcis-go/sanitizers/sanitize.go
@@ -1,8 +1,10 @@
-package arcis
+package sanitizers
 
 import (
 	"regexp"
 	"strings"
+
+	"github.com/GagancM/arcis/core"
 )
 
 // Pre-compiled XSS patterns for performance (ReDoS-safe)
@@ -86,10 +88,10 @@ type Sanitizer struct {
 }
 
 // NewSanitizer creates a new Sanitizer with the given configuration.
-func NewSanitizer(config Config) *Sanitizer {
+func NewSanitizer(config core.Config) *Sanitizer {
 	maxSize := config.MaxInputSize
 	if maxSize <= 0 {
-		maxSize = DefaultMaxInputSize
+		maxSize = core.DefaultMaxInputSize
 	}
 	return &Sanitizer{
 		xss:          config.SanitizeXSS,
@@ -109,7 +111,7 @@ func NewSanitizerWithOptions(xss, sql, nosql, path, cmd bool) *Sanitizer {
 		nosql:        nosql,
 		path:         path,
 		cmd:          cmd,
-		maxInputSize: DefaultMaxInputSize,
+		maxInputSize: core.DefaultMaxInputSize,
 	}
 }
 
@@ -174,7 +176,7 @@ func (s *Sanitizer) SanitizeMap(data map[string]interface{}) map[string]interfac
 }
 
 func (s *Sanitizer) sanitizeMapDepth(data map[string]interface{}, depth int) map[string]interface{} {
-	if depth > MaxRecursionDepth || data == nil {
+	if depth > core.MaxRecursionDepth || data == nil {
 		return data
 	}
 
@@ -211,7 +213,7 @@ func (s *Sanitizer) sanitizeMapDepth(data map[string]interface{}, depth int) map
 }
 
 func (s *Sanitizer) sanitizeSlice(data []interface{}, depth int) []interface{} {
-	if depth > MaxRecursionDepth || data == nil {
+	if depth > core.MaxRecursionDepth || data == nil {
 		return data
 	}
 

--- a/packages/arcis-go/sanitizers/sanitize_test.go
+++ b/packages/arcis-go/sanitizers/sanitize_test.go
@@ -1,4 +1,4 @@
-package arcis
+package sanitizers
 
 import (
 	"strings"

--- a/packages/arcis-go/stores/stores.go
+++ b/packages/arcis-go/stores/stores.go
@@ -1,0 +1,5 @@
+// Package stores provides rate limit store implementations for Arcis.
+//
+// The default in-memory store is built into the middleware package.
+// This package is reserved for external store implementations (e.g. Redis).
+package stores

--- a/packages/arcis-go/utils/ip.go
+++ b/packages/arcis-go/utils/ip.go
@@ -1,24 +1,13 @@
-package arcis
+package utils
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 )
 
-// InputTooLargeError is returned when input exceeds the maximum size.
-type InputTooLargeError struct {
-	Size    int
-	MaxSize int
-}
-
-func (e *InputTooLargeError) Error() string {
-	return fmt.Sprintf("input size %d exceeds maximum of %d bytes", e.Size, e.MaxSize)
-}
-
-// getClientIP extracts the client IP address from the request,
+// GetClientIP extracts the client IP address from the request,
 // handling common proxy headers.
-func getClientIP(r *http.Request) string {
+func GetClientIP(r *http.Request) string {
 	// Check X-Forwarded-For header (comma-separated list, first is client)
 	xff := r.Header.Get("X-Forwarded-For")
 	if xff != "" {

--- a/packages/arcis-go/utils/ip_test.go
+++ b/packages/arcis-go/utils/ip_test.go
@@ -1,4 +1,4 @@
-package arcis
+package utils
 
 import (
 	"net/http/httptest"
@@ -29,7 +29,7 @@ func TestGetClientIP(t *testing.T) {
 				req.Header.Set("X-Real-IP", tt.xri)
 			}
 
-			result := getClientIP(req)
+			result := GetClientIP(req)
 			if result != tt.expected {
 				t.Errorf("Expected %q, got %q", tt.expected, result)
 			}

--- a/packages/arcis-go/utils/redirect.go
+++ b/packages/arcis-go/utils/redirect.go
@@ -1,4 +1,4 @@
-package arcis
+package utils
 
 import (
 	"net/url"
@@ -27,17 +27,6 @@ var (
 )
 
 // ValidateRedirect checks a redirect URL for open redirect attacks.
-//
-// Safe:
-//   - Relative paths: /dashboard, /users?page=2
-//   - Absolute URLs to allowed hosts
-//
-// Blocked:
-//   - Absolute URLs to unknown hosts
-//   - Protocol-relative URLs (//evil.com)
-//   - javascript:, data:, vbscript:, blob: protocols
-//   - Backslash-prefixed paths (\\evil.com)
-//   - URLs with control characters
 func ValidateRedirect(rawURL string, opts *ValidateRedirectOptions) ValidateRedirectResult {
 	if opts == nil {
 		opts = &ValidateRedirectOptions{}

--- a/packages/arcis-go/utils/redirect_test.go
+++ b/packages/arcis-go/utils/redirect_test.go
@@ -1,4 +1,4 @@
-package arcis
+package utils
 
 import "testing"
 

--- a/packages/arcis-go/utils/url.go
+++ b/packages/arcis-go/utils/url.go
@@ -1,4 +1,4 @@
-package arcis
+package utils
 
 import (
 	"net/url"
@@ -33,13 +33,6 @@ var (
 )
 
 // ValidateURL checks a URL for SSRF safety.
-//
-// Blocks:
-//   - Private IPs (10.x, 172.16-31.x, 192.168.x)
-//   - Loopback (127.x.x.x, ::1, localhost)
-//   - Link-local / cloud metadata (169.254.x.x)
-//   - Dangerous protocols (file:, ftp:, gopher:, etc.)
-//   - URLs with embedded credentials (user:pass@host)
 func ValidateURL(rawURL string, opts *ValidateURLOptions) ValidateURLResult {
 	if opts == nil {
 		opts = &ValidateURLOptions{}

--- a/packages/arcis-go/utils/url_test.go
+++ b/packages/arcis-go/utils/url_test.go
@@ -1,4 +1,4 @@
-package arcis
+package utils
 
 import "testing"
 

--- a/packages/arcis-go/validation/validate.go
+++ b/packages/arcis-go/validation/validate.go
@@ -1,4 +1,4 @@
-package arcis
+package validation
 
 import (
 	"context"
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/GagancM/arcis/sanitizers"
 )
 
 // Validation patterns
@@ -59,14 +61,14 @@ func (e *ValidationError) Error() string {
 // Validator validates request data against a schema.
 type Validator struct {
 	schema    ValidationSchema
-	sanitizer *Sanitizer
+	sanitizer *sanitizers.Sanitizer
 }
 
 // NewValidator creates a new Validator with the given schema.
 func NewValidator(schema ValidationSchema) *Validator {
 	return &Validator{
 		schema:    schema,
-		sanitizer: NewSanitizerWithOptions(true, true, true, true, true),
+		sanitizer: sanitizers.NewSanitizerWithOptions(true, true, true, true, true),
 	}
 }
 

--- a/packages/arcis-go/validation/validate_test.go
+++ b/packages/arcis-go/validation/validate_test.go
@@ -1,4 +1,4 @@
-package arcis
+package validation
 
 import (
 	"strings"


### PR DESCRIPTION
## Summary

- **Refactored** monolithic `arcis.go` (1374 lines) into 11 focused source files matching Node.js/Python multi-file architecture
- **Added** HTTP header injection prevention (`SanitizeHeaderValue`, `SanitizeHeaders`, `DetectHeaderInjection`)
- **Added** SSRF prevention (`ValidateURL`, `IsURLSafe`) — blocks private IPs, loopback, link-local, cloud metadata, credentials in URLs
- **Added** open redirect prevention (`ValidateRedirect`, `IsRedirectSafe`) — blocks protocol-relative, javascript:/data:/vbscript:, backslash bypass
- **Hardened** error handler with `ContainsSensitiveInfo` — scrubs DB errors, connection strings, internal IPs from client responses
- **Hardened** prototype pollution prevention — case-insensitive key matching + 4 additional blocked keys (`__defineGetter__`, `__defineSetter__`, `__lookupGetter__`, `__lookupSetter__`)

## File structure (new)

| File | Purpose |
|------|---------|
| `arcis.go` | Main facade — Config, Arcis, New, Protect, Handler |
| `sanitize.go` | XSS, SQL, NoSQL, path, command sanitization |
| `headers.go` | Header injection prevention (NEW) |
| `security_headers.go` | CSP, HSTS, X-Frame-Options |
| `rate_limit.go` | Rate limiter with pluggable store |
| `validate.go` | Schema validation, mass assignment prevention |
| `url.go` | SSRF prevention (NEW) |
| `redirect.go` | Open redirect prevention (NEW) |
| `safe_logger.go` | Safe logging with key redaction |
| `error_handler.go` | Error handler with sensitive info scrubbing (HARDENED) |
| `utils.go` | IP detection, helpers |

## Test plan

- [ ] All 10 test files pass (`go test -v ./...`)
- [ ] Gin and Echo adapters still compile against refactored package
- [ ] Header injection: CRLF, bare CR/LF, null bytes stripped
- [ ] SSRF: private IPs, loopback, link-local, metadata, credentials blocked
- [ ] Open redirect: absolute URLs, protocol-relative, dangerous protocols blocked
- [ ] Error handler: DB errors, connection strings, internal IPs scrubbed in production
- [ ] Prototype pollution: case-insensitive blocking of all 7 dangerous keys