### PR TITLE
ci: deploy website from nwl instead of main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,8 +2,9 @@ name: Deploy Website
 
 on:
   push:
-    branches: [main]
+    branches: [nwl]
     paths: [website/**]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Change the website deploy workflow to trigger on push to \`nwl\` instead of \`main\`.

## Why

Website changes don't need to wait for a release PR from nwl to main. Treating the website like the packages (main-only) adds a pointless step every time we update docs or marketing.

## Changes

- \`pages.yml\` trigger changed from \`branches: [main]\` to \`branches: [nwl]\`
- Added \`workflow_dispatch\` so the deploy can be triggered manually from the Actions UI when needed

## Effect

- Merging website changes to \`nwl\` now auto-deploys to GitHub Pages
- No more \`nwl\` → \`main\` PR needed just for website
- Package publish flow is unchanged — still main-only via \`publish.yml\`

## Post-merge reminder

If the github-pages environment has branch protection set to 'main' only, update it:
Settings → Environments → github-pages → Deployment branches → add \`nwl\` or set 'No restriction'.

## Cleanup

PR #92 (nwl → main) can be closed once this lands — no longer needed for the website deploy.