### PR TITLE
feat(go): complete Tier 1 — CORS, Cookies, CSRF

### DIFF
--- a/packages/arcis-go/arcis.go
+++ b/packages/arcis-go/arcis.go
@@ -71,6 +71,15 @@ type Sanitizer = sanitizers.Sanitizer
 type RateLimiter = middleware.RateLimiter
 type SecurityHeaders = middleware.SecurityHeaders
 type ErrorHandler = middleware.ErrorHandler
+type SafeCors = middleware.SafeCors
+type CorsOptions = middleware.CorsOptions
+type CorsOrigin = middleware.CorsOrigin
+type CorsHeaders = middleware.CorsHeaders
+type SecureCookieDefaults = middleware.SecureCookieDefaults
+type SecureCookieOptions = middleware.SecureCookieOptions
+type CsrfProtection = middleware.CsrfProtection
+type CsrfOptions = middleware.CsrfOptions
+type CsrfCookieOptions = middleware.CsrfCookieOptions
 
 // Logging types
 type SafeLogger = logging.SafeLogger
@@ -134,6 +143,33 @@ var NewErrorHandlerWithLogger = middleware.NewErrorHandlerWithLogger
 
 // ContainsSensitiveInfo checks if an error message contains sensitive info.
 var ContainsSensitiveInfo = middleware.ContainsSensitiveInfo
+
+// NewSafeCors creates a SafeCors instance with the given options.
+var NewSafeCors = middleware.NewSafeCors
+
+// SafeCorsMiddleware creates a CORS http.Handler middleware from options.
+var SafeCorsMiddleware = middleware.SafeCorsMiddleware
+
+// NewSecureCookieDefaults creates a SecureCookieDefaults with the given options.
+var NewSecureCookieDefaults = middleware.NewSecureCookieDefaults
+
+// EnforceSecureCookie enforces secure defaults on a Set-Cookie header value.
+var EnforceSecureCookie = middleware.EnforceSecureCookie
+
+// SecureCookieMiddleware creates a secure cookie middleware from options.
+var SecureCookieMiddleware = middleware.SecureCookieMiddleware
+
+// NewCsrfProtection creates a CsrfProtection with the given options.
+var NewCsrfProtection = middleware.NewCsrfProtection
+
+// GenerateCsrfToken generates a cryptographically random CSRF token.
+var GenerateCsrfToken = middleware.GenerateCsrfToken
+
+// ValidateCsrfToken compares two CSRF tokens using constant-time comparison.
+var ValidateCsrfToken = middleware.ValidateCsrfToken
+
+// CsrfMiddleware creates a CSRF protection middleware from options.
+var CsrfMiddleware = middleware.CsrfMiddleware
 
 // NewSafeLogger creates a new SafeLogger with default settings.
 var NewSafeLogger = logging.NewSafeLogger

--- a/packages/arcis-go/echo/echo.go
+++ b/packages/arcis-go/echo/echo.go
@@ -69,6 +69,7 @@ package echo
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -485,6 +486,140 @@ func GetValidatedBody(c echo.Context) map[string]interface{} {
 		return v.(map[string]interface{})
 	}
 	return nil
+}
+
+// CsrfProtection returns an Echo middleware for CSRF protection using double-submit cookie.
+func CsrfProtection(opts arcis.CsrfOptions) echo.MiddlewareFunc {
+	csrf := arcis.NewCsrfProtection(opts)
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			// Use the Check method directly
+			method := c.Request().Method
+
+			// Check excluded paths
+			if csrf.Check(method, c.Request().URL.Path, "", "") && method != "POST" && method != "PUT" && method != "PATCH" && method != "DELETE" {
+				// Safe method — ensure cookie exists
+				if cookie, err := c.Request().Cookie("_csrf"); err != nil || cookie.Value == "" {
+					token, err := arcis.GenerateCsrfToken(32)
+					if err == nil {
+						c.Response().Header().Add("Set-Cookie", buildEchoCsrfCookie(opts, token))
+					}
+				}
+				return next(c)
+			}
+
+			// Protected method — validate
+			cookieToken := ""
+			if cookie, err := c.Request().Cookie(csrfCookieName(opts)); err == nil {
+				cookieToken = cookie.Value
+			}
+
+			headerName := opts.HeaderName
+			if headerName == "" {
+				headerName = "X-Csrf-Token"
+			}
+			requestToken := c.Request().Header.Get(headerName)
+			if requestToken == "" {
+				fieldName := opts.FieldName
+				if fieldName == "" {
+					fieldName = "_csrf"
+				}
+				requestToken = c.QueryParam(fieldName)
+			}
+
+			if !csrf.Check(method, c.Request().URL.Path, cookieToken, requestToken) {
+				return c.JSON(http.StatusForbidden, map[string]string{
+					"error":   "CSRF token validation failed",
+					"message": "Invalid or missing CSRF token. Include the token from the cookie in the X-CSRF-Token header.",
+				})
+			}
+
+			return next(c)
+		}
+	}
+}
+
+func csrfCookieName(opts arcis.CsrfOptions) string {
+	if opts.CookieName != "" {
+		return opts.CookieName
+	}
+	return "_csrf"
+}
+
+func buildEchoCsrfCookie(opts arcis.CsrfOptions, token string) string {
+	name := csrfCookieName(opts)
+	path := opts.Cookie.Path
+	if path == "" {
+		path = "/"
+	}
+	sameSite := opts.Cookie.SameSite
+	if sameSite == "" {
+		sameSite = "Lax"
+	}
+	parts := []string{name + "=" + token, "Path=" + path}
+	if opts.Cookie.HttpOnly {
+		parts = append(parts, "HttpOnly")
+	}
+	secure := true
+	if opts.Cookie.Secure != nil {
+		secure = *opts.Cookie.Secure
+	}
+	if secure {
+		parts = append(parts, "Secure")
+	}
+	parts = append(parts, "SameSite="+sameSite)
+	if opts.Cookie.Domain != "" {
+		parts = append(parts, "Domain="+opts.Cookie.Domain)
+	}
+	return strings.Join(parts, "; ")
+}
+
+// SecureCookies returns an Echo middleware that enforces secure cookie defaults.
+func SecureCookies(opts arcis.SecureCookieOptions) echo.MiddlewareFunc {
+	sc := arcis.NewSecureCookieDefaults(opts)
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			err := next(c)
+
+			// Enforce on all Set-Cookie headers after handler runs
+			cookies := c.Response().Header().Values("Set-Cookie")
+			if len(cookies) > 0 {
+				c.Response().Header().Del("Set-Cookie")
+				for _, cookie := range cookies {
+					c.Response().Header().Add("Set-Cookie", sc.Enforce(cookie))
+				}
+			}
+
+			return err
+		}
+	}
+}
+
+// Cors returns an Echo middleware for safe CORS handling.
+func Cors(opts arcis.CorsOptions) echo.MiddlewareFunc {
+	cors := arcis.NewSafeCors(opts)
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			origin := c.Request().Header.Get("Origin")
+			headers := cors.GetHeaders(origin, c.Request().Method)
+
+			for key, value := range headers {
+				c.Response().Header().Set(key, value)
+			}
+
+			// Handle preflight
+			if c.Request().Method == http.MethodOptions && origin != "" {
+				if _, ok := headers["Access-Control-Allow-Origin"]; ok {
+					return c.NoContent(http.StatusNoContent)
+				}
+			}
+
+			return next(c)
+		}
+	}
 }
 
 // ErrorHandler returns an Echo error handler function.

--- a/packages/arcis-go/gin/gin.go
+++ b/packages/arcis-go/gin/gin.go
@@ -471,6 +471,105 @@ func GetValidatedBody(c *gin.Context) map[string]interface{} {
 	return nil
 }
 
+// CsrfProtection returns a Gin middleware for CSRF protection using double-submit cookie.
+func CsrfProtection(opts arcis.CsrfOptions) gin.HandlerFunc {
+	csrf := arcis.NewCsrfProtection(opts)
+
+	return func(c *gin.Context) {
+		method := c.Request.Method
+
+		// Wrap the handler
+		handler := csrf.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Copy headers set by CSRF middleware to gin response
+			for key, values := range w.Header() {
+				for _, v := range values {
+					c.Writer.Header().Add(key, v)
+				}
+			}
+			c.Next()
+		}))
+
+		rec := &ginResponseCapture{header: http.Header{}}
+		handler.ServeHTTP(rec, c.Request)
+
+		if rec.status == http.StatusForbidden {
+			// CSRF validation failed
+			for key, values := range rec.header {
+				for _, v := range values {
+					c.Writer.Header().Set(key, v)
+				}
+			}
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+				"error":   "CSRF token validation failed",
+				"message": "Invalid or missing CSRF token. Include the token from the cookie in the X-CSRF-Token header.",
+			})
+			return
+		}
+
+		// Copy Set-Cookie headers from CSRF middleware
+		for _, cookie := range rec.header.Values("Set-Cookie") {
+			c.Writer.Header().Add("Set-Cookie", cookie)
+		}
+
+		// Only proceed if not a safe method that was already handled
+		if method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions {
+			c.Next()
+		}
+	}
+}
+
+// ginResponseCapture captures response status/headers from net/http handlers.
+type ginResponseCapture struct {
+	header http.Header
+	status int
+}
+
+func (g *ginResponseCapture) Header() http.Header          { return g.header }
+func (g *ginResponseCapture) Write(b []byte) (int, error)  { return len(b), nil }
+func (g *ginResponseCapture) WriteHeader(statusCode int)   { g.status = statusCode }
+
+// SecureCookies returns a Gin middleware that enforces secure cookie defaults.
+func SecureCookies(opts arcis.SecureCookieOptions) gin.HandlerFunc {
+	sc := arcis.NewSecureCookieDefaults(opts)
+
+	return func(c *gin.Context) {
+		c.Next()
+
+		// Enforce on all Set-Cookie headers after handler runs
+		cookies := c.Writer.Header().Values("Set-Cookie")
+		if len(cookies) > 0 {
+			c.Writer.Header().Del("Set-Cookie")
+			for _, cookie := range cookies {
+				c.Writer.Header().Add("Set-Cookie", sc.Enforce(cookie))
+			}
+		}
+	}
+}
+
+// Cors returns a Gin middleware for safe CORS handling.
+func Cors(opts arcis.CorsOptions) gin.HandlerFunc {
+	cors := arcis.NewSafeCors(opts)
+
+	return func(c *gin.Context) {
+		origin := c.GetHeader("Origin")
+		headers := cors.GetHeaders(origin, c.Request.Method)
+
+		for key, value := range headers {
+			c.Header(key, value)
+		}
+
+		// Handle preflight
+		if c.Request.Method == http.MethodOptions && origin != "" {
+			if _, ok := headers["Access-Control-Allow-Origin"]; ok {
+				c.AbortWithStatus(http.StatusNoContent)
+				return
+			}
+		}
+
+		c.Next()
+	}
+}
+
 // ErrorHandler returns a Gin error handler middleware.
 func ErrorHandler(isDev bool) gin.HandlerFunc {
 	handler := arcis.NewErrorHandler(isDev)

--- a/packages/arcis-go/middleware/cookies.go
+++ b/packages/arcis-go/middleware/cookies.go
@@ -1,0 +1,150 @@
+package middleware
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// SecureCookieOptions configures secure cookie enforcement.
+type SecureCookieOptions struct {
+	// HttpOnly prevents JavaScript access to cookies. Default: true
+	HttpOnly *bool
+
+	// Secure ensures cookies are only sent over HTTPS. Default: true
+	Secure *bool
+
+	// SameSite attribute for CSRF protection. "Strict", "Lax", "None", or "" to skip.
+	// Default: "Lax"
+	SameSite *string
+
+	// Path overrides the Path attribute on all cookies. Empty = keep original.
+	Path string
+}
+
+// SecureCookieDefaults enforces secure cookie attributes on Set-Cookie headers.
+type SecureCookieDefaults struct {
+	httpOnly bool
+	secure   bool
+	sameSite string // "Strict", "Lax", "None", or "" to skip
+	path     string
+}
+
+// NewSecureCookieDefaults creates a SecureCookieDefaults with the given options.
+func NewSecureCookieDefaults(opts SecureCookieOptions) *SecureCookieDefaults {
+	httpOnly := true
+	if opts.HttpOnly != nil {
+		httpOnly = *opts.HttpOnly
+	}
+
+	secure := true
+	if opts.Secure != nil {
+		secure = *opts.Secure
+	}
+
+	sameSite := "Lax"
+	if opts.SameSite != nil {
+		sameSite = *opts.SameSite
+	}
+
+	return &SecureCookieDefaults{
+		httpOnly: httpOnly,
+		secure:   secure,
+		sameSite: sameSite,
+		path:     opts.Path,
+	}
+}
+
+var pathRegexp = regexp.MustCompile(`(?i);\s*path=[^;]*`)
+
+// EnforceSecureCookie enforces secure defaults on a single Set-Cookie header value.
+func EnforceSecureCookie(cookieStr string, httpOnly, secure bool, sameSite, path string) string {
+	lower := strings.ToLower(cookieStr)
+	result := cookieStr
+
+	// HttpOnly — prevent JavaScript access
+	if httpOnly && !strings.Contains(lower, "httponly") {
+		result += "; HttpOnly"
+	}
+
+	// Secure — HTTPS only
+	if secure && !strings.Contains(lower, "; secure") {
+		result += "; Secure"
+	}
+
+	// SameSite — CSRF protection
+	if sameSite != "" && !strings.Contains(lower, "samesite") {
+		result += "; SameSite=" + sameSite
+		// SameSite=None requires Secure
+		if sameSite == "None" && !strings.Contains(strings.ToLower(result), "; secure") {
+			result += "; Secure"
+		}
+	}
+
+	// Override path if specified
+	if path != "" {
+		if strings.Contains(lower, "path=") {
+			result = pathRegexp.ReplaceAllString(result, "; Path="+path)
+		} else {
+			result += "; Path=" + path
+		}
+	}
+
+	return result
+}
+
+// Enforce applies secure defaults to a Set-Cookie header value.
+func (sc *SecureCookieDefaults) Enforce(cookieStr string) string {
+	return EnforceSecureCookie(cookieStr, sc.httpOnly, sc.secure, sc.sameSite, sc.path)
+}
+
+// Handler returns an http.Handler middleware that enforces secure cookie defaults.
+// It wraps the ResponseWriter to intercept Set-Cookie headers.
+func (sc *SecureCookieDefaults) Handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wrapped := &secureCookieWriter{ResponseWriter: w, enforcer: sc}
+		next.ServeHTTP(wrapped, r)
+	})
+}
+
+// secureCookieWriter wraps http.ResponseWriter to intercept Set-Cookie headers.
+type secureCookieWriter struct {
+	http.ResponseWriter
+	enforcer *SecureCookieDefaults
+}
+
+func (w *secureCookieWriter) Header() http.Header {
+	return w.ResponseWriter.Header()
+}
+
+func (w *secureCookieWriter) WriteHeader(statusCode int) {
+	// Enforce secure defaults on all Set-Cookie headers before writing
+	cookies := w.ResponseWriter.Header().Values("Set-Cookie")
+	if len(cookies) > 0 {
+		w.ResponseWriter.Header().Del("Set-Cookie")
+		for _, cookie := range cookies {
+			w.ResponseWriter.Header().Add("Set-Cookie", w.enforcer.Enforce(cookie))
+		}
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *secureCookieWriter) Write(data []byte) (int, error) {
+	// Enforce before first write (implicit 200)
+	cookies := w.ResponseWriter.Header().Values("Set-Cookie")
+	if len(cookies) > 0 {
+		w.ResponseWriter.Header().Del("Set-Cookie")
+		for _, cookie := range cookies {
+			w.ResponseWriter.Header().Add("Set-Cookie", w.enforcer.Enforce(cookie))
+		}
+	}
+	return w.ResponseWriter.Write(data)
+}
+
+// SecureCookieMiddleware creates a secure cookie http.Handler middleware from options.
+func SecureCookieMiddleware(opts SecureCookieOptions) func(http.Handler) http.Handler {
+	sc := NewSecureCookieDefaults(opts)
+	return func(next http.Handler) http.Handler {
+		return sc.Handler(next)
+	}
+}

--- a/packages/arcis-go/middleware/cookies_test.go
+++ b/packages/arcis-go/middleware/cookies_test.go
@@ -1,0 +1,285 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// --- EnforceSecureCookie tests ---
+
+func TestEnforceSecureCookie_AddsHttpOnly(t *testing.T) {
+	result := EnforceSecureCookie("session=abc", true, false, "", "")
+	if result != "session=abc; HttpOnly" {
+		t.Errorf("expected HttpOnly, got %q", result)
+	}
+}
+
+func TestEnforceSecureCookie_NoDuplicateHttpOnly(t *testing.T) {
+	result := EnforceSecureCookie("session=abc; HttpOnly", true, false, "", "")
+	if result != "session=abc; HttpOnly" {
+		t.Errorf("should not duplicate HttpOnly, got %q", result)
+	}
+}
+
+func TestEnforceSecureCookie_HttpOnlyDisabled(t *testing.T) {
+	result := EnforceSecureCookie("session=abc", false, false, "", "")
+	if result != "session=abc" {
+		t.Errorf("should not add HttpOnly when disabled, got %q", result)
+	}
+}
+
+func TestEnforceSecureCookie_AddsSecure(t *testing.T) {
+	result := EnforceSecureCookie("session=abc", false, true, "", "")
+	if result != "session=abc; Secure" {
+		t.Errorf("expected Secure, got %q", result)
+	}
+}
+
+func TestEnforceSecureCookie_NoDuplicateSecure(t *testing.T) {
+	result := EnforceSecureCookie("session=abc; Secure", false, true, "", "")
+	if result != "session=abc; Secure" {
+		t.Errorf("should not duplicate Secure, got %q", result)
+	}
+}
+
+func TestEnforceSecureCookie_SecureDisabled(t *testing.T) {
+	result := EnforceSecureCookie("session=abc", false, false, "", "")
+	if result != "session=abc" {
+		t.Errorf("should not add Secure when disabled, got %q", result)
+	}
+}
+
+func TestEnforceSecureCookie_SameSiteLax(t *testing.T) {
+	result := EnforceSecureCookie("session=abc", false, false, "Lax", "")
+	if result != "session=abc; SameSite=Lax" {
+		t.Errorf("expected SameSite=Lax, got %q", result)
+	}
+}
+
+func TestEnforceSecureCookie_SameSiteStrict(t *testing.T) {
+	result := EnforceSecureCookie("session=abc", false, false, "Strict", "")
+	if result != "session=abc; SameSite=Strict" {
+		t.Errorf("expected SameSite=Strict, got %q", result)
+	}
+}
+
+func TestEnforceSecureCookie_SameSiteNoneAddsSecure(t *testing.T) {
+	result := EnforceSecureCookie("session=abc", false, false, "None", "")
+	expected := "session=abc; SameSite=None; Secure"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestEnforceSecureCookie_SameSiteNoneNoDoubleSecure(t *testing.T) {
+	result := EnforceSecureCookie("session=abc", false, true, "None", "")
+	// Secure added first, then SameSite=None, should not duplicate
+	expected := "session=abc; Secure; SameSite=None"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestEnforceSecureCookie_NoDuplicateSameSite(t *testing.T) {
+	result := EnforceSecureCookie("session=abc; SameSite=Strict", false, false, "Lax", "")
+	if result != "session=abc; SameSite=Strict" {
+		t.Errorf("should not duplicate SameSite, got %q", result)
+	}
+}
+
+func TestEnforceSecureCookie_SameSiteDisabled(t *testing.T) {
+	result := EnforceSecureCookie("session=abc", false, false, "", "")
+	if result != "session=abc" {
+		t.Errorf("should not add SameSite when disabled, got %q", result)
+	}
+}
+
+func TestEnforceSecureCookie_AddsPath(t *testing.T) {
+	result := EnforceSecureCookie("session=abc", false, false, "", "/app")
+	if result != "session=abc; Path=/app" {
+		t.Errorf("expected Path=/app, got %q", result)
+	}
+}
+
+func TestEnforceSecureCookie_OverridesPath(t *testing.T) {
+	result := EnforceSecureCookie("session=abc; Path=/old", false, false, "", "/new")
+	if result != "session=abc; Path=/new" {
+		t.Errorf("expected path override, got %q", result)
+	}
+}
+
+func TestEnforceSecureCookie_AllDefaults(t *testing.T) {
+	result := EnforceSecureCookie("session=abc", true, true, "Lax", "")
+	expected := "session=abc; HttpOnly; Secure; SameSite=Lax"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestEnforceSecureCookie_AlreadySecure(t *testing.T) {
+	result := EnforceSecureCookie("session=abc; HttpOnly; Secure; SameSite=Lax", true, true, "Lax", "")
+	expected := "session=abc; HttpOnly; Secure; SameSite=Lax"
+	if result != expected {
+		t.Errorf("should not modify already secure cookie, got %q", result)
+	}
+}
+
+func TestEnforceSecureCookie_CaseInsensitiveDetection(t *testing.T) {
+	// Existing attributes with different casing should be detected
+	result := EnforceSecureCookie("session=abc; HTTPONLY; SECURE; SAMESITE=Strict", true, true, "Lax", "")
+	if result != "session=abc; HTTPONLY; SECURE; SAMESITE=Strict" {
+		t.Errorf("should detect case-insensitive attrs, got %q", result)
+	}
+}
+
+// --- SecureCookieDefaults tests ---
+
+func TestSecureCookieDefaults_Enforce(t *testing.T) {
+	sc := NewSecureCookieDefaults(SecureCookieOptions{})
+	result := sc.Enforce("session=abc")
+	expected := "session=abc; HttpOnly; Secure; SameSite=Lax"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestSecureCookieDefaults_CustomOptions(t *testing.T) {
+	httpOnly := false
+	sameSite := "Strict"
+	sc := NewSecureCookieDefaults(SecureCookieOptions{
+		HttpOnly: &httpOnly,
+		SameSite: &sameSite,
+	})
+	result := sc.Enforce("session=abc")
+	expected := "session=abc; Secure; SameSite=Strict"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestSecureCookieDefaults_DisableSecure(t *testing.T) {
+	secure := false
+	sc := NewSecureCookieDefaults(SecureCookieOptions{
+		Secure: &secure,
+	})
+	result := sc.Enforce("session=abc")
+	expected := "session=abc; HttpOnly; SameSite=Lax"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestSecureCookieDefaults_WithPath(t *testing.T) {
+	sc := NewSecureCookieDefaults(SecureCookieOptions{
+		Path: "/api",
+	})
+	result := sc.Enforce("session=abc")
+	expected := "session=abc; HttpOnly; Secure; SameSite=Lax; Path=/api"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+// --- HTTP Handler middleware tests ---
+
+func TestCookieHandler_EnforcesOnSetCookie(t *testing.T) {
+	sc := NewSecureCookieDefaults(SecureCookieOptions{})
+	handler := sc.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Set-Cookie", "session=abc123")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	cookies := rec.Header().Values("Set-Cookie")
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 Set-Cookie, got %d", len(cookies))
+	}
+	expected := "session=abc123; HttpOnly; Secure; SameSite=Lax"
+	if cookies[0] != expected {
+		t.Errorf("expected %q, got %q", expected, cookies[0])
+	}
+}
+
+func TestCookieHandler_EnforcesMultipleCookies(t *testing.T) {
+	sc := NewSecureCookieDefaults(SecureCookieOptions{})
+	handler := sc.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Set-Cookie", "session=abc")
+		w.Header().Add("Set-Cookie", "theme=dark")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	cookies := rec.Header().Values("Set-Cookie")
+	if len(cookies) != 2 {
+		t.Fatalf("expected 2 Set-Cookie, got %d", len(cookies))
+	}
+
+	if cookies[0] != "session=abc; HttpOnly; Secure; SameSite=Lax" {
+		t.Errorf("first cookie wrong: %q", cookies[0])
+	}
+	if cookies[1] != "theme=dark; HttpOnly; Secure; SameSite=Lax" {
+		t.Errorf("second cookie wrong: %q", cookies[1])
+	}
+}
+
+func TestCookieHandler_NoCookiesUnchanged(t *testing.T) {
+	sc := NewSecureCookieDefaults(SecureCookieOptions{})
+	handler := sc.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if len(rec.Header().Values("Set-Cookie")) != 0 {
+		t.Error("should not add Set-Cookie when none present")
+	}
+}
+
+func TestCookieHandler_ImplicitWrite(t *testing.T) {
+	sc := NewSecureCookieDefaults(SecureCookieOptions{})
+	handler := sc.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Set-Cookie", "token=xyz")
+		w.Write([]byte("hello"))
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	cookies := rec.Header().Values("Set-Cookie")
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 Set-Cookie, got %d", len(cookies))
+	}
+	if cookies[0] != "token=xyz; HttpOnly; Secure; SameSite=Lax" {
+		t.Errorf("expected enforced cookie on implicit write, got %q", cookies[0])
+	}
+}
+
+// --- SecureCookieMiddleware factory test ---
+
+func TestSecureCookieMiddleware_Factory(t *testing.T) {
+	mw := SecureCookieMiddleware(SecureCookieOptions{})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Set-Cookie", "id=1")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	cookies := rec.Header().Values("Set-Cookie")
+	if len(cookies) != 1 || cookies[0] != "id=1; HttpOnly; Secure; SameSite=Lax" {
+		t.Errorf("factory middleware failed: %v", cookies)
+	}
+}

--- a/packages/arcis-go/middleware/cors.go
+++ b/packages/arcis-go/middleware/cors.go
@@ -1,0 +1,183 @@
+package middleware
+
+import (
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Default CORS configuration values.
+var (
+	DefaultCorsMethods = []string{"GET", "HEAD", "PUT", "PATCH", "POST", "DELETE"}
+	DefaultCorsHeaders = []string{"Content-Type", "Authorization"}
+	DefaultCorsMaxAge  = 600 // 10 minutes
+)
+
+// CorsOrigin represents the allowed origin configuration.
+// It can be a string, []string, *regexp.Regexp, func(string) bool, or bool (true = reflect).
+type CorsOrigin interface{}
+
+// CorsOptions configures the Safe CORS middleware.
+type CorsOptions struct {
+	// Origin defines which origins are allowed. Required.
+	// Accepts: string, []string, *regexp.Regexp, func(string) bool, or true (reflect request origin).
+	Origin CorsOrigin
+
+	// Methods defines the allowed HTTP methods for preflight.
+	// Default: GET, HEAD, PUT, PATCH, POST, DELETE
+	Methods []string
+
+	// AllowedHeaders defines the allowed request headers for preflight.
+	// Default: Content-Type, Authorization
+	AllowedHeaders []string
+
+	// ExposedHeaders defines which response headers the browser can access.
+	// Default: empty
+	ExposedHeaders []string
+
+	// Credentials indicates whether cookies/auth headers are allowed.
+	// Default: false
+	Credentials bool
+
+	// MaxAge defines how long preflight results can be cached (seconds).
+	// Default: 600 (10 minutes)
+	MaxAge int
+}
+
+// CorsHeaders holds the computed CORS response headers.
+type CorsHeaders map[string]string
+
+// SafeCors provides safe CORS header management.
+type SafeCors struct {
+	origin         CorsOrigin
+	methods        []string
+	allowedHeaders []string
+	exposedHeaders []string
+	credentials    bool
+	maxAge         int
+}
+
+// NewSafeCors creates a SafeCors instance with the given options.
+func NewSafeCors(opts CorsOptions) *SafeCors {
+	methods := opts.Methods
+	if len(methods) == 0 {
+		methods = DefaultCorsMethods
+	}
+
+	allowedHeaders := opts.AllowedHeaders
+	if len(allowedHeaders) == 0 {
+		allowedHeaders = DefaultCorsHeaders
+	}
+
+	exposedHeaders := opts.ExposedHeaders
+	if exposedHeaders == nil {
+		exposedHeaders = []string{}
+	}
+
+	maxAge := opts.MaxAge
+	if maxAge == 0 {
+		maxAge = DefaultCorsMaxAge
+	}
+
+	return &SafeCors{
+		origin:         opts.Origin,
+		methods:        methods,
+		allowedHeaders: allowedHeaders,
+		exposedHeaders: exposedHeaders,
+		credentials:    opts.Credentials,
+		maxAge:         maxAge,
+	}
+}
+
+// isOriginAllowed checks if a request origin is permitted.
+func isOriginAllowed(requestOrigin string, allowed CorsOrigin) bool {
+	// Always block "null" origin (sandboxed iframes, data: URIs)
+	if strings.EqualFold(requestOrigin, "null") {
+		return false
+	}
+
+	switch v := allowed.(type) {
+	case bool:
+		return v
+	case string:
+		return requestOrigin == v
+	case []string:
+		for _, o := range v {
+			if requestOrigin == o {
+				return true
+			}
+		}
+		return false
+	case *regexp.Regexp:
+		return v.MatchString(requestOrigin)
+	case func(string) bool:
+		return v(requestOrigin)
+	default:
+		return false
+	}
+}
+
+// GetHeaders computes the CORS headers for a given request origin and method.
+func (sc *SafeCors) GetHeaders(requestOrigin string, method string) CorsHeaders {
+	headers := CorsHeaders{
+		"Vary": "Origin",
+	}
+
+	// No origin header → same-origin request, only Vary needed
+	if requestOrigin == "" {
+		return headers
+	}
+
+	if !isOriginAllowed(requestOrigin, sc.origin) {
+		return headers
+	}
+
+	// Origin is allowed — set CORS headers
+	headers["Access-Control-Allow-Origin"] = requestOrigin
+
+	if sc.credentials {
+		headers["Access-Control-Allow-Credentials"] = "true"
+	}
+
+	if len(sc.exposedHeaders) > 0 {
+		headers["Access-Control-Expose-Headers"] = strings.Join(sc.exposedHeaders, ", ")
+	}
+
+	// Preflight-specific headers
+	if strings.EqualFold(method, "OPTIONS") {
+		headers["Access-Control-Allow-Methods"] = strings.Join(sc.methods, ", ")
+		headers["Access-Control-Allow-Headers"] = strings.Join(sc.allowedHeaders, ", ")
+		headers["Access-Control-Max-Age"] = strconv.Itoa(sc.maxAge)
+	}
+
+	return headers
+}
+
+// Handler returns an http.Handler middleware that applies CORS headers.
+func (sc *SafeCors) Handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		corsHeaders := sc.GetHeaders(origin, r.Method)
+
+		for key, value := range corsHeaders {
+			w.Header().Set(key, value)
+		}
+
+		// Handle preflight
+		if r.Method == http.MethodOptions && origin != "" && isOriginAllowed(origin, sc.origin) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// SafeCorsMiddleware creates a CORS http.Handler middleware from options.
+func SafeCorsMiddleware(opts CorsOptions) func(http.Handler) http.Handler {
+	cors := NewSafeCors(opts)
+	return func(next http.Handler) http.Handler {
+		return cors.Handler(next)
+	}
+}

--- a/packages/arcis-go/middleware/cors_test.go
+++ b/packages/arcis-go/middleware/cors_test.go
@@ -1,0 +1,454 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+)
+
+// --- isOriginAllowed tests ---
+
+func TestIsOriginAllowed_ExactString(t *testing.T) {
+	if !isOriginAllowed("https://example.com", "https://example.com") {
+		t.Error("should allow exact match")
+	}
+	if isOriginAllowed("https://evil.com", "https://example.com") {
+		t.Error("should reject non-matching origin")
+	}
+}
+
+func TestIsOriginAllowed_StringSlice(t *testing.T) {
+	allowed := []string{"https://a.com", "https://b.com"}
+	if !isOriginAllowed("https://a.com", allowed) {
+		t.Error("should allow listed origin")
+	}
+	if !isOriginAllowed("https://b.com", allowed) {
+		t.Error("should allow second listed origin")
+	}
+	if isOriginAllowed("https://c.com", allowed) {
+		t.Error("should reject unlisted origin")
+	}
+}
+
+func TestIsOriginAllowed_Regexp(t *testing.T) {
+	re := regexp.MustCompile(`^https://.*\.example\.com$`)
+	if !isOriginAllowed("https://app.example.com", re) {
+		t.Error("should allow matching regex")
+	}
+	if isOriginAllowed("https://evil.com", re) {
+		t.Error("should reject non-matching regex")
+	}
+}
+
+func TestIsOriginAllowed_Function(t *testing.T) {
+	fn := func(origin string) bool {
+		return origin == "https://custom.com"
+	}
+	if !isOriginAllowed("https://custom.com", fn) {
+		t.Error("should allow when function returns true")
+	}
+	if isOriginAllowed("https://other.com", fn) {
+		t.Error("should reject when function returns false")
+	}
+}
+
+func TestIsOriginAllowed_BoolTrue(t *testing.T) {
+	if !isOriginAllowed("https://anything.com", true) {
+		t.Error("should allow any origin when true")
+	}
+}
+
+func TestIsOriginAllowed_BoolFalse(t *testing.T) {
+	if isOriginAllowed("https://anything.com", false) {
+		t.Error("should reject all origins when false")
+	}
+}
+
+func TestIsOriginAllowed_NullAlwaysBlocked(t *testing.T) {
+	cases := []CorsOrigin{
+		true,
+		"null",
+		[]string{"null", "https://example.com"},
+		func(origin string) bool { return true },
+	}
+	for _, allowed := range cases {
+		if isOriginAllowed("null", allowed) {
+			t.Errorf("should block null origin even with allowed=%T", allowed)
+		}
+	}
+}
+
+func TestIsOriginAllowed_NullCaseInsensitive(t *testing.T) {
+	if isOriginAllowed("Null", true) {
+		t.Error("should block 'Null' (case-insensitive)")
+	}
+	if isOriginAllowed("NULL", true) {
+		t.Error("should block 'NULL' (case-insensitive)")
+	}
+}
+
+func TestIsOriginAllowed_UnsupportedType(t *testing.T) {
+	if isOriginAllowed("https://example.com", 42) {
+		t.Error("should reject unsupported origin type")
+	}
+}
+
+// --- SafeCors.GetHeaders tests ---
+
+func TestGetHeaders_NoOrigin(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: "https://example.com"})
+	headers := cors.GetHeaders("", "GET")
+
+	if headers["Vary"] != "Origin" {
+		t.Error("should always set Vary: Origin")
+	}
+	if _, ok := headers["Access-Control-Allow-Origin"]; ok {
+		t.Error("should not set ACAO when no origin")
+	}
+}
+
+func TestGetHeaders_AllowedOrigin(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: "https://example.com"})
+	headers := cors.GetHeaders("https://example.com", "GET")
+
+	if headers["Access-Control-Allow-Origin"] != "https://example.com" {
+		t.Errorf("expected origin https://example.com, got %s", headers["Access-Control-Allow-Origin"])
+	}
+	if headers["Vary"] != "Origin" {
+		t.Error("should set Vary: Origin")
+	}
+}
+
+func TestGetHeaders_RejectedOrigin(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: "https://example.com"})
+	headers := cors.GetHeaders("https://evil.com", "GET")
+
+	if _, ok := headers["Access-Control-Allow-Origin"]; ok {
+		t.Error("should not set ACAO for rejected origin")
+	}
+	if headers["Vary"] != "Origin" {
+		t.Error("should still set Vary: Origin for cache correctness")
+	}
+}
+
+func TestGetHeaders_Credentials(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{
+		Origin:      "https://example.com",
+		Credentials: true,
+	})
+	headers := cors.GetHeaders("https://example.com", "GET")
+
+	if headers["Access-Control-Allow-Credentials"] != "true" {
+		t.Error("should set credentials header")
+	}
+}
+
+func TestGetHeaders_NoCredentialsByDefault(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: "https://example.com"})
+	headers := cors.GetHeaders("https://example.com", "GET")
+
+	if _, ok := headers["Access-Control-Allow-Credentials"]; ok {
+		t.Error("should not set credentials by default")
+	}
+}
+
+func TestGetHeaders_ExposedHeaders(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{
+		Origin:         "https://example.com",
+		ExposedHeaders: []string{"X-Request-Id", "X-Total-Count"},
+	})
+	headers := cors.GetHeaders("https://example.com", "GET")
+
+	expected := "X-Request-Id, X-Total-Count"
+	if headers["Access-Control-Expose-Headers"] != expected {
+		t.Errorf("expected %q, got %q", expected, headers["Access-Control-Expose-Headers"])
+	}
+}
+
+func TestGetHeaders_Preflight(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: "https://example.com"})
+	headers := cors.GetHeaders("https://example.com", "OPTIONS")
+
+	if headers["Access-Control-Allow-Methods"] != "GET, HEAD, PUT, PATCH, POST, DELETE" {
+		t.Errorf("unexpected methods: %s", headers["Access-Control-Allow-Methods"])
+	}
+	if headers["Access-Control-Allow-Headers"] != "Content-Type, Authorization" {
+		t.Errorf("unexpected headers: %s", headers["Access-Control-Allow-Headers"])
+	}
+	if headers["Access-Control-Max-Age"] != "600" {
+		t.Errorf("expected max-age 600, got %s", headers["Access-Control-Max-Age"])
+	}
+}
+
+func TestGetHeaders_PreflightNotSetForGET(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: "https://example.com"})
+	headers := cors.GetHeaders("https://example.com", "GET")
+
+	if _, ok := headers["Access-Control-Allow-Methods"]; ok {
+		t.Error("should not set preflight headers for GET")
+	}
+	if _, ok := headers["Access-Control-Allow-Headers"]; ok {
+		t.Error("should not set preflight headers for GET")
+	}
+	if _, ok := headers["Access-Control-Max-Age"]; ok {
+		t.Error("should not set preflight headers for GET")
+	}
+}
+
+func TestGetHeaders_CustomMethods(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{
+		Origin:  "https://example.com",
+		Methods: []string{"GET", "POST"},
+	})
+	headers := cors.GetHeaders("https://example.com", "OPTIONS")
+
+	if headers["Access-Control-Allow-Methods"] != "GET, POST" {
+		t.Errorf("expected 'GET, POST', got %s", headers["Access-Control-Allow-Methods"])
+	}
+}
+
+func TestGetHeaders_CustomAllowedHeaders(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{
+		Origin:         "https://example.com",
+		AllowedHeaders: []string{"X-Custom", "Authorization"},
+	})
+	headers := cors.GetHeaders("https://example.com", "OPTIONS")
+
+	if headers["Access-Control-Allow-Headers"] != "X-Custom, Authorization" {
+		t.Errorf("expected custom headers, got %s", headers["Access-Control-Allow-Headers"])
+	}
+}
+
+func TestGetHeaders_CustomMaxAge(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{
+		Origin: "https://example.com",
+		MaxAge: 3600,
+	})
+	headers := cors.GetHeaders("https://example.com", "OPTIONS")
+
+	if headers["Access-Control-Max-Age"] != "3600" {
+		t.Errorf("expected max-age 3600, got %s", headers["Access-Control-Max-Age"])
+	}
+}
+
+func TestGetHeaders_PreflightRejectedOrigin(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: "https://example.com"})
+	headers := cors.GetHeaders("https://evil.com", "OPTIONS")
+
+	if _, ok := headers["Access-Control-Allow-Methods"]; ok {
+		t.Error("should not set preflight headers for rejected origin")
+	}
+}
+
+func TestGetHeaders_WhitelistOrigin(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{
+		Origin: []string{"https://a.com", "https://b.com"},
+	})
+
+	h1 := cors.GetHeaders("https://a.com", "GET")
+	if h1["Access-Control-Allow-Origin"] != "https://a.com" {
+		t.Error("should allow first whitelisted origin")
+	}
+
+	h2 := cors.GetHeaders("https://b.com", "GET")
+	if h2["Access-Control-Allow-Origin"] != "https://b.com" {
+		t.Error("should allow second whitelisted origin")
+	}
+
+	h3 := cors.GetHeaders("https://c.com", "GET")
+	if _, ok := h3["Access-Control-Allow-Origin"]; ok {
+		t.Error("should reject non-whitelisted origin")
+	}
+}
+
+func TestGetHeaders_RegexpOrigin(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{
+		Origin: regexp.MustCompile(`^https://.*\.myapp\.com$`),
+	})
+
+	h := cors.GetHeaders("https://api.myapp.com", "GET")
+	if h["Access-Control-Allow-Origin"] != "https://api.myapp.com" {
+		t.Error("should allow regex-matching origin")
+	}
+
+	h2 := cors.GetHeaders("https://evil.com", "GET")
+	if _, ok := h2["Access-Control-Allow-Origin"]; ok {
+		t.Error("should reject non-matching origin")
+	}
+}
+
+func TestGetHeaders_FunctionOrigin(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{
+		Origin: func(o string) bool { return o == "https://dynamic.com" },
+	})
+
+	h := cors.GetHeaders("https://dynamic.com", "GET")
+	if h["Access-Control-Allow-Origin"] != "https://dynamic.com" {
+		t.Error("should allow function-approved origin")
+	}
+}
+
+func TestGetHeaders_ReflectOrigin(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: true})
+
+	h := cors.GetHeaders("https://any.com", "GET")
+	if h["Access-Control-Allow-Origin"] != "https://any.com" {
+		t.Error("should reflect origin when true")
+	}
+}
+
+func TestGetHeaders_NullOriginBlocked(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: true})
+	h := cors.GetHeaders("null", "GET")
+
+	if _, ok := h["Access-Control-Allow-Origin"]; ok {
+		t.Error("should block null origin even with reflect=true")
+	}
+}
+
+// --- HTTP Handler tests ---
+
+func TestHandler_SetsHeadersOnAllowedOrigin(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: "https://example.com"})
+	handler := cors.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Origin", "https://example.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Access-Control-Allow-Origin") != "https://example.com" {
+		t.Error("should set ACAO header")
+	}
+	if rec.Header().Get("Vary") != "Origin" {
+		t.Error("should set Vary header")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestHandler_RejectedOriginNoHeaders(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: "https://example.com"})
+	handler := cors.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Origin", "https://evil.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Error("should not set ACAO for rejected origin")
+	}
+	if rec.Header().Get("Vary") != "Origin" {
+		t.Error("should still set Vary")
+	}
+}
+
+func TestHandler_PreflightReturns204(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: "https://example.com"})
+	nextCalled := false
+	handler := cors.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	}))
+
+	req := httptest.NewRequest("OPTIONS", "/", nil)
+	req.Header.Set("Origin", "https://example.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204 on preflight, got %d", rec.Code)
+	}
+	if nextCalled {
+		t.Error("should not call next handler on preflight")
+	}
+	if rec.Header().Get("Access-Control-Allow-Methods") == "" {
+		t.Error("should set preflight methods")
+	}
+}
+
+func TestHandler_PreflightRejectedCallsNext(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: "https://example.com"})
+	nextCalled := false
+	handler := cors.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	}))
+
+	req := httptest.NewRequest("OPTIONS", "/", nil)
+	req.Header.Set("Origin", "https://evil.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if !nextCalled {
+		t.Error("should call next for rejected preflight (not a CORS preflight)")
+	}
+}
+
+func TestHandler_NoOriginCallsNext(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{Origin: "https://example.com"})
+	nextCalled := false
+	handler := cors.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if !nextCalled {
+		t.Error("should call next when no origin")
+	}
+	if rec.Header().Get("Vary") != "Origin" {
+		t.Error("should set Vary even without origin")
+	}
+}
+
+func TestHandler_CredentialsHeader(t *testing.T) {
+	cors := NewSafeCors(CorsOptions{
+		Origin:      "https://example.com",
+		Credentials: true,
+	})
+	handler := cors.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Origin", "https://example.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Access-Control-Allow-Credentials") != "true" {
+		t.Error("should set credentials header")
+	}
+}
+
+// --- SafeCorsMiddleware factory test ---
+
+func TestSafeCorsMiddleware(t *testing.T) {
+	mw := SafeCorsMiddleware(CorsOptions{Origin: "https://example.com"})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Origin", "https://example.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Access-Control-Allow-Origin") != "https://example.com" {
+		t.Error("factory should produce working middleware")
+	}
+}

--- a/packages/arcis-go/middleware/csrf.go
+++ b/packages/arcis-go/middleware/csrf.go
@@ -1,0 +1,297 @@
+package middleware
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Default CSRF configuration values.
+const (
+	DefaultCsrfCookieName = "_csrf"
+	DefaultCsrfHeaderName = "X-Csrf-Token"
+	DefaultCsrfFieldName  = "_csrf"
+	DefaultTokenLength    = 32
+)
+
+// DefaultProtectedMethods are the HTTP methods that require CSRF validation.
+var DefaultProtectedMethods = []string{"POST", "PUT", "PATCH", "DELETE"}
+
+// CsrfCookieOptions configures the CSRF token cookie.
+type CsrfCookieOptions struct {
+	// Path for the cookie. Default: "/"
+	Path string
+	// HttpOnly — set false so client JS can read it for headers. Default: false
+	HttpOnly bool
+	// Secure flag (HTTPS only). Default: true
+	Secure *bool
+	// SameSite attribute. Default: "Lax"
+	SameSite string
+	// Domain for the cookie
+	Domain string
+}
+
+// CsrfOptions configures CSRF protection.
+type CsrfOptions struct {
+	// CookieName for the CSRF token. Default: "_csrf"
+	CookieName string
+	// HeaderName to check for the token. Default: "X-Csrf-Token"
+	HeaderName string
+	// FieldName to check in form/JSON body. Default: "_csrf"
+	FieldName string
+	// TokenLength in bytes (hex-encoded = 2x chars). Default: 32
+	TokenLength int
+	// ProtectedMethods that require CSRF validation. Default: POST, PUT, PATCH, DELETE
+	ProtectedMethods []string
+	// ExcludePaths excluded from CSRF checks (e.g., webhook endpoints)
+	ExcludePaths []string
+	// Cookie options for the CSRF token
+	Cookie CsrfCookieOptions
+	// OnError custom handler when CSRF validation fails. If nil, returns 403 JSON.
+	OnError func(w http.ResponseWriter, r *http.Request)
+}
+
+// CsrfProtection provides CSRF protection using double-submit cookie pattern.
+type CsrfProtection struct {
+	cookieName       string
+	headerName       string
+	fieldName        string
+	tokenLength      int
+	protectedMethods map[string]bool
+	excludePaths     []string
+	cookie           CsrfCookieOptions
+	onError          func(w http.ResponseWriter, r *http.Request)
+}
+
+// GenerateCsrfToken generates a cryptographically random CSRF token.
+func GenerateCsrfToken(length int) (string, error) {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// ValidateCsrfToken compares two CSRF tokens using constant-time comparison.
+func ValidateCsrfToken(cookieToken, requestToken string) bool {
+	if cookieToken == "" || requestToken == "" {
+		return false
+	}
+	if len(cookieToken) != len(requestToken) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(cookieToken), []byte(requestToken)) == 1
+}
+
+// NewCsrfProtection creates a CsrfProtection with the given options.
+func NewCsrfProtection(opts CsrfOptions) *CsrfProtection {
+	cookieName := opts.CookieName
+	if cookieName == "" {
+		cookieName = DefaultCsrfCookieName
+	}
+
+	headerName := opts.HeaderName
+	if headerName == "" {
+		headerName = DefaultCsrfHeaderName
+	}
+
+	fieldName := opts.FieldName
+	if fieldName == "" {
+		fieldName = DefaultCsrfFieldName
+	}
+
+	tokenLength := opts.TokenLength
+	if tokenLength == 0 {
+		tokenLength = DefaultTokenLength
+	}
+
+	methods := opts.ProtectedMethods
+	if len(methods) == 0 {
+		methods = DefaultProtectedMethods
+	}
+	protectedSet := make(map[string]bool, len(methods))
+	for _, m := range methods {
+		protectedSet[strings.ToUpper(m)] = true
+	}
+
+	excludePaths := opts.ExcludePaths
+	if excludePaths == nil {
+		excludePaths = []string{}
+	}
+
+	cookie := opts.Cookie
+	if cookie.Path == "" {
+		cookie.Path = "/"
+	}
+	if cookie.SameSite == "" {
+		cookie.SameSite = "Lax"
+	}
+	if cookie.Secure == nil {
+		t := true
+		cookie.Secure = &t
+	}
+
+	return &CsrfProtection{
+		cookieName:       cookieName,
+		headerName:       headerName,
+		fieldName:        fieldName,
+		tokenLength:      tokenLength,
+		protectedMethods: protectedSet,
+		excludePaths:     excludePaths,
+		cookie:           cookie,
+		onError:          opts.OnError,
+	}
+}
+
+// isExcluded checks if a path is excluded from CSRF protection.
+func (cp *CsrfProtection) isExcluded(path string) bool {
+	for _, excluded := range cp.excludePaths {
+		if path == excluded || strings.HasPrefix(path, excluded+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// buildCookieHeader builds a Set-Cookie header value for the CSRF token.
+func (cp *CsrfProtection) buildCookieHeader(token string) string {
+	parts := []string{fmt.Sprintf("%s=%s", cp.cookieName, token)}
+	parts = append(parts, "Path="+cp.cookie.Path)
+	if cp.cookie.HttpOnly {
+		parts = append(parts, "HttpOnly")
+	}
+	if cp.cookie.Secure != nil && *cp.cookie.Secure {
+		parts = append(parts, "Secure")
+	}
+	parts = append(parts, "SameSite="+cp.cookie.SameSite)
+	if cp.cookie.Domain != "" {
+		parts = append(parts, "Domain="+cp.cookie.Domain)
+	}
+	return strings.Join(parts, "; ")
+}
+
+// getCookieToken reads the CSRF token from the request cookie.
+func (cp *CsrfProtection) getCookieToken(r *http.Request) string {
+	cookie, err := r.Cookie(cp.cookieName)
+	if err != nil {
+		return ""
+	}
+	return cookie.Value
+}
+
+// getRequestToken extracts the CSRF token from the request (header, then body, then query).
+func (cp *CsrfProtection) getRequestToken(r *http.Request) string {
+	// 1. Check header (most common for SPAs)
+	headerToken := r.Header.Get(cp.headerName)
+	if headerToken != "" {
+		return headerToken
+	}
+
+	// 2. Check form field
+	if r.Form != nil {
+		formToken := r.FormValue(cp.fieldName)
+		if formToken != "" {
+			return formToken
+		}
+	}
+
+	// 3. Check query string
+	queryToken := r.URL.Query().Get(cp.fieldName)
+	if queryToken != "" {
+		return queryToken
+	}
+
+	return ""
+}
+
+// sendError sends the CSRF error response.
+func (cp *CsrfProtection) sendError(w http.ResponseWriter, r *http.Request) {
+	if cp.onError != nil {
+		cp.onError(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	json.NewEncoder(w).Encode(map[string]string{
+		"error":   "CSRF token validation failed",
+		"message": "Invalid or missing CSRF token. Include the token from the cookie in the X-CSRF-Token header.",
+	})
+}
+
+// Check performs framework-agnostic CSRF validation.
+// Returns true if the request is valid (safe method, excluded path, or valid token).
+func (cp *CsrfProtection) Check(method, path, cookieToken, requestToken string) bool {
+	if cp.isExcluded(path) {
+		return true
+	}
+	if !cp.protectedMethods[strings.ToUpper(method)] {
+		return true
+	}
+	if cookieToken == "" || requestToken == "" {
+		return false
+	}
+	return ValidateCsrfToken(cookieToken, requestToken)
+}
+
+// GenerateToken generates a new CSRF token.
+func (cp *CsrfProtection) GenerateToken() (string, error) {
+	return GenerateCsrfToken(cp.tokenLength)
+}
+
+// Handler returns an http.Handler middleware for CSRF protection.
+func (cp *CsrfProtection) Handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method := strings.ToUpper(r.Method)
+
+		// Check if path is excluded
+		if cp.isExcluded(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// For safe methods — ensure a CSRF cookie exists
+		if !cp.protectedMethods[method] {
+			existing := cp.getCookieToken(r)
+			if existing == "" {
+				token, err := GenerateCsrfToken(cp.tokenLength)
+				if err == nil {
+					w.Header().Add("Set-Cookie", cp.buildCookieHeader(token))
+				}
+			}
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// For protected methods — validate the token
+		cookieToken := cp.getCookieToken(r)
+		if cookieToken == "" {
+			cp.sendError(w, r)
+			return
+		}
+
+		requestToken := cp.getRequestToken(r)
+		if requestToken == "" {
+			cp.sendError(w, r)
+			return
+		}
+
+		if !ValidateCsrfToken(cookieToken, requestToken) {
+			cp.sendError(w, r)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// CsrfMiddleware creates a CSRF protection http.Handler middleware from options.
+func CsrfMiddleware(opts CsrfOptions) func(http.Handler) http.Handler {
+	csrf := NewCsrfProtection(opts)
+	return func(next http.Handler) http.Handler {
+		return csrf.Handler(next)
+	}
+}

--- a/packages/arcis-go/middleware/csrf_test.go
+++ b/packages/arcis-go/middleware/csrf_test.go
@@ -1,0 +1,389 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- GenerateCsrfToken tests ---
+
+func TestGenerateCsrfToken_Length(t *testing.T) {
+	token, err := GenerateCsrfToken(32)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(token) != 64 { // 32 bytes = 64 hex chars
+		t.Errorf("expected 64 hex chars, got %d", len(token))
+	}
+}
+
+func TestGenerateCsrfToken_Unique(t *testing.T) {
+	t1, _ := GenerateCsrfToken(32)
+	t2, _ := GenerateCsrfToken(32)
+	if t1 == t2 {
+		t.Error("tokens should be unique")
+	}
+}
+
+func TestGenerateCsrfToken_CustomLength(t *testing.T) {
+	token, _ := GenerateCsrfToken(16)
+	if len(token) != 32 {
+		t.Errorf("expected 32 hex chars for 16 bytes, got %d", len(token))
+	}
+}
+
+// --- ValidateCsrfToken tests ---
+
+func TestValidateCsrfToken_Match(t *testing.T) {
+	if !ValidateCsrfToken("abc123", "abc123") {
+		t.Error("should match identical tokens")
+	}
+}
+
+func TestValidateCsrfToken_Mismatch(t *testing.T) {
+	if ValidateCsrfToken("abc123", "xyz789") {
+		t.Error("should not match different tokens")
+	}
+}
+
+func TestValidateCsrfToken_EmptyCookie(t *testing.T) {
+	if ValidateCsrfToken("", "abc123") {
+		t.Error("should reject empty cookie token")
+	}
+}
+
+func TestValidateCsrfToken_EmptyRequest(t *testing.T) {
+	if ValidateCsrfToken("abc123", "") {
+		t.Error("should reject empty request token")
+	}
+}
+
+func TestValidateCsrfToken_BothEmpty(t *testing.T) {
+	if ValidateCsrfToken("", "") {
+		t.Error("should reject both empty")
+	}
+}
+
+func TestValidateCsrfToken_DifferentLength(t *testing.T) {
+	if ValidateCsrfToken("short", "muchlongertoken") {
+		t.Error("should reject different lengths")
+	}
+}
+
+// --- CsrfProtection.Check tests ---
+
+func TestCheck_SafeMethodAllowed(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{})
+	if !csrf.Check("GET", "/", "", "") {
+		t.Error("GET should be allowed without token")
+	}
+	if !csrf.Check("HEAD", "/", "", "") {
+		t.Error("HEAD should be allowed without token")
+	}
+	if !csrf.Check("OPTIONS", "/", "", "") {
+		t.Error("OPTIONS should be allowed without token")
+	}
+}
+
+func TestCheck_ProtectedMethodNeedsToken(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{})
+	if csrf.Check("POST", "/", "", "") {
+		t.Error("POST should be rejected without tokens")
+	}
+	if csrf.Check("PUT", "/", "", "") {
+		t.Error("PUT should be rejected without tokens")
+	}
+	if csrf.Check("PATCH", "/", "", "") {
+		t.Error("PATCH should be rejected without tokens")
+	}
+	if csrf.Check("DELETE", "/", "", "") {
+		t.Error("DELETE should be rejected without tokens")
+	}
+}
+
+func TestCheck_ValidToken(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{})
+	token, _ := GenerateCsrfToken(32)
+	if !csrf.Check("POST", "/", token, token) {
+		t.Error("should allow matching tokens")
+	}
+}
+
+func TestCheck_InvalidToken(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{})
+	t1, _ := GenerateCsrfToken(32)
+	t2, _ := GenerateCsrfToken(32)
+	if csrf.Check("POST", "/", t1, t2) {
+		t.Error("should reject mismatched tokens")
+	}
+}
+
+func TestCheck_ExcludedPath(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{
+		ExcludePaths: []string{"/api/webhooks"},
+	})
+	if !csrf.Check("POST", "/api/webhooks", "", "") {
+		t.Error("excluded exact path should be allowed")
+	}
+	if !csrf.Check("POST", "/api/webhooks/stripe", "", "") {
+		t.Error("excluded subpath should be allowed")
+	}
+	if csrf.Check("POST", "/api/other", "", "") {
+		t.Error("non-excluded path should still need token")
+	}
+}
+
+func TestCheck_MissingCookieToken(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{})
+	if csrf.Check("POST", "/", "", "sometoken") {
+		t.Error("should reject missing cookie token")
+	}
+}
+
+func TestCheck_MissingRequestToken(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{})
+	if csrf.Check("POST", "/", "sometoken", "") {
+		t.Error("should reject missing request token")
+	}
+}
+
+// --- Handler tests ---
+
+func TestHandler_SafeMethodSetsCookie(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{})
+	handler := csrf.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	cookies := rec.Header().Values("Set-Cookie")
+	if len(cookies) == 0 {
+		t.Error("should set CSRF cookie on safe method")
+	}
+	if len(cookies) > 0 && !containsSubstring(cookies[0], "_csrf=") {
+		t.Errorf("cookie should contain _csrf=, got %q", cookies[0])
+	}
+}
+
+func TestHandler_SafeMethodNoDuplicateCookie(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{})
+	handler := csrf.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: "_csrf", Value: "existing-token"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	cookies := rec.Header().Values("Set-Cookie")
+	if len(cookies) > 0 {
+		t.Error("should not set cookie when one already exists")
+	}
+}
+
+func TestHandler_ProtectedMethodNoToken403(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{})
+	handler := csrf.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("POST", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["error"] != "CSRF token validation failed" {
+		t.Errorf("unexpected error message: %q", body["error"])
+	}
+}
+
+func TestHandler_ProtectedMethodValidToken(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{})
+	nextCalled := false
+	handler := csrf.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token, _ := GenerateCsrfToken(32)
+	req := httptest.NewRequest("POST", "/", nil)
+	req.AddCookie(&http.Cookie{Name: "_csrf", Value: token})
+	req.Header.Set("X-Csrf-Token", token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if !nextCalled {
+		t.Error("should call next handler with valid token")
+	}
+}
+
+func TestHandler_ProtectedMethodInvalidToken(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{})
+	handler := csrf.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("POST", "/", nil)
+	req.AddCookie(&http.Cookie{Name: "_csrf", Value: "token-a"})
+	req.Header.Set("X-Csrf-Token", "token-b")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for mismatched tokens, got %d", rec.Code)
+	}
+}
+
+func TestHandler_ExcludedPathSkipsValidation(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{
+		ExcludePaths: []string{"/webhooks"},
+	})
+	nextCalled := false
+	handler := csrf.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("POST", "/webhooks/stripe", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 for excluded path, got %d", rec.Code)
+	}
+	if !nextCalled {
+		t.Error("should call next for excluded path")
+	}
+}
+
+func TestHandler_CustomOnError(t *testing.T) {
+	called := false
+	csrf := NewCsrfProtection(CsrfOptions{
+		OnError: func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusTeapot)
+		},
+	})
+	handler := csrf.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("POST", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("should call custom error handler")
+	}
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("expected custom status, got %d", rec.Code)
+	}
+}
+
+func TestHandler_QueryStringToken(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{})
+	handler := csrf.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token, _ := GenerateCsrfToken(32)
+	req := httptest.NewRequest("POST", "/?_csrf="+token, nil)
+	req.AddCookie(&http.Cookie{Name: "_csrf", Value: token})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 with query token, got %d", rec.Code)
+	}
+}
+
+func TestHandler_CustomCookieName(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{
+		CookieName: "my-csrf",
+		HeaderName: "X-My-Csrf",
+	})
+	handler := csrf.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token, _ := GenerateCsrfToken(32)
+	req := httptest.NewRequest("POST", "/", nil)
+	req.AddCookie(&http.Cookie{Name: "my-csrf", Value: token})
+	req.Header.Set("X-My-Csrf", token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 with custom names, got %d", rec.Code)
+	}
+}
+
+func TestHandler_CookieAttributes(t *testing.T) {
+	csrf := NewCsrfProtection(CsrfOptions{
+		Cookie: CsrfCookieOptions{
+			SameSite: "Strict",
+			Domain:   "example.com",
+		},
+	})
+	handler := csrf.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	cookies := rec.Header().Values("Set-Cookie")
+	if len(cookies) == 0 {
+		t.Fatal("expected Set-Cookie header")
+	}
+	c := cookies[0]
+	if !containsSubstring(c, "SameSite=Strict") {
+		t.Errorf("expected SameSite=Strict in %q", c)
+	}
+	if !containsSubstring(c, "Domain=example.com") {
+		t.Errorf("expected Domain=example.com in %q", c)
+	}
+	if !containsSubstring(c, "Secure") {
+		t.Errorf("expected Secure in %q", c)
+	}
+}
+
+// --- CsrfMiddleware factory test ---
+
+func TestCsrfMiddleware_Factory(t *testing.T) {
+	mw := CsrfMiddleware(CsrfOptions{})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("POST", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("factory middleware should reject POST without token, got %d", rec.Code)
+	}
+}
+
+func containsSubstring(s, substr string) bool {
+	return strings.Contains(s, substr)
+}


### PR DESCRIPTION
## Summary
- **Safe CORS** — whitelist-based origin validation, null blocking, Vary: Origin, preflight handling (33 tests)
- **Secure Cookie Defaults** — enforces HttpOnly, Secure, SameSite=Lax on all Set-Cookie headers via ResponseWriter wrapper (26 tests)
- **CSRF Protection** — double-submit cookie pattern with constant-time comparison, configurable names/paths, crypto-random tokens (19 tests)

All 3 features include net/http middleware + Gin and Echo adapters + root `arcis.go` re-exports.

**Go SDK now covers all 42 Tier 1 security flaws — full parity with Node.js and Python.**

## Test plan
- [x] 33 CORS tests pass (origin types, null blocking, preflight, credentials, handler)
- [x] 26 cookie tests pass (HttpOnly, Secure, SameSite, path override, middleware interception)
- [x] 19 CSRF tests pass (token generation, validation, handler flow, excluded paths, custom error)
- [x] All existing middleware tests still pass (rate limit, error handler, security headers)
- [ ] Verify gin/echo adapters compile with `go test ./gin/ ./echo/`