### PR TITLE
docs: update attack vector count and test counts for v1.4.0

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Deploy Website
+
+on:
+  push:
+    branches: [main]
+    paths: [website/**]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: website
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/arcis.svg)](https://pypi.org/project/arcis/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/Gagancm/arcis/actions/workflows/ci.yml/badge.svg?branch=nwl)](https://github.com/Gagancm/arcis/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-2800%2B-brightgreen.svg)](https://github.com/Gagancm/arcis)
+[![Tests](https://img.shields.io/badge/tests-2795%2B-brightgreen.svg)](https://github.com/Gagancm/arcis)
 
 Arcis is a unified, zero-dependency security middleware for Node.js, Python, and Go. <br />
 One line of code protects your application against 45+ security flaws at runtime — XSS, SQL injection, SSRF, CSRF, HPP, and more.
@@ -24,7 +24,7 @@ One line of code protects your application against 45+ security flaws at runtime
 
 ## What is Arcis?
 
-Arcis is a security middleware library that protects web applications against 42+ security flaws at runtime. It works with **Node.js**, **Python**, and **Go** — the three most popular backend languages — with a consistent API across all three.
+Arcis is a security middleware library that protects web applications against 45+ security flaws at runtime. It works with **Node.js**, **Python**, and **Go** — the three most popular backend languages — with a consistent API across all three.
 
 Arcis sits between incoming requests and your application code. It sanitizes input, detects attack patterns, enforces rate limits, sets security headers, and blocks malicious traffic — all before your code ever sees the request. Only proven, pattern-matched threats are blocked. Safe input passes through untouched.
 
@@ -56,7 +56,7 @@ At the checkpoint, Arcis:
 ## Features
 
 - **One-Line Setup**: A single `app.use(arcis())` activates all protections. Sanitization, rate limiting, security headers, CSRF, bot detection, and CORS — all on by default.
-- **42+ Security Flaws Handled**: Covers XSS, SQL/NoSQL injection, command injection, path traversal, SSTI, XXE, SSRF, CSRF, prototype pollution, header injection, open redirect, and more.
+- **45+ Security Flaws Handled**: Covers XSS, SQL/NoSQL injection, command injection, path traversal, SSTI, XXE, SSRF, CSRF, HPP, prototype pollution, header injection, open redirect, and more.
 - **Zero Dependencies**: Arcis is entirely self-contained. No transitive dependencies, no supply chain risk.
 - **Three-Language Parity**: Same API, same behavior, same test results across Node.js, Python, and Go. Enforced by shared test vectors.
 - **Framework-Agnostic Core**: Core functions (sanitizers, validators, encoders) work with plain strings and objects — no framework lock-in. Built-in adapters for Express, FastAPI, Flask, Django, Gin, and Echo.
@@ -394,10 +394,10 @@ All SDKs are tested against a shared set of test vectors (`TEST_VECTORS.json`) t
 
 | SDK | Tests | Framework | Status |
 |-----|-------|-----------|--------|
-| Node.js | 1,193 | vitest | All passing |
-| Python | 995 | pytest | All passing |
+| Node.js | 1,264 | vitest | All passing |
+| Python | 1,011 | pytest | All passing |
 | Go | 520 | go test -race | All passing |
-| **Total** | **2,708** | | |
+| **Total** | **2,795** | | |
 
 ---
 
@@ -445,7 +445,7 @@ The attack is removed. The safe text passes through. No one gets hacked.
 
 ### Completed (v1.0 — v1.2)
 
-- 42+ security flaw coverage (runtime + detection)
+- 45+ security flaw coverage (runtime + detection)
 - 3 SDKs (Node.js, Python, Go) at full parity
 - 7 framework adapters (Express, FastAPI, Flask, Django, Gin, Echo, net/http)
 - 3 rate limiting algorithms (fixed, sliding, token bucket)

--- a/packages/arcis-node/README.md
+++ b/packages/arcis-node/README.md
@@ -8,7 +8,7 @@
 
 Part of the [Arcis](https://github.com/Gagancm/arcis) ecosystem with implementations for Node.js, Python, and Go.
 
-**17 attack vectors handled. 970+ tests. Zero dependencies.**
+**20 attack vectors handled. 1,264+ tests. Zero dependencies.**
 
 ## Installation
 

--- a/packages/arcis-node/README.md
+++ b/packages/arcis-node/README.md
@@ -8,7 +8,7 @@
 
 Part of the [Arcis](https://github.com/Gagancm/arcis) ecosystem with implementations for Node.js, Python, and Go.
 
-**20 attack vectors handled. 1,264+ tests. Zero dependencies.**
+**45+ security flaws covered. 1,264+ tests. Zero dependencies.**
 
 ## Installation
 

--- a/website/index.html
+++ b/website/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Arcis — Security Middleware for Every Backend</title>
-  <meta name="description" content="One line of code protects your app against 42+ security flaws. Zero dependencies. Works with Node.js, Python, and Go.">
+  <meta name="description" content="One line of code protects your app against 45+ security flaws. Zero dependencies. Works with Node.js, Python, and Go.">
   <meta property="og:title" content="Arcis — Security Middleware for Every Backend">
-  <meta property="og:description" content="One line of code. 42+ security flaws handled. Zero dependencies. Node.js, Python, Go.">
+  <meta property="og:description" content="One line of code. 45+ security flaws handled. Zero dependencies. Node.js, Python, Go.">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -1095,13 +1095,13 @@
     <div class="container">
       <div class="hero-badge">
         <span class="dot"></span>
-        v1.3.0 — SCA scanner, context-aware encoding, 15 security headers
+        v1.4.0 — HPP protection, CSRF hardening, 14 audit rules
       </div>
 
       <h1>Security middleware that <em>just works</em></h1>
 
       <p class="hero-sub">
-        One line of code. 42+ security flaws neutralized at runtime. Zero dependencies. Zero configuration. Node.js, Python, and Go.
+        One line of code. 45+ security flaws neutralized at runtime. Zero dependencies. Zero configuration. Node.js, Python, and Go.
       </p>
 
       <div class="hero-actions">
@@ -1125,7 +1125,7 @@
           </div>
           <div class="code-body">
             <span class="keyword">import</span> <span class="punctuation">{</span> <span class="function">arcis</span> <span class="punctuation">}</span> <span class="keyword">from</span> <span class="string">'@arcis/node'</span><span class="punctuation">;</span><br><br>
-            <span class="comment">// That's it. 42+ security flaws handled.</span><br>
+            <span class="comment">// That's it. 45+ security flaws handled.</span><br>
             app.<span class="function">use</span><span class="punctuation">(</span><span class="function">arcis</span><span class="punctuation">());</span>
           </div>
         </div>
@@ -1166,7 +1166,7 @@
     <div class="container">
       <div class="stats-grid">
         <div class="stat reveal">
-          <div class="stat-number"><span class="accent-red">42+</span></div>
+          <div class="stat-number"><span class="accent-red">45+</span></div>
           <div class="stat-label">Security Flaws Handled</div>
         </div>
         <div class="stat reveal reveal-delay-1">
@@ -1174,7 +1174,7 @@
           <div class="stat-label">SDKs &mdash; Node, Python, Go</div>
         </div>
         <div class="stat reveal reveal-delay-2">
-          <div class="stat-number">2,800+</div>
+          <div class="stat-number">2,795+</div>
           <div class="stat-label">Tests Passing</div>
         </div>
         <div class="stat reveal reveal-delay-3">
@@ -1311,7 +1311,7 @@
           <ul>
             <li>One package: <code>@arcis/node</code></li>
             <li>One line: <code>app.use(arcis())</code></li>
-            <li>42+ flaws covered instantly</li>
+            <li>45+ flaws covered instantly</li>
             <li>Zero dependencies to audit</li>
             <li>Same API across 3 languages</li>
             <li>Secure defaults, no config needed</li>
@@ -1410,7 +1410,7 @@
           <ul class="feature-detail">
             <li><code>arcis sca</code> &mdash; supply chain attack scanner</li>
             <li><code>arcis scan</code> &mdash; vulnerability scanner</li>
-            <li><code>arcis audit</code> &mdash; static analysis (11 rules)</li>
+            <li><code>arcis audit</code> &mdash; static analysis (14 rules)</li>
             <li>CI-friendly exit codes</li>
           </ul>
         </div>
@@ -1448,15 +1448,15 @@
           <div class="pipeline-num">3</div>
           <div class="pipeline-content">
             <h3>Input Sanitization</h3>
-            <p>Strip XSS, SQL injection, NoSQL, command injection, path traversal, SSTI, XXE, JSONP, header injection, prototype pollution.</p>
-            <span class="pipeline-tag">10 attack vectors neutralized</span>
+            <p>Strip XSS, SQL injection, NoSQL, command injection, path traversal, SSTI, XXE, JSONP, header injection, prototype pollution, HTTP parameter pollution.</p>
+            <span class="pipeline-tag">11 attack vectors neutralized</span>
           </div>
         </div>
         <div class="pipeline-step reveal reveal-delay-3" data-step="3">
           <div class="pipeline-num">4</div>
           <div class="pipeline-content">
             <h3>CSRF Verification</h3>
-            <p>Double-submit cookie pattern with constant-time token comparison. Prevents timing side-channel attacks.</p>
+            <p>Double-submit cookie pattern with constant-time token comparison. Per-request <code>skipCsrf</code> callback and <code>__Host-</code> cookie prefix support.</p>
             <span class="pipeline-tag">403 CSRF Token Invalid</span>
           </div>
         </div>
@@ -1508,7 +1508,7 @@
               <span class="keyword">import</span> <span class="punctuation">{</span> <span class="function">arcis</span> <span class="punctuation">}</span> <span class="keyword">from</span> <span class="string">'@arcis/node'</span><span class="punctuation">;</span><br>
               <span class="keyword">import</span> express <span class="keyword">from</span> <span class="string">'express'</span><span class="punctuation">;</span><br><br>
               <span class="keyword">const</span> app = <span class="function">express</span><span class="punctuation">();</span><br>
-              app.<span class="function">use</span><span class="punctuation">(</span><span class="function">arcis</span><span class="punctuation">());</span> <span class="comment">// All 42+ protections active</span><br><br>
+              app.<span class="function">use</span><span class="punctuation">(</span><span class="function">arcis</span><span class="punctuation">());</span> <span class="comment">// All 45+ protections active</span><br><br>
               app.<span class="function">get</span><span class="punctuation">(</span><span class="string">'/'</span><span class="punctuation">,</span> <span class="punctuation">(</span>req<span class="punctuation">,</span> res<span class="punctuation">)</span> <span class="keyword">=></span> <span class="punctuation">{</span><br>
               &nbsp;&nbsp;<span class="comment">// req.query and req.body are already sanitized</span><br>
               &nbsp;&nbsp;res.<span class="function">json</span><span class="punctuation">({</span> message<span class="punctuation">:</span> <span class="string">'Safe and sound.'</span> <span class="punctuation">});</span><br>
@@ -1529,7 +1529,7 @@
               <span class="keyword">from</span> fastapi <span class="keyword">import</span> FastAPI<br>
               <span class="keyword">from</span> arcis <span class="keyword">import</span> ArcisMiddleware<br><br>
               app = <span class="function">FastAPI</span><span class="punctuation">()</span><br>
-              app.<span class="function">add_middleware</span><span class="punctuation">(</span>ArcisMiddleware<span class="punctuation">)</span> <span class="comment"># All 42+ protections active</span><br><br>
+              app.<span class="function">add_middleware</span><span class="punctuation">(</span>ArcisMiddleware<span class="punctuation">)</span> <span class="comment"># All 45+ protections active</span><br><br>
               <span class="keyword">@</span>app.<span class="function">get</span><span class="punctuation">(</span><span class="string">"/"</span><span class="punctuation">)</span><br>
               <span class="keyword">def</span> <span class="function">root</span><span class="punctuation">():</span><br>
               &nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Input already sanitized and validated</span><br>
@@ -1554,7 +1554,7 @@
               <span class="punctuation">)</span><br><br>
               <span class="keyword">func</span> <span class="function">main</span><span class="punctuation">()</span> <span class="punctuation">{</span><br>
               &nbsp;&nbsp;&nbsp;&nbsp;r <span class="punctuation">:=</span> gin.<span class="function">Default</span><span class="punctuation">()</span><br>
-              &nbsp;&nbsp;&nbsp;&nbsp;r.<span class="function">Use</span><span class="punctuation">(</span>arcisgin.<span class="function">Middleware</span><span class="punctuation">())</span> <span class="comment">// All 42+ protections active</span><br>
+              &nbsp;&nbsp;&nbsp;&nbsp;r.<span class="function">Use</span><span class="punctuation">(</span>arcisgin.<span class="function">Middleware</span><span class="punctuation">())</span> <span class="comment">// All 45+ protections active</span><br>
               &nbsp;&nbsp;&nbsp;&nbsp;r.<span class="function">Run</span><span class="punctuation">()</span><br>
               <span class="punctuation">}</span>
             </div>
@@ -1568,7 +1568,7 @@
   <section class="section" id="threats">
     <div class="container">
       <div class="section-label reveal">Protection</div>
-      <h2 class="section-title reveal">42+ security flaws. One package.</h2>
+      <h2 class="section-title reveal">45+ security flaws. One package.</h2>
       <p class="section-desc reveal" style="max-width: 700px;">
         Covers OWASP Top 10 and beyond. From injection attacks to response hardening &mdash; if it can hurt your app, Arcis handles it.
       </p>
@@ -1590,6 +1590,10 @@
         <div class="threat-item reveal"><div class="threat-name">Open Redirect</div><div class="threat-desc">Absolute URLs, javascript:, protocol-relative, backslash</div></div>
         <div class="threat-item reveal"><div class="threat-name">Error Leakage</div><div class="threat-desc">Stack traces, DB errors, internal IPs, connection strings</div></div>
         <div class="threat-item reveal"><div class="threat-name">Header Injection</div><div class="threat-desc">CRLF injection, response splitting, null bytes stripped</div></div>
+        <div class="threat-item reveal"><div class="threat-name">HTTP Parameter Pollution</div><div class="threat-desc">Duplicate query/body params normalized, last-value-wins, per-param whitelist</div></div>
+        <div class="threat-item reveal"><div class="threat-name">CSRF Hardening</div><div class="threat-desc">Per-request skipCsrf callback, __Host- cookie prefix enforcement</div></div>
+        <div class="threat-item reveal"><div class="threat-name">Unsafe Deserialization</div><div class="threat-desc">Static analysis detects pickle.loads, eval, unsafe YAML in audit rules</div></div>
+        <div class="threat-item reveal"><div class="threat-name">SSRF via Code</div><div class="threat-desc">Audit detects user-controlled URLs passed to fetch/requests/http.Get</div></div>
       </div>
     </div>
   </section>
@@ -1723,7 +1727,7 @@
       <div class="footer-inner">
         <div class="footer-brand">
           <div class="footer-logo">Arcis<span>.</span></div>
-          <p class="footer-tagline">Security middleware for every backend. One line of code, 42+ flaws handled, zero dependencies.</p>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 45+ flaws handled, zero dependencies.</p>
           <div class="footer-badges">
             <span class="footer-badge">
               <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>


### PR DESCRIPTION
## Summary

- Fixes outdated numbers on npm and PyPI package pages
- `packages/arcis-node/README.md`: 17 attack vectors → 20, 970+ tests → 1,264+
- `README.md`: all `42+` references → `45+`, test counts updated to reflect v1.4.0

## Updated counts

| SDK | Old | New |
|-----|-----|-----|
| Node.js tests | 1,193 | 1,264 |
| Python tests | 995 | 1,011 |
| Go tests | 520 | 520 |
| **Total** | **2,708** | **2,795** |
| Attack vectors | 17 | 20 |
| Security flaws | 42+ | 45+ |