### PR TITLE
fix: close all remaining audit findings (M1-M10 + L1-L7) + signup protection

### DIFF
--- a/packages/arcis-go/arcis.go
+++ b/packages/arcis-go/arcis.go
@@ -329,6 +329,22 @@ var DetectBot = middleware.DetectBot
 // BotProtection creates an http.Handler middleware for bot detection.
 var BotProtection = middleware.BotProtection
 
+// ─── Tier 2: Signup Protection ──────────────────────────────────────────────
+
+// NewSignupProtection creates a composite signup-form protector combining
+// email validation, bot detection, and a dedicated per-IP rate limit.
+var NewSignupProtection = middleware.NewSignupProtection
+
+// DefaultSignupProtectionOptions returns options with every check enabled.
+var DefaultSignupProtectionOptions = middleware.DefaultSignupProtectionOptions
+
+type (
+	SignupProtection        = middleware.SignupProtection
+	SignupProtectionOptions = middleware.SignupProtectionOptions
+	SignupCheckResult       = middleware.SignupCheckResult
+	SignupBlockReason       = middleware.SignupBlockReason
+)
+
 // ─── Tier 2: PII Scanning/Redaction ─────────────────────────────────────────
 
 // ScanPii finds all PII occurrences in a string.

--- a/packages/arcis-go/middleware/cors.go
+++ b/packages/arcis-go/middleware/cors.go
@@ -110,6 +110,13 @@ func isOriginAllowed(requestOrigin string, allowed CorsOrigin) bool {
 		}
 		return false
 	case *regexp.Regexp:
+		// SECURITY: Go's regexp package uses RE2 (linear time, no catastrophic
+		// backtracking) so user-provided regex cannot cause ReDoS. We still cap
+		// input length defensively — an Origin header longer than 2048 chars is
+		// malformed or an abuse attempt.
+		if len(requestOrigin) > 2048 {
+			return false
+		}
 		return v.MatchString(requestOrigin)
 	case func(string) bool:
 		return v(requestOrigin)

--- a/packages/arcis-go/middleware/cors_redos_cap_test.go
+++ b/packages/arcis-go/middleware/cors_redos_cap_test.go
@@ -1,0 +1,24 @@
+package middleware
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// M6 — Regexp origin check caps input length defensively.
+// Go's RE2 engine is linear-time so there's no real ReDoS, but
+// oversized Origin headers must still be rejected fast.
+func TestAuditM6_RegexpOriginLengthCap(t *testing.T) {
+	re := regexp.MustCompile(`^https://.*\.example\.com$`)
+
+	overlong := "https://" + strings.Repeat("a", 4000) + ".example.com"
+	if isOriginAllowed(overlong, re) {
+		t.Errorf("expected overlong origin (>2048) to be rejected, got allowed")
+	}
+
+	normal := "https://api.example.com"
+	if !isOriginAllowed(normal, re) {
+		t.Errorf("expected normal origin to be allowed")
+	}
+}

--- a/packages/arcis-go/middleware/hpp.go
+++ b/packages/arcis-go/middleware/hpp.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,6 +18,12 @@ type HppOptions struct {
 
 	// DisableFormCheck disables form body normalization (default: enabled).
 	DisableFormCheck bool
+
+	// OnParseError is invoked when ParseForm fails. Default: log to stderr via
+	// the standard logger. Set to a no-op func to silence. The middleware then
+	// still skips form normalization for that request (we can't normalize what
+	// we couldn't parse), but the operator is at least told about it.
+	OnParseError func(r *http.Request, err error)
 }
 
 // HppMiddleware normalizes duplicate query and form parameters to their last
@@ -69,7 +76,13 @@ func HppMiddleware(opts HppOptions) func(http.Handler) http.Handler {
 						strings.Contains(contentType, "multipart/form-data")
 
 					if isForm {
-						if err := r.ParseForm(); err == nil {
+						if err := r.ParseForm(); err != nil {
+							if opts.OnParseError != nil {
+								opts.OnParseError(r, err)
+							} else {
+								log.Printf("[arcis] hpp: ParseForm failed, skipping form normalization: %v", err)
+							}
+						} else {
 							for key, values := range r.PostForm {
 								if len(values) > 1 && !whitelist[key] {
 									last := values[len(values)-1]

--- a/packages/arcis-go/middleware/signup_protection.go
+++ b/packages/arcis-go/middleware/signup_protection.go
@@ -1,0 +1,169 @@
+package middleware
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/GagancM/arcis/validation"
+)
+
+// SignupBlockReason is one of the documented reasons a signup is rejected.
+type SignupBlockReason string
+
+const (
+	SignupReasonOK              SignupBlockReason = "ok"
+	SignupReasonMissingEmail    SignupBlockReason = "missing_email"
+	SignupReasonInvalidEmail    SignupBlockReason = "invalid_email"
+	SignupReasonDisposableEmail SignupBlockReason = "disposable_email"
+	SignupReasonBot             SignupBlockReason = "bot"
+	SignupReasonRateLimited     SignupBlockReason = "rate_limited"
+)
+
+// SignupCheckResult is the verdict from SignupProtection.Check.
+type SignupCheckResult struct {
+	Allowed bool
+	Reason  SignupBlockReason
+	Details map[string]interface{}
+}
+
+// SignupProtectionOptions configures SignupProtection.
+//
+// Mirrors the Node.js `signupProtection()` API: combines email validation,
+// bot detection, and a dedicated per-IP rate limit into one call. Fully
+// local — no cloud lookups.
+type SignupProtectionOptions struct {
+	// CheckEmail runs email syntax + disposable validation. Default: true.
+	CheckEmail bool
+	// BlockDisposable rejects disposable mail domains. Default: true.
+	BlockDisposable bool
+	// CheckBot runs bot detection on User-Agent + behavioral headers. Default: true.
+	CheckBot bool
+	// AllowedBotCategories lets specific bot classes through (e.g. SEARCH_ENGINE).
+	AllowedBotCategories []BotCategory
+	// AllowedEmailDomains bypasses disposable check for these domains.
+	AllowedEmailDomains []string
+	// BlockedEmailDomains always rejects these domains.
+	BlockedEmailDomains []string
+	// RateLimitMax — set to 0 to disable rate limiting. Default: 5.
+	RateLimitMax int
+	// RateLimitWindow. Default: 60s.
+	RateLimitWindow time.Duration
+	// OnBlocked is invoked on every rejection (for telemetry/logging).
+	OnBlocked func(r *http.Request, result SignupCheckResult)
+}
+
+// SignupProtection bundles bot, email, and rate-limit checks for signup endpoints.
+type SignupProtection struct {
+	opts    SignupProtectionOptions
+	limiter *RateLimiter
+}
+
+// DefaultSignupProtectionOptions returns options with every check enabled
+// and sensible rate-limit defaults (5 requests per 60 seconds).
+func DefaultSignupProtectionOptions() SignupProtectionOptions {
+	return SignupProtectionOptions{
+		CheckEmail:      true,
+		BlockDisposable: true,
+		CheckBot:        true,
+		RateLimitMax:    5,
+		RateLimitWindow: 60 * time.Second,
+	}
+}
+
+// NewSignupProtection builds a SignupProtection with the given options.
+// Zero values in the options struct are replaced with defaults.
+func NewSignupProtection(opts SignupProtectionOptions) *SignupProtection {
+	// Apply defaults for zero-values that should NOT be interpreted as
+	// "user asked to disable this check". Use explicit helpers if you want
+	// to disable individual checks.
+	if opts.RateLimitWindow == 0 {
+		opts.RateLimitWindow = 60 * time.Second
+	}
+	if opts.RateLimitMax == 0 {
+		opts.RateLimitMax = 5
+	}
+
+	sp := &SignupProtection{opts: opts}
+	if opts.RateLimitMax > 0 {
+		sp.limiter = NewRateLimiter(opts.RateLimitMax, opts.RateLimitWindow)
+	}
+	return sp
+}
+
+// Check runs all configured checks against the request and email.
+// The caller extracts `email` from the request body (framework-specific).
+func (sp *SignupProtection) Check(r *http.Request, email string) SignupCheckResult {
+	if sp.opts.CheckBot {
+		bot := DetectBot(r)
+		if bot.IsBot && !containsCategory(sp.opts.AllowedBotCategories, bot.Category) {
+			return sp.block(r, SignupCheckResult{
+				Reason: SignupReasonBot,
+				Details: map[string]interface{}{
+					"category":   string(bot.Category),
+					"name":       bot.Name,
+					"confidence": bot.Confidence,
+				},
+			})
+		}
+	}
+
+	if sp.opts.CheckEmail {
+		if email == "" {
+			return sp.block(r, SignupCheckResult{Reason: SignupReasonMissingEmail})
+		}
+		emailOpts := &validation.EmailValidationOptions{
+			CheckDisposable: sp.opts.BlockDisposable,
+			AllowedDomains:  sp.opts.AllowedEmailDomains,
+			BlockedDomains:  sp.opts.BlockedEmailDomains,
+		}
+		v := validation.ValidateEmail(email, emailOpts)
+		if !v.Valid {
+			reason := SignupReasonInvalidEmail
+			if v.Reason == "disposable" {
+				reason = SignupReasonDisposableEmail
+			}
+			return sp.block(r, SignupCheckResult{
+				Reason:  reason,
+				Details: map[string]interface{}{"emailReason": v.Reason},
+			})
+		}
+	}
+
+	if sp.limiter != nil {
+		rl := sp.limiter.Check(r)
+		if !rl.Allowed {
+			return sp.block(r, SignupCheckResult{
+				Reason: SignupReasonRateLimited,
+				Details: map[string]interface{}{
+					"retryAfter": rl.Reset.Seconds(),
+				},
+			})
+		}
+	}
+
+	return SignupCheckResult{Allowed: true, Reason: SignupReasonOK}
+}
+
+// Close releases the rate-limiter's cleanup goroutine.
+func (sp *SignupProtection) Close() {
+	if sp.limiter != nil {
+		sp.limiter.Close()
+	}
+}
+
+func (sp *SignupProtection) block(r *http.Request, res SignupCheckResult) SignupCheckResult {
+	res.Allowed = false
+	if sp.opts.OnBlocked != nil {
+		sp.opts.OnBlocked(r, res)
+	}
+	return res
+}
+
+func containsCategory(list []BotCategory, c BotCategory) bool {
+	for _, x := range list {
+		if x == c {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/arcis-go/middleware/signup_protection_test.go
+++ b/packages/arcis-go/middleware/signup_protection_test.go
@@ -1,0 +1,145 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// browserReq returns a request with a typical human-browser header set so
+// DetectBot does not flag it on missing-header heuristics.
+func browserReq(ua string) *http.Request {
+	if ua == "" {
+		ua = "Mozilla/5.0 (Windows NT 10.0) Chrome/120.0.0.0"
+	}
+	req := httptest.NewRequest("POST", "/signup", nil)
+	req.Header.Set("User-Agent", ua)
+	req.Header.Set("Accept", "text/html")
+	req.Header.Set("Accept-Language", "en-US")
+	req.Header.Set("Accept-Encoding", "gzip")
+	req.RemoteAddr = "1.2.3.4:1234"
+	return req
+}
+
+func TestSignupProtection_AllowsValidHumanSignup(t *testing.T) {
+	sp := NewSignupProtection(DefaultSignupProtectionOptions())
+	defer sp.Close()
+
+	res := sp.Check(browserReq(""), "alice@gmail.com")
+	if !res.Allowed {
+		t.Errorf("expected allowed, got reason=%s", res.Reason)
+	}
+}
+
+func TestSignupProtection_BlocksMissingEmail(t *testing.T) {
+	sp := NewSignupProtection(DefaultSignupProtectionOptions())
+	defer sp.Close()
+
+	res := sp.Check(browserReq(""), "")
+	if res.Allowed || res.Reason != SignupReasonMissingEmail {
+		t.Errorf("expected missing_email, got allowed=%v reason=%s", res.Allowed, res.Reason)
+	}
+}
+
+func TestSignupProtection_BlocksInvalidSyntax(t *testing.T) {
+	sp := NewSignupProtection(DefaultSignupProtectionOptions())
+	defer sp.Close()
+
+	res := sp.Check(browserReq(""), "not-an-email")
+	if res.Allowed || res.Reason != SignupReasonInvalidEmail {
+		t.Errorf("expected invalid_email, got allowed=%v reason=%s", res.Allowed, res.Reason)
+	}
+}
+
+func TestSignupProtection_BlocksDisposable(t *testing.T) {
+	sp := NewSignupProtection(DefaultSignupProtectionOptions())
+	defer sp.Close()
+
+	res := sp.Check(browserReq(""), "throwaway@mailinator.com")
+	if res.Allowed || res.Reason != SignupReasonDisposableEmail {
+		t.Errorf("expected disposable_email, got allowed=%v reason=%s", res.Allowed, res.Reason)
+	}
+}
+
+func TestSignupProtection_BlocksAutomatedBot(t *testing.T) {
+	sp := NewSignupProtection(DefaultSignupProtectionOptions())
+	defer sp.Close()
+
+	res := sp.Check(browserReq("curl/8.0"), "alice@gmail.com")
+	if res.Allowed || res.Reason != SignupReasonBot {
+		t.Errorf("expected bot, got allowed=%v reason=%s", res.Allowed, res.Reason)
+	}
+}
+
+func TestSignupProtection_AllowedBotCategoriesLetsThrough(t *testing.T) {
+	opts := DefaultSignupProtectionOptions()
+	opts.AllowedBotCategories = []BotCategory{BotCategorySearchEngine}
+	sp := NewSignupProtection(opts)
+	defer sp.Close()
+
+	req := browserReq("Mozilla/5.0 (compatible; Googlebot/2.1)")
+	res := sp.Check(req, "alice@gmail.com")
+	if !res.Allowed {
+		t.Errorf("expected Googlebot to be allowed by whitelist, got reason=%s", res.Reason)
+	}
+}
+
+func TestSignupProtection_RateLimitsRepeatedSignups(t *testing.T) {
+	opts := DefaultSignupProtectionOptions()
+	opts.RateLimitMax = 2
+	opts.RateLimitWindow = time.Minute
+	sp := NewSignupProtection(opts)
+	defer sp.Close()
+
+	allowed := 0
+	rateLimited := false
+	for i := 0; i < 4; i++ {
+		res := sp.Check(browserReq(""), "alice@gmail.com")
+		if res.Allowed {
+			allowed++
+		} else if res.Reason == SignupReasonRateLimited {
+			rateLimited = true
+		}
+	}
+	if allowed != 2 {
+		t.Errorf("expected exactly 2 allowed, got %d", allowed)
+	}
+	if !rateLimited {
+		t.Error("expected at least one rate_limited rejection")
+	}
+}
+
+func TestSignupProtection_OnBlockedFires(t *testing.T) {
+	var reasons []SignupBlockReason
+	opts := DefaultSignupProtectionOptions()
+	opts.RateLimitMax = 0 // disable rate limit path
+	opts.OnBlocked = func(r *http.Request, res SignupCheckResult) {
+		reasons = append(reasons, res.Reason)
+	}
+	sp := NewSignupProtection(opts)
+	defer sp.Close()
+
+	sp.Check(browserReq(""), "bad")
+	if len(reasons) != 1 || reasons[0] != SignupReasonInvalidEmail {
+		t.Errorf("expected [invalid_email], got %v", reasons)
+	}
+}
+
+func TestSignupProtection_AllowedDomainBypassesDisposable(t *testing.T) {
+	opts := DefaultSignupProtectionOptions()
+	opts.AllowedEmailDomains = []string{"mailinator.com"}
+	sp := NewSignupProtection(opts)
+	defer sp.Close()
+
+	res := sp.Check(browserReq(""), "ci@mailinator.com")
+	if !res.Allowed {
+		t.Errorf("expected allow via whitelist, got reason=%s", res.Reason)
+	}
+}
+
+func TestSignupProtection_CloseIsIdempotent(t *testing.T) {
+	sp := NewSignupProtection(DefaultSignupProtectionOptions())
+	sp.Close()
+	sp.Close() // must not panic
+}

--- a/packages/arcis-go/sanitizers/audit_medium_fixes_test.go
+++ b/packages/arcis-go/sanitizers/audit_medium_fixes_test.go
@@ -1,0 +1,57 @@
+package sanitizers
+
+import (
+	"strings"
+	"testing"
+)
+
+// M1 — SSTI operator-free dunder patterns.
+func TestAuditM1_SSTIDunderPatterns(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		notContains string
+	}{
+		{"jinja dunder dict", "hello ${self.__dict__} world", "__dict__"},
+		{"pug dunder class", "#{obj.__class__}", "__class__"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := SanitizeSSTI(tt.input)
+			if strings.Contains(out, tt.notContains) {
+				t.Errorf("expected %q to be removed from %q, got %q", tt.notContains, tt.input, out)
+			}
+		})
+	}
+}
+
+// M2 — XSS <style> tag removal.
+func TestAuditM2_XSSStyleTagRemoval(t *testing.T) {
+	tests := []string{
+		"<style>body { x: expression(alert(1)) }</style>",
+		`<style type="text/css">`,
+	}
+	for _, in := range tests {
+		out := strings.ToLower(SanitizeXSS(in))
+		if strings.Contains(out, "<style") {
+			t.Errorf("expected <style to be stripped from %q, got %q", in, out)
+		}
+	}
+}
+
+// M10 — Null byte injection patterns in path sanitization.
+func TestAuditM10_NullByteInPath(t *testing.T) {
+	tests := []string{
+		"../etc/passwd%00.jpg",
+		"file.txt\x00.png",
+	}
+	for _, in := range tests {
+		out := SanitizePath(in)
+		if strings.Contains(strings.ToLower(out), "%00") {
+			t.Errorf("expected %%00 stripped from %q, got %q", in, out)
+		}
+		if strings.Contains(out, "\x00") {
+			t.Errorf("expected literal NUL stripped from %q, got %q", in, out)
+		}
+	}
+}

--- a/packages/arcis-go/sanitizers/conformance_test.go
+++ b/packages/arcis-go/sanitizers/conformance_test.go
@@ -1,0 +1,108 @@
+package sanitizers
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Cross-SDK conformance: load spec/TEST_VECTORS.json and verify the Go
+// implementation produces output matching the spec's expected_behavior.
+//
+// Only a handful of unambiguously-describable behaviors are checked here.
+// Many vectors describe "must not contain X" constraints that translate
+// directly to Go assertions; ambiguous or SDK-specific ones are skipped.
+
+type vector struct {
+	Input            string `json:"input"`
+	ExpectedBehavior string `json:"expected_behavior"`
+	ExpectedContains string `json:"expected_contains,omitempty"`
+}
+
+type sanitizeStringVectors struct {
+	XSS []vector `json:"xss"`
+	SQL []vector `json:"sql"`
+}
+
+type testVectorsDoc struct {
+	SanitizeString sanitizeStringVectors `json:"sanitize_string"`
+}
+
+func loadVectors(t *testing.T) testVectorsDoc {
+	t.Helper()
+	// Walk up from CWD to find spec/TEST_VECTORS.json.
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 6; i++ {
+		candidate := filepath.Join(dir, "spec", "TEST_VECTORS.json")
+		if _, err := os.Stat(candidate); err == nil {
+			data, err := os.ReadFile(candidate)
+			if err != nil {
+				t.Fatalf("read vectors: %v", err)
+			}
+			var doc testVectorsDoc
+			if err := json.Unmarshal(data, &doc); err != nil {
+				t.Fatalf("parse vectors: %v", err)
+			}
+			return doc
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Skip("spec/TEST_VECTORS.json not found (run from repo checkout)")
+	return testVectorsDoc{}
+}
+
+// forbiddenSubstring derives a "must not contain X" token from expected_behavior.
+// Returns ("", false) when the vector is not of that form.
+func forbiddenSubstring(behavior string) (string, bool) {
+	b := strings.ToLower(behavior)
+	marker := "must not contain '"
+	idx := strings.Index(b, marker)
+	if idx < 0 {
+		return "", false
+	}
+	rest := behavior[idx+len(marker):]
+	end := strings.Index(rest, "'")
+	if end < 0 {
+		return "", false
+	}
+	return rest[:end], true
+}
+
+func TestConformance_SanitizeString_XSS(t *testing.T) {
+	doc := loadVectors(t)
+	for i, v := range doc.SanitizeString.XSS {
+		forbidden, ok := forbiddenSubstring(v.ExpectedBehavior)
+		if !ok {
+			continue
+		}
+		got := SanitizeString(v.Input)
+		if strings.Contains(strings.ToLower(got), strings.ToLower(forbidden)) {
+			t.Errorf("xss vector %d (input=%q): output %q still contains forbidden %q",
+				i, v.Input, got, forbidden)
+		}
+	}
+}
+
+func TestConformance_SanitizeString_SQL(t *testing.T) {
+	doc := loadVectors(t)
+	for i, v := range doc.SanitizeString.SQL {
+		forbidden, ok := forbiddenSubstring(v.ExpectedBehavior)
+		if !ok {
+			continue
+		}
+		got := SanitizeString(v.Input)
+		if strings.Contains(strings.ToLower(got), strings.ToLower(forbidden)) {
+			t.Errorf("sql vector %d (input=%q): output %q still contains forbidden %q",
+				i, v.Input, got, forbidden)
+		}
+	}
+}

--- a/packages/arcis-go/sanitizers/conformance_test.go
+++ b/packages/arcis-go/sanitizers/conformance_test.go
@@ -84,7 +84,7 @@ func TestConformance_SanitizeString_XSS(t *testing.T) {
 		if !ok {
 			continue
 		}
-		got := SanitizeString(v.Input)
+		got := SanitizeXSS(v.Input)
 		if strings.Contains(strings.ToLower(got), strings.ToLower(forbidden)) {
 			t.Errorf("xss vector %d (input=%q): output %q still contains forbidden %q",
 				i, v.Input, got, forbidden)
@@ -99,7 +99,7 @@ func TestConformance_SanitizeString_SQL(t *testing.T) {
 		if !ok {
 			continue
 		}
-		got := SanitizeString(v.Input)
+		got := SanitizeSQL(v.Input)
 		if strings.Contains(strings.ToLower(got), strings.ToLower(forbidden)) {
 			t.Errorf("sql vector %d (input=%q): output %q still contains forbidden %q",
 				i, v.Input, got, forbidden)

--- a/packages/arcis-go/sanitizers/encode.go
+++ b/packages/arcis-go/sanitizers/encode.go
@@ -115,7 +115,9 @@ func EncodeForURL(value string) string {
 }
 
 // EncodeForCSS encodes for CSS value context.
-// Non-alphanumeric characters are hex-escaped as \HH (trailing space per CSS spec).
+// Non-alphanumeric characters are hex-escaped as zero-padded \HHHHHH (6 hex
+// digits). This form is self-terminating and, unlike the shorter \HH<space>
+// variant, does not risk absorbing a following legitimate space character.
 //
 // Use when embedding in CSS values:
 //
@@ -125,13 +127,12 @@ func EncodeForCSS(value string) string {
 		return ""
 	}
 	var b strings.Builder
-	b.Grow(len(value) * 2)
+	b.Grow(len(value) * 7)
 	for _, r := range value {
 		if isRuneAlphanumeric(r) {
 			b.WriteRune(r)
 		} else {
-			// CSS hex escape: backslash + hex code + trailing space
-			fmt.Fprintf(&b, "\\%X ", r)
+			fmt.Fprintf(&b, "\\%06X", r)
 		}
 	}
 	return b.String()

--- a/packages/arcis-go/sanitizers/encode_test.go
+++ b/packages/arcis-go/sanitizers/encode_test.go
@@ -167,13 +167,20 @@ func TestEncodeForCSS(t *testing.T) {
 		}
 	})
 
-	t.Run("trailing space per CSS spec", func(t *testing.T) {
+	t.Run("zero-padded 6-digit hex escape", func(t *testing.T) {
 		result := EncodeForCSS(";")
-		if !strings.HasSuffix(result, " ") {
-			t.Errorf("should end with trailing space, got %q", result)
+		// ';' is 0x3B → expect \00003B (self-terminating, no trailing space)
+		if result != "\\00003B" {
+			t.Errorf("want %q, got %q", "\\00003B", result)
 		}
-		if !strings.Contains(result, "\\") {
-			t.Errorf("should contain backslash, got %q", result)
+	})
+
+	t.Run("escape does not absorb following space", func(t *testing.T) {
+		// Prior \HH<space> form would merge with a legitimate following space.
+		// 6-digit form must not.
+		result := EncodeForCSS("; ")
+		if !strings.HasSuffix(result, "\\000020") {
+			t.Errorf("trailing space should be escaped as \\000020, got %q", result)
 		}
 	})
 

--- a/packages/arcis-go/sanitizers/sanitize.go
+++ b/packages/arcis-go/sanitizers/sanitize.go
@@ -15,6 +15,7 @@ var xssPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)vbscript:`),
 	regexp.MustCompile(`(?i)on\w+\s*=`),
 	regexp.MustCompile(`(?i)<iframe`),
+	regexp.MustCompile(`(?i)<style[\s>]`),
 	regexp.MustCompile(`(?i)<object`),
 	regexp.MustCompile(`(?i)<embed`),
 	regexp.MustCompile(`(?i)(?:^|[\s"'=])data:`),
@@ -49,6 +50,8 @@ var pathPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`\.\.\\`),
 	regexp.MustCompile(`(?i)%2e%2e`),
 	regexp.MustCompile(`(?i)%252e`),
+	regexp.MustCompile(`(?i)%00`), // null byte injection — truncates file paths (file.txt%00.jpg)
+	regexp.MustCompile(`\x00`),    // literal null byte
 }
 
 // Pre-compiled command injection patterns
@@ -75,8 +78,10 @@ var sstiDetectPatterns = []*regexp.Regexp{
 // Only strip ${...} and #{...} when operators are present inside the expression.
 var sstiRemovePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`\{\{.*?\}\}`),                           // Jinja2 / Twig
+	regexp.MustCompile(`\$\{[^}]*__\w+__[^}]*\}`),              // Freemarker with Python dunders
 	regexp.MustCompile(`\$\{[^}]*[?!()*+\-/][^}]*\}`),          // Freemarker with operators
 	regexp.MustCompile(`<%[\s\S]*?%>`),                          // ERB / EJS
+	regexp.MustCompile(`#\{[^}]*__\w+__[^}]*\}`),               // Pug with Python dunders
 	regexp.MustCompile(`#\{[^}]*[?!()*+\-/][^}]*\}`),           // Pug with operators
 	regexp.MustCompile(`(?i)__(?:class|mro|subclasses|globals|builtins|import)__`),
 }

--- a/packages/arcis-node/src/core/constants.ts
+++ b/packages/arcis-node/src/core/constants.ts
@@ -109,6 +109,9 @@ export const XSS_REMOVE_PATTERNS = [
   /<script[^>]*>[\s\S]*?<\/script>/gi,
   /** Standalone/unclosed script tags */
   /<script[^>]*>/gi,
+  /** style — CSS expression() and behavior: attacks (IE-era but still relevant) */
+  /<style[^>]*>[\s\S]*?<\/style>/gi,
+  /<style[^>]*/gi,
   /** iframe — full block and partial/unclosed */
   /<iframe[^>]*>[\s\S]*?<\/iframe>/gi,
   /<iframe[^>]*/gi,

--- a/packages/arcis-node/src/index.ts
+++ b/packages/arcis-node/src/index.ts
@@ -43,6 +43,13 @@ export { secureCookieDefaults, createSecureCookies, enforceSecureCookie } from '
 export { botProtection, detectBot } from './middleware/bot-detection';
 export { csrfProtection, createCsrf, generateCsrfToken, validateCsrfToken } from './middleware/csrf';
 export { hpp, createHpp } from './middleware/hpp';
+export { signupProtection, checkSignup } from './middleware/signup-protection';
+export type {
+  SignupProtectionOptions,
+  SignupCheckResult,
+  SignupBlockReason,
+  SignupProtectionMiddleware,
+} from './middleware/signup-protection';
 
 // =============================================================================
 // SANITIZERS

--- a/packages/arcis-node/src/middleware/bot-detection.ts
+++ b/packages/arcis-node/src/middleware/bot-detection.ts
@@ -227,8 +227,19 @@ function detectBehavioralSignals(req: Request): string[] {
  */
 export function detectBot(req: Request): BotDetectionResult {
   const rawUa = req.headers['user-agent'] ?? '';
-  // Truncate to prevent CPU abuse from very long UA strings
-  const ua = rawUa.length > 2048 ? rawUa.slice(0, 2048) : rawUa;
+  // SECURITY: A UA longer than 2048 chars is either buggy client or attempt to hide
+  // a bot signature past a truncation boundary. Flag as suspicious bot directly —
+  // don't silently truncate and continue.
+  if (rawUa.length > 2048) {
+    return {
+      isBot: true,
+      category: 'UNKNOWN',
+      name: null,
+      confidence: 0.9,
+      signals: detectBehavioralSignals(req),
+    };
+  }
+  const ua = rawUa;
   const signals = detectBehavioralSignals(req);
 
   // No User-Agent at all

--- a/packages/arcis-node/src/middleware/cookies.ts
+++ b/packages/arcis-node/src/middleware/cookies.ts
@@ -105,6 +105,23 @@ export function secureCookieDefaults(options: SecureCookieOptions = {}): Request
     path: options.path,
   };
 
+  // Fail loudly on incompatible combinations — silent misconfiguration is a
+  // common footgun (e.g. SameSite=None without Secure is rejected by every
+  // modern browser, producing a request that just silently loses cookies).
+  if (resolved.sameSite === 'None' && resolved.secure === false) {
+    throw new Error(
+      '[arcis] secureCookieDefaults: sameSite=None requires secure=true (modern browsers reject the cookie otherwise)'
+    );
+  }
+  if (resolved.httpOnly === false && resolved.secure === false && isProduction) {
+    // Only a warning — some apps legitimately need non-HttpOnly cookies (e.g. CSRF double-submit).
+    // But running both off in production is almost never intentional.
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[arcis] secureCookieDefaults: httpOnly and secure are both disabled in production — cookies will be readable by JS and sent over HTTP'
+    );
+  }
+
   return (_req: Request, res: Response, next: NextFunction) => {
     // Monkey-patch res.setHeader to intercept Set-Cookie
     const originalSetHeader = res.setHeader.bind(res);

--- a/packages/arcis-node/src/middleware/csrf.ts
+++ b/packages/arcis-node/src/middleware/csrf.ts
@@ -59,6 +59,16 @@ export interface CsrfOptions {
   };
   /** Custom error handler when CSRF validation fails */
   onError?: (req: Request, res: Response, next: NextFunction) => void;
+  /**
+   * Rotate the CSRF token after each successful validation on a protected
+   * method. Defends against token-fixation attacks where an attacker plants
+   * a known token before authentication. Default: false.
+   *
+   * When enabled, every successful POST/PUT/PATCH/DELETE causes the server to
+   * issue a fresh token via Set-Cookie — the client must re-read the cookie
+   * before the next mutating request.
+   */
+  rotateOnUse?: boolean;
 }
 
 const DEFAULTS = {
@@ -226,6 +236,12 @@ export function csrfProtection(options: CsrfOptions = {}): RequestHandler {
 
     if (!validateCsrfToken(cookieToken, requestToken)) {
       return onError(req, res, next);
+    }
+
+    // Optional token rotation on successful validation
+    if (options.rotateOnUse) {
+      const freshToken = generateCsrfToken(tokenLength);
+      setCsrfCookie(res, cookieName, freshToken, cookieOpts);
     }
 
     next();

--- a/packages/arcis-node/src/middleware/hpp.ts
+++ b/packages/arcis-node/src/middleware/hpp.ts
@@ -55,7 +55,9 @@ export interface HppOptions {
  * });
  */
 export function hpp(options: HppOptions = {}): RequestHandler {
-  const whitelist = new Set(options.whitelist ?? []);
+  // SECURITY: Store whitelist as lowercase so case-variant params can't bypass.
+  // Some frameworks normalize param case downstream — `TAGS` should match whitelist `tags`.
+  const whitelist = new Set((options.whitelist ?? []).map((k) => k.toLowerCase()));
   const checkQuery = options.checkQuery ?? true;
   const checkBody = options.checkBody ?? true;
 
@@ -68,7 +70,7 @@ export function hpp(options: HppOptions = {}): RequestHandler {
       for (const [key, value] of Object.entries(req.query)) {
         if (Array.isArray(value)) {
           const strings = value.filter((v): v is string => typeof v === 'string');
-          if (whitelist.has(key)) {
+          if (whitelist.has(key.toLowerCase())) {
             // Whitelisted — preserve as array
             clean[key] = strings;
           } else {
@@ -93,7 +95,7 @@ export function hpp(options: HppOptions = {}): RequestHandler {
 
       for (const [key, value] of Object.entries(req.body as Record<string, unknown>)) {
         if (Array.isArray(value)) {
-          if (whitelist.has(key)) {
+          if (whitelist.has(key.toLowerCase())) {
             clean[key] = value;
           } else {
             polluted[key] = value;

--- a/packages/arcis-node/src/middleware/index.ts
+++ b/packages/arcis-node/src/middleware/index.ts
@@ -17,3 +17,5 @@ export { safeCors, createCors } from './cors';
 export { secureCookieDefaults, createSecureCookies, enforceSecureCookie } from './cookies';
 export { botProtection, detectBot } from './bot-detection';
 export { csrfProtection, createCsrf, generateCsrfToken, validateCsrfToken } from './csrf';
+export { signupProtection, checkSignup } from './signup-protection';
+export type { SignupProtectionOptions, SignupCheckResult, SignupBlockReason, SignupProtectionMiddleware } from './signup-protection';

--- a/packages/arcis-node/src/middleware/rate-limit.ts
+++ b/packages/arcis-node/src/middleware/rate-limit.ts
@@ -42,14 +42,17 @@ export function createRateLimiter(options: RateLimitOptions = {}): RateLimiterMi
     statusCode = RATE_LIMIT.DEFAULT_STATUS_CODE,
     keyGenerator = (req) => {
       const ip = req.ip ?? req.socket?.remoteAddress;
-      if (!ip) {
-        console.warn(
-          '[arcis] Rate limiter: cannot resolve client IP. All unresolvable clients share ' +
-          'one counter. Set Express trust proxy if behind a reverse proxy.'
-        );
-        return 'unknown';
-      }
-      return ip;
+      if (ip) return ip;
+      // SECURITY: When IP is unresolvable, fall back to a fingerprint of UA +
+      // Accept-Language so unresolvable clients don't share a single counter
+      // (one attacker could exhaust the limit and block every other client).
+      const ua = (req.headers['user-agent'] ?? '') as string;
+      const lang = (req.headers['accept-language'] ?? '') as string;
+      const fp = `${ua}|${lang}`;
+      // Small non-crypto hash — just needs to disperse unknown clients
+      let hash = 0;
+      for (let i = 0; i < fp.length; i++) hash = ((hash << 5) - hash + fp.charCodeAt(i)) | 0;
+      return `unknown:${hash.toString(36)}`;
     },
     skip,
     store: externalStore,

--- a/packages/arcis-node/src/middleware/signup-protection.ts
+++ b/packages/arcis-node/src/middleware/signup-protection.ts
@@ -1,0 +1,169 @@
+/**
+ * @module @arcis/node/middleware/signup-protection
+ *
+ * Composite signup-form protection: one middleware that combines email
+ * validation (syntax + disposable), bot detection, and a dedicated
+ * per-IP rate limit. Matches the Arcjet `protectSignup` convenience
+ * primitive but stays fully local — no cloud lookups.
+ *
+ * @example
+ *   app.post('/signup', signupProtection(), handler);
+ *
+ * @example
+ *   app.post('/signup', signupProtection({
+ *     emailField: 'email',
+ *     rateLimit: { max: 5, windowMs: 60_000 },
+ *     blockDisposable: true,
+ *   }), handler);
+ */
+
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import { validateEmail } from '../validation/email';
+import { detectBot, type BotCategory } from './bot-detection';
+import { createRateLimiter } from './rate-limit';
+
+export type SignupBlockReason =
+  | 'missing_email'
+  | 'invalid_email'
+  | 'disposable_email'
+  | 'bot'
+  | 'rate_limited';
+
+export interface SignupCheckResult {
+  allowed: boolean;
+  reason: SignupBlockReason | 'ok';
+  details?: Record<string, unknown>;
+}
+
+export interface SignupProtectionOptions {
+  /** Request body field holding the email address. Default: 'email' */
+  emailField?: string;
+  /** Run email validation. Default: true */
+  checkEmail?: boolean;
+  /** Reject disposable email domains. Default: true */
+  blockDisposable?: boolean;
+  /** Run bot detection. Default: true */
+  checkBot?: boolean;
+  /** Bot categories allowed through (e.g. test harnesses). Default: [] — all bots blocked */
+  allowedBotCategories?: BotCategory[];
+  /** Per-IP rate limit on signup endpoint. Set to `false` to disable. Default: 5 requests / 60s */
+  rateLimit?: { max?: number; windowMs?: number } | false;
+  /** Extra email domains to allow (bypasses disposable check) */
+  allowedEmailDomains?: string[];
+  /** Extra email domains to block */
+  blockedEmailDomains?: string[];
+  /** Called when a request is blocked — for telemetry/logging */
+  onBlocked?: (req: Request, result: SignupCheckResult) => void;
+}
+
+export interface SignupProtectionMiddleware extends RequestHandler {
+  /** Release the rate-limiter cleanup interval */
+  close: () => void;
+}
+
+/**
+ * Pure signup check — no rate-limit mutation, no response writes.
+ * Useful for framework adapters or custom control flow.
+ */
+export function checkSignup(
+  req: Request,
+  options: SignupProtectionOptions = {}
+): SignupCheckResult {
+  const {
+    emailField = 'email',
+    checkEmail = true,
+    blockDisposable = true,
+    checkBot = true,
+    allowedBotCategories = [],
+    allowedEmailDomains = [],
+    blockedEmailDomains = [],
+  } = options;
+
+  if (checkBot) {
+    const bot = detectBot(req);
+    if (bot.isBot && !allowedBotCategories.includes(bot.category)) {
+      return {
+        allowed: false,
+        reason: 'bot',
+        details: { category: bot.category, name: bot.name, confidence: bot.confidence },
+      };
+    }
+  }
+
+  if (checkEmail) {
+    const email = (req.body as Record<string, unknown> | undefined)?.[emailField];
+    if (typeof email !== 'string' || email.length === 0) {
+      return { allowed: false, reason: 'missing_email' };
+    }
+    const result = validateEmail(email, {
+      checkDisposable: blockDisposable,
+      allowedDomains: allowedEmailDomains,
+      blockedDomains: blockedEmailDomains,
+    });
+    if (!result.valid) {
+      const reason: SignupBlockReason =
+        result.reason === 'disposable' ? 'disposable_email' : 'invalid_email';
+      return { allowed: false, reason, details: { emailReason: result.reason } };
+    }
+  }
+
+  return { allowed: true, reason: 'ok' };
+}
+
+/**
+ * Express middleware: applies bot + email + rate-limit checks to a signup
+ * endpoint. Responds 400/403/429 with a JSON body on block; otherwise
+ * calls `next()`.
+ */
+export function signupProtection(
+  options: SignupProtectionOptions = {}
+): SignupProtectionMiddleware {
+  const rateLimitCfg = options.rateLimit;
+  const limiter =
+    rateLimitCfg === false
+      ? null
+      : createRateLimiter({
+          max: rateLimitCfg?.max ?? 5,
+          windowMs: rateLimitCfg?.windowMs ?? 60_000,
+          message: 'Too many signup attempts',
+        });
+
+  const handler: RequestHandler = (req, res, next) => {
+    const result = checkSignup(req, options);
+    if (!result.allowed) {
+      options.onBlocked?.(req, result);
+      const status = result.reason === 'bot' ? 403 : 400;
+      res.status(status).json({ error: 'signup_blocked', reason: result.reason });
+      return;
+    }
+    if (limiter) {
+      // Delegate to rate limiter — it will respond 429 on breach or call next() otherwise.
+      let rateLimited = false;
+      const rateLimitNext: NextFunction = (err?: unknown) => {
+        if (err) return next(err);
+        if (!rateLimited) next();
+      };
+      const patchedRes = new Proxy(res, {
+        get(target, prop) {
+          if (prop === 'status') {
+            return (code: number) => {
+              if (code === 429) {
+                rateLimited = true;
+                options.onBlocked?.(req, { allowed: false, reason: 'rate_limited' });
+              }
+              return (target.status as (c: number) => Response).call(target, code);
+            };
+          }
+          return Reflect.get(target, prop);
+        },
+      });
+      limiter(req, patchedRes as Response, rateLimitNext);
+      return;
+    }
+    next();
+  };
+
+  const middleware = handler as SignupProtectionMiddleware;
+  middleware.close = () => limiter?.close();
+  return middleware;
+}

--- a/packages/arcis-node/src/sanitizers/jsonp.ts
+++ b/packages/arcis-node/src/sanitizers/jsonp.ts
@@ -4,10 +4,11 @@
  */
 
 /**
- * Valid JSONP callback pattern: only alphanumeric, underscore, dot, and bracket notation.
- * This prevents injection of arbitrary JS via callback parameters.
+ * Valid JSONP callback pattern: only alphanumeric, underscore, dollar, and dot.
+ * Bracket notation is rejected — it enables bypasses like `cb[x` (unbalanced)
+ * and isn't needed for real-world JSONP callbacks.
  */
-const SAFE_CALLBACK_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$.[\]]*$/;
+const SAFE_CALLBACK_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$.]*$/;
 
 /**
  * Dangerous patterns that should never appear in a callback name,
@@ -15,7 +16,6 @@ const SAFE_CALLBACK_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$.[\]]*$/;
  */
 const DANGEROUS_CALLBACK_PATTERNS = [
   /\.\./,        // prototype chain traversal
-  /\[\s*\]/,     // empty bracket access
 ] as const;
 
 /**

--- a/packages/arcis-node/src/sanitizers/pii.ts
+++ b/packages/arcis-node/src/sanitizers/pii.ts
@@ -34,7 +34,9 @@ export interface PiiRedactOptions extends PiiScanOptions {
 const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z]{2,})+/g;
 
 // US phone numbers: (xxx) xxx-xxxx, xxx-xxx-xxxx, xxx.xxx.xxxx, xxx xxx xxxx, +1xxxxxxxxxx
-const PHONE_RE = /(?:\+?1[-.\s]?)?\(?[2-9]\d{2}\)?[-.\s]?\d{3}[-.\s]?\d{4}/g;
+// (?<!\d) / (?!\d) boundaries prevent false positives inside longer digit
+// sequences like ZIP+number combos ("94102 555-1234") or bank account strings.
+const PHONE_RE = /(?<!\d)(?:\+?1[-.\s]?)?\(?[2-9]\d{2}\)?[-.\s]?\d{3}[-.\s]?\d{4}(?!\d)/g;
 
 // Credit cards: 13-19 digits with optional separators (spaces or dashes)
 const CREDIT_CARD_RE = /\b(?:\d[ -]*?){13,19}\b/g;

--- a/packages/arcis-node/src/sanitizers/ssti.ts
+++ b/packages/arcis-node/src/sanitizers/ssti.ts
@@ -42,17 +42,19 @@ const SSTI_REMOVE_PATTERNS = [
   /** Jinja2 / Twig: {{ ... }} — always strip (not valid in any JS context) */
   /\{\{.*?\}\}/g,
   /**
-   * Freemarker / Spring EL: ${...} — only strip when the expression contains
-   * operators (?!*+-/), method calls (), or known-dangerous prefixes.
+   * Freemarker / Spring EL: ${...} — strip when expression contains operators,
+   * method calls, or Python dunder patterns (sandbox escape).
    * Bare ${name} and ${user.name} are left intact (JS template literal syntax).
    */
+  /\$\{[^}]*__\w+__[^}]*\}/g,
   /\$\{[^}]*[?!()*+\-/][^}]*\}/g,
   /** ERB / EJS: <%= ... %> */
   /<%[=\-]?.*?%>/gs,
   /**
-   * Pug / Jade: #{...} — same narrowing as ${ above.
+   * Pug / Jade: #{...} — same narrowing as ${ above, plus dunder detection.
    * #{name} output expressions are left intact.
    */
+  /#\{[^}]*__\w+__[^}]*\}/g,
   /#\{[^}]*[?!()*+\-/][^}]*\}/g,
   /** Python dunder sandbox escape — always strip */
   /__(?:class|mro|subclasses|globals|builtins|import)__/gi,

--- a/packages/arcis-node/src/sanitizers/xxe.ts
+++ b/packages/arcis-node/src/sanitizers/xxe.ts
@@ -11,6 +11,14 @@ import type { SanitizeResult, ThreatInfo } from '../core/types';
  * Covers DOCTYPE declarations, ENTITY definitions, SYSTEM/PUBLIC references,
  * parameter entities, and CDATA abuse.
  */
+/**
+ * Billion-laughs defense: cap raw XML input length and the count of
+ * entity references. A valid document rarely needs more than a handful of
+ * entities; thousands of `&foo;` references is the classic bomb shape.
+ */
+const MAX_XXE_INPUT_BYTES = 1_000_000; // 1 MB — above any reasonable config/SOAP payload
+const MAX_ENTITY_REFERENCES = 64;
+
 const XXE_DETECT_PATTERNS = [
   /** DOCTYPE declaration */
   /<!DOCTYPE\b/gi,
@@ -52,6 +60,22 @@ export function sanitizeXxe(input: string, collectThreats = false): string | San
   const threats: ThreatInfo[] = [];
   let value = input;
   let wasSanitized = false;
+
+  // Billion-laughs defense: oversize input or many entity refs → flatten to empty.
+  // Safer to discard than to attempt partial sanitization of a bomb payload.
+  if (value.length > MAX_XXE_INPUT_BYTES) {
+    if (collectThreats) {
+      threats.push({ type: 'xxe', pattern: 'oversize_input', original: `length=${value.length}` });
+    }
+    return collectThreats ? { value: '', wasSanitized: true, threats } : '';
+  }
+  const entityRefs = value.match(/&\w+;/g);
+  if (entityRefs && entityRefs.length > MAX_ENTITY_REFERENCES) {
+    if (collectThreats) {
+      threats.push({ type: 'xxe', pattern: 'entity_expansion', original: `count=${entityRefs.length}` });
+    }
+    return collectThreats ? { value: '', wasSanitized: true, threats } : '';
+  }
 
   for (const pattern of XXE_REMOVE_PATTERNS) {
     pattern.lastIndex = 0;

--- a/packages/arcis-node/tests/audit-low-fixes.test.ts
+++ b/packages/arcis-node/tests/audit-low-fixes.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Regression tests for LOW-severity audit fixes (L1-L5).
+ *
+ * L1: XXE billion-laughs defense (size + entity-count cap)
+ * L2: PII phone regex narrowed with digit boundaries
+ * L3: Cookie config validation (throws on SameSite=None + secure=false)
+ * L5: CSRF rotateOnUse option
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { sanitizeXxe } from '../src/sanitizers/xxe';
+import { scanPii } from '../src/sanitizers/pii';
+import { secureCookieDefaults } from '../src/middleware/cookies';
+import { csrfProtection, generateCsrfToken } from '../src/middleware/csrf';
+
+describe('L1: XXE billion-laughs defense', () => {
+  it('flattens oversize input (>1MB) to empty string', () => {
+    const huge = 'a'.repeat(1_000_001);
+    expect(sanitizeXxe(huge)).toBe('');
+  });
+
+  it('flattens payload with >64 entity references', () => {
+    const bomb = '<root>' + '&lol;'.repeat(65) + '</root>';
+    expect(sanitizeXxe(bomb)).toBe('');
+  });
+
+  it('records oversize threat when collecting', () => {
+    const huge = 'a'.repeat(1_000_001);
+    const result = sanitizeXxe(huge, true);
+    expect(result.value).toBe('');
+    expect(result.wasSanitized).toBe(true);
+    expect(result.threats.some(t => t.pattern === 'oversize_input')).toBe(true);
+  });
+
+  it('records entity_expansion threat when collecting', () => {
+    const bomb = '&a;'.repeat(100);
+    const result = sanitizeXxe(bomb, true);
+    expect(result.threats.some(t => t.pattern === 'entity_expansion')).toBe(true);
+  });
+
+  it('leaves small benign payloads alone', () => {
+    expect(sanitizeXxe('<root><item>ok</item></root>')).toBe('<root><item>ok</item></root>');
+  });
+});
+
+describe('L2: PII phone regex boundaries', () => {
+  it('does not match phone-like substring inside longer digit run', () => {
+    // Prior regex matched '555-123-4567' inside ZIP+phone concatenations
+    // that had surrounding digits. Should NOT match now.
+    const matches = scanPii('id=94102555123456789', { types: ['phone'] });
+    expect(matches).toHaveLength(0);
+  });
+
+  it('still matches standard US phone formats', () => {
+    const matches = scanPii('Call 555-123-4567 today', { types: ['phone'] });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].value).toBe('555-123-4567');
+  });
+
+  it('matches +1 prefix format', () => {
+    const matches = scanPii('+1 555-123-4567', { types: ['phone'] });
+    expect(matches).toHaveLength(1);
+  });
+});
+
+describe('L3: Cookie config validation', () => {
+  it('throws when SameSite=None combined with secure=false', () => {
+    expect(() =>
+      secureCookieDefaults({ sameSite: 'None', secure: false })
+    ).toThrow(/sameSite=None requires secure=true/);
+  });
+
+  it('accepts SameSite=None when secure=true', () => {
+    expect(() =>
+      secureCookieDefaults({ sameSite: 'None', secure: true })
+    ).not.toThrow();
+  });
+
+  it('accepts default Lax config', () => {
+    expect(() => secureCookieDefaults()).not.toThrow();
+  });
+});
+
+describe('L5: CSRF rotateOnUse', () => {
+  function mockReq(overrides: Partial<Request> = {}): Request {
+    return {
+      method: 'POST',
+      path: '/api/submit',
+      url: '/api/submit',
+      headers: {},
+      body: {},
+      cookies: {},
+      ...overrides,
+    } as unknown as Request;
+  }
+
+  function mockRes(): Response & { _headers: Record<string, unknown> } {
+    const headers: Record<string, unknown> = {};
+    const res = {
+      _headers: headers,
+      setHeader: vi.fn((name: string, value: unknown) => {
+        headers[name] = value;
+      }),
+      getHeader: vi.fn((name: string) => headers[name]),
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+    return res as unknown as Response & { _headers: Record<string, unknown> };
+  }
+
+  it('issues a fresh Set-Cookie on successful validation when rotateOnUse=true', () => {
+    const token = generateCsrfToken(16);
+    const mw = csrfProtection({ tokenLength: 16, rotateOnUse: true });
+
+    const req = mockReq({
+      cookies: { _csrf: token },
+      headers: { 'x-csrf-token': token },
+    });
+    const res = mockRes();
+    const next = vi.fn();
+
+    mw(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    const setCookie = res._headers['Set-Cookie'];
+    expect(setCookie).toBeDefined();
+    const cookieStr = Array.isArray(setCookie) ? setCookie[0] : String(setCookie);
+    // New cookie must contain _csrf= with a token distinct from the submitted one
+    expect(cookieStr).toMatch(/_csrf=/);
+    const newToken = cookieStr.match(/_csrf=([^;]+)/)?.[1];
+    expect(newToken).toBeDefined();
+    expect(newToken).not.toBe(token);
+  });
+
+  it('does not rotate when rotateOnUse is absent (default)', () => {
+    const token = generateCsrfToken(16);
+    const mw = csrfProtection({ tokenLength: 16 });
+
+    const req = mockReq({
+      cookies: { _csrf: token },
+      headers: { 'x-csrf-token': token },
+    });
+    const res = mockRes();
+    const next = vi.fn();
+
+    mw(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res._headers['Set-Cookie']).toBeUndefined();
+  });
+});

--- a/packages/arcis-node/tests/audit-medium-fixes.test.ts
+++ b/packages/arcis-node/tests/audit-medium-fixes.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression tests for AUDIT_PLAN medium findings (M1-M10).
+ * Each describe block maps 1:1 to an audit finding so future regressions
+ * surface at the right severity level.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { sanitizeSsti } from '../src/sanitizers/ssti';
+import { sanitizeString as sanitizeXss } from '../src/sanitizers/sanitize';
+import { sanitizeJsonpCallback, detectJsonpInjection } from '../src/sanitizers/jsonp';
+import { hpp } from '../src/middleware/hpp';
+import { detectBot } from '../src/middleware/bot-detection';
+import { createRateLimiter } from '../src/middleware/rate-limit';
+
+function mockReq(overrides: Record<string, unknown> = {}): Request {
+  return {
+    method: 'GET',
+    path: '/',
+    headers: {},
+    cookies: {},
+    body: {},
+    query: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+function mockRes(): Partial<Response> {
+  const res: any = {};
+  res.setHeader = vi.fn().mockReturnValue(res);
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('M1 — SSTI operator-free dunder patterns', () => {
+  it('strips ${self.__dict__}', () => {
+    expect(sanitizeSsti('hello ${self.__dict__} world')).not.toContain('__dict__');
+  });
+
+  it('strips #{obj.__class__} in Pug context', () => {
+    expect(sanitizeSsti('#{obj.__class__}')).not.toContain('__class__');
+  });
+
+  it('still leaves bare ${name} intact', () => {
+    expect(sanitizeSsti('Hello ${name}')).toBe('Hello ${name}');
+  });
+});
+
+describe('M2 — XSS <style> tag removal', () => {
+  it('strips <style> blocks with expression() attack', () => {
+    const out = sanitizeXss('<style>body { x: expression(alert(1)) }</style>');
+    expect(out.toLowerCase()).not.toContain('<style');
+    expect(out).not.toContain('expression');
+  });
+
+  it('strips unclosed <style attr>', () => {
+    expect(sanitizeXss('<style type="text/css">').toLowerCase()).not.toContain('<style');
+  });
+});
+
+describe('M3 — JSONP brackets rejected', () => {
+  it('rejects callback with unbalanced bracket `cb[x`', () => {
+    expect(sanitizeJsonpCallback('cb[x')).toBeNull();
+  });
+
+  it('rejects callback with any brackets', () => {
+    expect(sanitizeJsonpCallback('cb[0]')).toBeNull();
+    expect(sanitizeJsonpCallback('arr[1].fn')).toBeNull();
+  });
+
+  it('detectJsonpInjection flags bracketed callbacks', () => {
+    expect(detectJsonpInjection('cb[x')).toBe(true);
+  });
+
+  it('still accepts simple identifiers and dotted names', () => {
+    expect(sanitizeJsonpCallback('myCallback')).toBe('myCallback');
+    expect(sanitizeJsonpCallback('ns.cb')).toBe('ns.cb');
+  });
+});
+
+describe('M4 — HPP whitelist case-insensitive', () => {
+  it('whitelisted `tags` matches incoming `TAGS` (preserved as array)', () => {
+    const req = mockReq({ query: { TAGS: ['a', 'b'] } });
+    const next = vi.fn();
+    hpp({ whitelist: ['tags'] })(req, mockRes() as Response, next as unknown as NextFunction);
+    expect(Array.isArray((req.query as any).TAGS)).toBe(true);
+    expect((req.query as any).TAGS).toEqual(['a', 'b']);
+  });
+
+  it('non-whitelisted params still collapse to last value', () => {
+    const req = mockReq({ query: { role: ['user', 'admin'] } });
+    const next = vi.fn();
+    hpp({ whitelist: ['tags'] })(req, mockRes() as Response, next as unknown as NextFunction);
+    expect((req.query as any).role).toBe('admin');
+  });
+});
+
+describe('M5 — Bot detection flags overlong UA', () => {
+  it('flags UA > 2048 chars as bot without silent truncation', () => {
+    const longUa = 'Mozilla/5.0 ' + 'x'.repeat(2500);
+    const req = { headers: { 'user-agent': longUa } } as any;
+    const result = detectBot(req);
+    expect(result.isBot).toBe(true);
+    expect(result.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('accepts normal UA', () => {
+    const req = {
+      headers: {
+        'user-agent': 'Mozilla/5.0 (Windows NT 10.0) Chrome/120.0.0.0',
+        'accept': 'text/html',
+        'accept-language': 'en-US',
+        'accept-encoding': 'gzip',
+      },
+    } as any;
+    expect(detectBot(req).isBot).toBe(false);
+  });
+});
+
+describe('M8 — Rate limit unknown IP uses UA+Lang fingerprint', () => {
+  it('two unknown-IP requests with different UAs get different counter keys', async () => {
+    const limiter = createRateLimiter({ max: 1, windowMs: 60_000 });
+    try {
+      const reqA = {
+        ip: undefined,
+        socket: {},
+        headers: { 'user-agent': 'ClientA/1.0', 'accept-language': 'en' },
+      } as any;
+      const reqB = {
+        ip: undefined,
+        socket: {},
+        headers: { 'user-agent': 'ClientB/1.0', 'accept-language': 'en' },
+      } as any;
+
+      const nextA = vi.fn();
+      const nextB = vi.fn();
+      await limiter(reqA, mockRes() as Response, nextA as unknown as NextFunction);
+      await limiter(reqB, mockRes() as Response, nextB as unknown as NextFunction);
+
+      // Different fingerprints → each gets its own bucket → both allowed under max=1
+      expect(nextA).toHaveBeenCalled();
+      expect(nextB).toHaveBeenCalled();
+    } finally {
+      limiter.close();
+    }
+  });
+});

--- a/packages/arcis-node/tests/middleware/signup-protection.test.ts
+++ b/packages/arcis-node/tests/middleware/signup-protection.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for signupProtection / checkSignup — composite protection for signup endpoints.
+ * Closes the Arcjet "signup form protection" gap from AUDIT_PLAN.md.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { signupProtection, checkSignup } from '../../src/middleware/signup-protection';
+
+function mockReq(overrides: Record<string, unknown> = {}): Request {
+  const headers = {
+    'user-agent': 'Mozilla/5.0 (Windows NT 10.0) Chrome/120.0.0.0',
+    accept: 'text/html',
+    'accept-language': 'en-US',
+    'accept-encoding': 'gzip',
+    ...((overrides.headers as Record<string, string>) || {}),
+  };
+  return {
+    method: 'POST',
+    path: '/signup',
+    ip: '1.2.3.4',
+    socket: { remoteAddress: '1.2.3.4' },
+    body: {},
+    query: {},
+    cookies: {},
+    ...overrides,
+    headers,
+  } as unknown as Request;
+}
+
+function mockRes(): { res: Response; status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn>; setHeader: ReturnType<typeof vi.fn> } {
+  const obj: any = {};
+  const status = vi.fn().mockReturnValue(obj);
+  const json = vi.fn().mockReturnValue(obj);
+  const setHeader = vi.fn().mockReturnValue(obj);
+  obj.status = status;
+  obj.json = json;
+  obj.setHeader = setHeader;
+  return { res: obj as Response, status, json, setHeader };
+}
+
+describe('checkSignup (pure)', () => {
+  it('allows a valid human signup', () => {
+    const req = mockReq({ body: { email: 'alice@gmail.com' } });
+    expect(checkSignup(req)).toEqual({ allowed: true, reason: 'ok' });
+  });
+
+  it('blocks missing email', () => {
+    const req = mockReq({ body: {} });
+    expect(checkSignup(req).reason).toBe('missing_email');
+  });
+
+  it('blocks invalid email syntax', () => {
+    const req = mockReq({ body: { email: 'not-an-email' } });
+    expect(checkSignup(req).reason).toBe('invalid_email');
+  });
+
+  it('blocks disposable email domains', () => {
+    const req = mockReq({ body: { email: 'throwaway@mailinator.com' } });
+    expect(checkSignup(req).reason).toBe('disposable_email');
+  });
+
+  it('blocks automated bots', () => {
+    const req = mockReq({
+      body: { email: 'alice@gmail.com' },
+      headers: { 'user-agent': 'curl/8.0' },
+    });
+    const out = checkSignup(req);
+    expect(out.allowed).toBe(false);
+    expect(out.reason).toBe('bot');
+  });
+
+  it('respects allowedBotCategories', () => {
+    const req = mockReq({
+      body: { email: 'alice@gmail.com' },
+      headers: { 'user-agent': 'Googlebot/2.1' },
+    });
+    expect(checkSignup(req, { allowedBotCategories: ['SEARCH_ENGINE'] }).allowed).toBe(true);
+  });
+
+  it('honors custom emailField', () => {
+    const req = mockReq({ body: { contact: 'alice@gmail.com' } });
+    expect(checkSignup(req, { emailField: 'contact' }).allowed).toBe(true);
+  });
+
+  it('allowedEmailDomains bypasses disposable check', () => {
+    const req = mockReq({ body: { email: 'ci@mailinator.com' } });
+    expect(
+      checkSignup(req, { allowedEmailDomains: ['mailinator.com'] }).allowed
+    ).toBe(true);
+  });
+});
+
+describe('signupProtection (middleware)', () => {
+  it('calls next() on valid signup', () => {
+    const mw = signupProtection({ rateLimit: false });
+    try {
+      const next = vi.fn();
+      const { res } = mockRes();
+      mw(mockReq({ body: { email: 'alice@gmail.com' } }), res, next as NextFunction);
+      expect(next).toHaveBeenCalledTimes(1);
+    } finally {
+      mw.close();
+    }
+  });
+
+  it('responds 400 on invalid email', () => {
+    const mw = signupProtection({ rateLimit: false });
+    try {
+      const next = vi.fn();
+      const { res, status, json } = mockRes();
+      mw(mockReq({ body: { email: 'bad' } }), res, next as NextFunction);
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'invalid_email' })
+      );
+      expect(next).not.toHaveBeenCalled();
+    } finally {
+      mw.close();
+    }
+  });
+
+  it('responds 403 on bot', () => {
+    const mw = signupProtection({ rateLimit: false });
+    try {
+      const next = vi.fn();
+      const { res, status } = mockRes();
+      mw(
+        mockReq({
+          body: { email: 'alice@gmail.com' },
+          headers: { 'user-agent': 'curl/8.0' },
+        }),
+        res,
+        next as NextFunction
+      );
+      expect(status).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
+    } finally {
+      mw.close();
+    }
+  });
+
+  it('rate-limits bursts from one IP', async () => {
+    const mw = signupProtection({ rateLimit: { max: 2, windowMs: 60_000 } });
+    try {
+      const req = () => mockReq({ body: { email: 'alice@gmail.com' } });
+      const nextCalls: number[] = [];
+      const statuses: number[] = [];
+      for (let i = 0; i < 4; i++) {
+        const next = vi.fn(() => nextCalls.push(i));
+        const { res, status } = mockRes();
+        await mw(req(), res, next as NextFunction);
+        if (status.mock.calls.length) statuses.push(status.mock.calls[0][0]);
+      }
+      // First 2 pass, 3rd+ blocked by 429
+      expect(nextCalls.length).toBe(2);
+      expect(statuses).toContain(429);
+    } finally {
+      mw.close();
+    }
+  });
+
+  it('onBlocked fires on rejection', () => {
+    const onBlocked = vi.fn();
+    const mw = signupProtection({ rateLimit: false, onBlocked });
+    try {
+      const { res } = mockRes();
+      mw(mockReq({ body: { email: 'bad' } }), res, vi.fn() as NextFunction);
+      expect(onBlocked).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ reason: 'invalid_email' })
+      );
+    } finally {
+      mw.close();
+    }
+  });
+});

--- a/packages/arcis-node/tests/sanitizers/jsonp.test.ts
+++ b/packages/arcis-node/tests/sanitizers/jsonp.test.ts
@@ -28,8 +28,8 @@ describe('sanitizeJsonpCallback', () => {
       expect(sanitizeJsonpCallback('_cb')).toBe('_cb');
     });
 
-    it('should accept callback with bracket notation', () => {
-      expect(sanitizeJsonpCallback('obj[0]')).toBe('obj[0]');
+    it('should reject callback with bracket notation (M3 audit fix)', () => {
+      expect(sanitizeJsonpCallback('obj[0]')).toBeNull();
     });
 
     it('should accept jQuery-style callback', () => {

--- a/packages/arcis-python/arcis/__init__.py
+++ b/packages/arcis-python/arcis/__init__.py
@@ -141,6 +141,7 @@ from .middleware.rate_limit_token import TokenBucketLimiter
 from .middleware.bot_detection import BotProtection, BotDenied, BotDetectionResult, detect_bot
 from .middleware.hpp import HppProtection, create_hpp
 from .middleware.csrf import CsrfProtection, create_csrf, generate_csrf_token, validate_csrf_token
+from .middleware.signup_protection import SignupProtection, SignupCheckResult, check_signup
 
 from .utils import (
     parse_duration,
@@ -222,6 +223,10 @@ __all__ = [
     "BotDenied",
     "BotDetectionResult",
     "detect_bot",
+    # Signup protection (composite: email + bot + rate-limit)
+    "SignupProtection",
+    "SignupCheckResult",
+    "check_signup",
     # PII detection and redaction
     "scan_pii",
     "detect_pii",

--- a/packages/arcis-python/arcis/fastapi.py
+++ b/packages/arcis-python/arcis/fastapi.py
@@ -182,7 +182,9 @@ class AsyncRateLimiter:
         
         # Cleanup task for in-memory store
         self._cleanup_task: Optional[asyncio.Task] = None
-    
+        # Lock prevents concurrent first requests from each spawning a cleanup task
+        self._cleanup_lock: Optional[asyncio.Lock] = None
+
     def _default_key_func(self, request: Request) -> str:
         """Default key function - uses client IP address."""
         # FastAPI/Starlette
@@ -201,22 +203,34 @@ class AsyncRateLimiter:
         return "unknown"
     
     async def _start_cleanup(self) -> None:
-        """Start background cleanup task for in-memory store."""
+        """Start background cleanup task for in-memory store.
+
+        Uses a lock so concurrent first requests don't each spawn a task.
+        Lock is lazily created on first call (must be inside running loop).
+        """
         if self._store_provided:
             return  # External stores handle their own cleanup
-        
-        async def cleanup_loop():
-            while not self._closed:
-                try:
-                    await asyncio.sleep(self.window_seconds)
-                    if not self._closed:
-                        await self.store.cleanup()
-                except asyncio.CancelledError:
-                    break
-                except Exception as e:
-                    logger.error("Async rate limiter cleanup error: %s", e)
-        
-        self._cleanup_task = asyncio.create_task(cleanup_loop())
+
+        if self._cleanup_lock is None:
+            self._cleanup_lock = asyncio.Lock()
+
+        async with self._cleanup_lock:
+            # Re-check under lock — another coroutine may have started it
+            if self._cleanup_task is not None:
+                return
+
+            async def cleanup_loop():
+                while not self._closed:
+                    try:
+                        await asyncio.sleep(self.window_seconds)
+                        if not self._closed:
+                            await self.store.cleanup()
+                    except asyncio.CancelledError:
+                        break
+                    except Exception as e:
+                        logger.error("Async rate limiter cleanup error: %s", e)
+
+            self._cleanup_task = asyncio.create_task(cleanup_loop())
     
     async def check(self, request: Request) -> Dict[str, Any]:
         """

--- a/packages/arcis-python/arcis/middleware/signup_protection.py
+++ b/packages/arcis-python/arcis/middleware/signup_protection.py
@@ -1,0 +1,168 @@
+"""
+Arcis signup-form protection.
+
+Composite primitive combining email validation (syntax + disposable),
+bot detection, and a dedicated per-IP rate limit. Matches the Arcjet
+`protectSignup` convenience API while staying fully local (no cloud
+lookups).
+
+Example:
+    protection = SignupProtection(rate_limit_max=5, rate_limit_window_ms=60_000)
+    result = protection.check(request)
+    if not result.allowed:
+        raise HTTPException(status_code=400, detail=result.reason)
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from ..validation.email import validate_email_address
+from .bot_detection import detect_bot
+from .rate_limit import RateLimiter, RateLimitExceeded
+
+
+SignupBlockReason = str  # 'missing_email' | 'invalid_email' | 'disposable_email' | 'bot' | 'rate_limited' | 'ok'
+
+
+@dataclass
+class SignupCheckResult:
+    """Outcome of a signup protection check."""
+    allowed: bool
+    reason: SignupBlockReason
+    details: Dict[str, Any] = field(default_factory=dict)
+
+
+def check_signup(
+    request: Any,
+    *,
+    email_field: str = "email",
+    check_email: bool = True,
+    block_disposable: bool = True,
+    check_bot: bool = True,
+    allowed_bot_categories: Optional[List[str]] = None,
+    allowed_email_domains: Optional[List[str]] = None,
+    blocked_email_domains: Optional[List[str]] = None,
+) -> SignupCheckResult:
+    """Pure signup check. No rate-limit mutation; safe to call repeatedly.
+
+    `request` must expose either a dict-like `body`/`json`/`form` attribute
+    or be a mapping itself. The email field is looked up in that order.
+    """
+    allowed_bot_categories = allowed_bot_categories or []
+
+    if check_bot:
+        bot = detect_bot(request)
+        if bot.is_bot and bot.category not in allowed_bot_categories:
+            return SignupCheckResult(
+                allowed=False,
+                reason="bot",
+                details={"category": bot.category, "name": bot.name, "confidence": bot.confidence},
+            )
+
+    if check_email:
+        email = _extract_field(request, email_field)
+        if not isinstance(email, str) or not email:
+            return SignupCheckResult(allowed=False, reason="missing_email")
+
+        result = validate_email_address(
+            email,
+            check_disposable=block_disposable,
+            allowed_domains=allowed_email_domains,
+            blocked_domains=blocked_email_domains,
+        )
+        if not result.valid:
+            reason = "disposable_email" if result.reason == "disposable" else "invalid_email"
+            return SignupCheckResult(
+                allowed=False,
+                reason=reason,
+                details={"email_reason": result.reason},
+            )
+
+    return SignupCheckResult(allowed=True, reason="ok")
+
+
+def _extract_field(request: Any, field_name: str) -> Any:
+    """Best-effort extraction of a body field across request shapes."""
+    for attr in ("body", "json", "form"):
+        container = getattr(request, attr, None)
+        if callable(container):
+            try:
+                container = container()
+            except Exception:
+                container = None
+        if isinstance(container, dict) and field_name in container:
+            return container[field_name]
+    if isinstance(request, dict) and field_name in request:
+        return request[field_name]
+    return None
+
+
+class SignupProtection:
+    """Stateful signup protection: bundles a rate limiter with the pure check.
+
+    Call `.check(request)` per request; on exhaustion it returns a
+    `SignupCheckResult` with reason='rate_limited' rather than raising.
+
+    Remember to call `.close()` on shutdown so the rate-limiter cleanup
+    thread exits cleanly.
+    """
+
+    def __init__(
+        self,
+        *,
+        email_field: str = "email",
+        check_email: bool = True,
+        block_disposable: bool = True,
+        check_bot: bool = True,
+        allowed_bot_categories: Optional[List[str]] = None,
+        allowed_email_domains: Optional[List[str]] = None,
+        blocked_email_domains: Optional[List[str]] = None,
+        rate_limit_max: Optional[int] = 5,
+        rate_limit_window_ms: int = 60_000,
+        rate_limit_key_func: Optional[Callable[[Any], str]] = None,
+        on_blocked: Optional[Callable[[Any, SignupCheckResult], None]] = None,
+    ):
+        self._opts = dict(
+            email_field=email_field,
+            check_email=check_email,
+            block_disposable=block_disposable,
+            check_bot=check_bot,
+            allowed_bot_categories=allowed_bot_categories,
+            allowed_email_domains=allowed_email_domains,
+            blocked_email_domains=blocked_email_domains,
+        )
+        self._on_blocked = on_blocked
+        self._limiter: Optional[RateLimiter] = None
+        if rate_limit_max is not None and rate_limit_max > 0:
+            self._limiter = RateLimiter(
+                max_requests=rate_limit_max,
+                window_ms=rate_limit_window_ms,
+                message="Too many signup attempts",
+                key_func=rate_limit_key_func,
+            )
+
+    def check(self, request: Any) -> SignupCheckResult:
+        result = check_signup(request, **self._opts)
+        if not result.allowed:
+            if self._on_blocked:
+                self._on_blocked(request, result)
+            return result
+
+        if self._limiter is not None:
+            try:
+                self._limiter.check(request)
+            except RateLimitExceeded as e:
+                rl_result = SignupCheckResult(
+                    allowed=False,
+                    reason="rate_limited",
+                    details={"retry_after": getattr(e, "retry_after", None)},
+                )
+                if self._on_blocked:
+                    self._on_blocked(request, rl_result)
+                return rl_result
+
+        return result
+
+    def close(self) -> None:
+        if self._limiter is not None:
+            self._limiter.close()

--- a/packages/arcis-python/arcis/sanitizers/jsonp.py
+++ b/packages/arcis-python/arcis/sanitizers/jsonp.py
@@ -8,13 +8,13 @@ XSS injection via ?callback= query parameters.
 import re
 from typing import Optional
 
-# Valid JSONP callback: alphanumeric, underscore, dot, dollar, brackets
-_SAFE_CALLBACK_PATTERN = re.compile(r"^[a-zA-Z_$][a-zA-Z0-9_$.[\]]*$")
+# Valid JSONP callback: alphanumeric, underscore, dollar, dot only.
+# Brackets rejected — enables bypasses like `cb[x` (unbalanced) and not needed in practice.
+_SAFE_CALLBACK_PATTERN = re.compile(r"^[a-zA-Z_$][a-zA-Z0-9_$.]*$")
 
 # Dangerous patterns within an otherwise-valid callback
 _DANGEROUS_CALLBACK_PATTERNS = [
     re.compile(r"\.\."),        # prototype chain traversal
-    re.compile(r"\[\s*\]"),     # empty bracket access
 ]
 
 

--- a/packages/arcis-python/arcis/sanitizers/ssti.py
+++ b/packages/arcis-python/arcis/sanitizers/ssti.py
@@ -39,11 +39,13 @@ _SSTI_DETECT_PATTERNS = [
 _SSTI_REMOVE_PATTERNS = [
     # Jinja2 / Twig: {{ ... }} — always strip (not valid in any JS context)
     re.compile(r"\{\{.*?\}\}", re.DOTALL),
-    # Freemarker / Spring EL: only strip when expression contains operators/calls
+    # Freemarker / Spring EL: strip when expression contains operators/calls or dunders
+    re.compile(r"\$\{[^}]*__\w+__[^}]*\}"),
     re.compile(r"\$\{[^}]*[?!()*+\-/][^}]*\}"),
     # ERB / EJS — always strip
     re.compile(r"<%[=\-]?.*?%>", re.DOTALL),
-    # Pug / Jade: only strip when expression contains operators/calls
+    # Pug / Jade: strip when expression contains operators/calls or dunders
+    re.compile(r"#\{[^}]*__\w+__[^}]*\}"),
     re.compile(r"#\{[^}]*[?!()*+\-/][^}]*\}"),
     # Python dunder sandbox escape — always strip
     re.compile(r"__(?:class|mro|subclasses|globals|builtins|import)__", re.IGNORECASE),

--- a/packages/arcis-python/tests/middleware/test_signup_protection.py
+++ b/packages/arcis-python/tests/middleware/test_signup_protection.py
@@ -1,0 +1,138 @@
+"""
+Tests for SignupProtection / check_signup — composite signup-endpoint protection.
+Closes the Arcjet `protectSignup` gap while staying fully local.
+"""
+
+import pytest
+
+from arcis.middleware.signup_protection import (
+    SignupProtection,
+    check_signup,
+)
+
+
+class FakeRequest:
+    """Minimal request object matching the shape bot_detection + rate_limit expect."""
+
+    def __init__(self, headers=None, body=None, ip="1.2.3.4"):
+        self.headers = {}
+        if headers:
+            for k, v in headers.items():
+                self.headers[k.lower()] = v
+        self.body = body or {}
+        self.remote_addr = ip
+
+
+def _browser_headers(extra=None):
+    h = {
+        "user-agent": "Mozilla/5.0 (Windows NT 10.0) Chrome/120.0.0.0",
+        "accept": "text/html",
+        "accept-language": "en-US",
+        "accept-encoding": "gzip",
+    }
+    if extra:
+        h.update(extra)
+    return h
+
+
+# ─── Pure check_signup ─────────────────────────────────────────────────────────
+
+class TestCheckSignup:
+    def test_allows_valid_human_signup(self):
+        req = FakeRequest(headers=_browser_headers(), body={"email": "alice@gmail.com"})
+        out = check_signup(req)
+        assert out.allowed is True
+        assert out.reason == "ok"
+
+    def test_blocks_missing_email(self):
+        req = FakeRequest(headers=_browser_headers(), body={})
+        assert check_signup(req).reason == "missing_email"
+
+    def test_blocks_invalid_syntax(self):
+        req = FakeRequest(headers=_browser_headers(), body={"email": "not-an-email"})
+        assert check_signup(req).reason == "invalid_email"
+
+    def test_blocks_disposable_domain(self):
+        req = FakeRequest(
+            headers=_browser_headers(), body={"email": "throwaway@mailinator.com"}
+        )
+        assert check_signup(req).reason == "disposable_email"
+
+    def test_blocks_automated_bot(self):
+        req = FakeRequest(
+            headers={"user-agent": "curl/8.0"}, body={"email": "alice@gmail.com"}
+        )
+        assert check_signup(req).reason == "bot"
+
+    def test_allows_whitelisted_bot_categories(self):
+        req = FakeRequest(
+            headers={"user-agent": "Googlebot/2.1"}, body={"email": "alice@gmail.com"}
+        )
+        assert check_signup(req, allowed_bot_categories=["SEARCH_ENGINE"]).allowed is True
+
+    def test_custom_email_field(self):
+        req = FakeRequest(headers=_browser_headers(), body={"contact": "alice@gmail.com"})
+        assert check_signup(req, email_field="contact").allowed is True
+
+    def test_allowed_email_domains_bypasses_disposable(self):
+        req = FakeRequest(headers=_browser_headers(), body={"email": "ci@mailinator.com"})
+        assert check_signup(
+            req, allowed_email_domains=["mailinator.com"]
+        ).allowed is True
+
+
+# ─── SignupProtection (stateful) ───────────────────────────────────────────────
+
+class TestSignupProtection:
+    def test_happy_path(self):
+        sp = SignupProtection(rate_limit_max=None)
+        try:
+            req = FakeRequest(headers=_browser_headers(), body={"email": "a@gmail.com"})
+            assert sp.check(req).allowed is True
+        finally:
+            sp.close()
+
+    def test_bot_blocked_before_rate_limit(self):
+        sp = SignupProtection(rate_limit_max=5)
+        try:
+            req = FakeRequest(
+                headers={"user-agent": "curl/8.0"}, body={"email": "a@gmail.com"}
+            )
+            out = sp.check(req)
+            assert out.allowed is False
+            assert out.reason == "bot"
+        finally:
+            sp.close()
+
+    def test_rate_limits_repeated_signups(self):
+        sp = SignupProtection(rate_limit_max=2, rate_limit_window_ms=60_000)
+        try:
+            results = []
+            for _ in range(4):
+                req = FakeRequest(
+                    headers=_browser_headers(), body={"email": "a@gmail.com"}
+                )
+                results.append(sp.check(req))
+            allowed = [r for r in results if r.allowed]
+            blocked = [r for r in results if not r.allowed]
+            assert len(allowed) == 2
+            assert any(r.reason == "rate_limited" for r in blocked)
+        finally:
+            sp.close()
+
+    def test_on_blocked_callback_fires(self):
+        calls = []
+        sp = SignupProtection(
+            rate_limit_max=None, on_blocked=lambda req, res: calls.append(res.reason)
+        )
+        try:
+            req = FakeRequest(headers=_browser_headers(), body={"email": "nope"})
+            sp.check(req)
+            assert calls == ["invalid_email"]
+        finally:
+            sp.close()
+
+    def test_close_is_idempotent(self):
+        sp = SignupProtection(rate_limit_max=2)
+        sp.close()
+        sp.close()  # must not raise

--- a/packages/arcis-python/tests/sanitizers/test_jsonp.py
+++ b/packages/arcis-python/tests/sanitizers/test_jsonp.py
@@ -27,8 +27,9 @@ class TestSanitizeJsonpCallback:
     def test_underscore_prefix(self):
         assert sanitize_jsonp_callback("_cb") == "_cb"
 
-    def test_bracket_notation(self):
-        assert sanitize_jsonp_callback("obj[0]") == "obj[0]"
+    def test_bracket_notation_rejected(self):
+        # M3 audit fix: brackets enable `cb[x` bypass and are never needed in practice
+        assert sanitize_jsonp_callback("obj[0]") is None
 
     def test_jquery_style(self):
         assert sanitize_jsonp_callback("jQuery110209547534") == "jQuery110209547534"

--- a/packages/arcis-python/tests/test_audit_medium_fixes.py
+++ b/packages/arcis-python/tests/test_audit_medium_fixes.py
@@ -1,0 +1,64 @@
+"""Regression tests for AUDIT_PLAN medium findings (M1, M3, M7) — Python SDK."""
+
+import asyncio
+import pytest
+
+from arcis.sanitizers.ssti import sanitize_ssti
+from arcis.sanitizers.jsonp import sanitize_jsonp_callback, detect_jsonp_injection
+
+
+class TestM1_SSTIDunderPatterns:
+    def test_strips_self_dunder_dict(self):
+        out = sanitize_ssti("hello ${self.__dict__} world")
+        assert "__dict__" not in out
+
+    def test_strips_pug_dunder_class(self):
+        out = sanitize_ssti("#{obj.__class__}")
+        assert "__class__" not in out
+
+    def test_leaves_plain_template_literal(self):
+        assert sanitize_ssti("Hello ${name}") == "Hello ${name}"
+
+
+class TestM3_JSONPBrackets:
+    def test_rejects_unbalanced_bracket(self):
+        assert sanitize_jsonp_callback("cb[x") is None
+
+    def test_rejects_any_brackets(self):
+        assert sanitize_jsonp_callback("cb[0]") is None
+        assert sanitize_jsonp_callback("arr[1].fn") is None
+
+    def test_detect_flags_brackets(self):
+        assert detect_jsonp_injection("cb[x") is True
+
+    def test_accepts_plain_identifiers(self):
+        assert sanitize_jsonp_callback("myCallback") == "myCallback"
+        assert sanitize_jsonp_callback("ns.cb") == "ns.cb"
+
+
+class TestM7_AsyncCleanupRace:
+    def test_concurrent_start_cleanup_yields_single_task(self):
+        pytest.importorskip("starlette")
+        from arcis.fastapi import AsyncRateLimiter
+
+        async def run():
+            limiter = AsyncRateLimiter(max_requests=10, window_ms=60_000)
+            try:
+                # Fire many concurrent _start_cleanup() calls — the lock must ensure
+                # only one cleanup task is actually spawned.
+                await asyncio.gather(*(limiter._start_cleanup() for _ in range(20)))
+                assert limiter._cleanup_task is not None
+                # Second wave must not replace the task
+                original = limiter._cleanup_task
+                await asyncio.gather(*(limiter._start_cleanup() for _ in range(10)))
+                assert limiter._cleanup_task is original
+            finally:
+                limiter._closed = True
+                if limiter._cleanup_task:
+                    limiter._cleanup_task.cancel()
+                    try:
+                        await limiter._cleanup_task
+                    except (asyncio.CancelledError, Exception):
+                        pass
+
+        asyncio.run(run())

--- a/packages/core/patterns.json
+++ b/packages/core/patterns.json
@@ -49,6 +49,13 @@
           "redos_safe": true
         },
         {
+          "id": "xss-style-tag",
+          "pattern": "<style[\\s>]",
+          "flags": "gi",
+          "description": "Detects style tags (CSS injection, expression(), behavior: attacks)",
+          "redos_safe": true
+        },
+        {
           "id": "xss-object",
           "pattern": "<object",
           "flags": "gi",


### PR DESCRIPTION
## Summary
- Closes all 10 Medium audit findings (M1-M10) and all 7 Low findings (L1-L7)
- Adds cross-SDK `signupProtection` middleware (Node/Python/Go) to close the Arcjet signup gap — composite email validation + bot detection + rate limit, fully local
- Adds Go cross-SDK conformance harness that loads `spec/TEST_VECTORS.json` (closes L7)

## Changes by severity

### Medium
- M1 dunder SSTI patterns, M2 `<style>` in XSS, M3 JSONP bracket rejection, M4 HPP whitelist lowercased, M5 overlong UA flagged, M6 CORS regex cap (Go), M7 Python async lock, M8 UA+Lang fingerprint for unknown IPs, M9 Go email validator rules, M10 Go path `%00` + NUL stripping

### Low
- L1 XXE billion-laughs (1MB + 64-entity caps)
- L2 PII phone digit boundaries
- L3 Cookie config validation (`SameSite=None` + `secure=false` throws)
- L4 Go HPP `OnParseError` hook, default logs instead of silent skip
- L5 CSRF `rotateOnUse` option
- L6 Go CSS encoding zero-padded `\HHHHHH` self-terminating
- L7 Go conformance tests against `TEST_VECTORS.json`

### Signup protection
- `signupProtection()` / `SignupProtection` / `NewSignupProtection()` across all three SDKs with a consistent `SignupCheckResult` shape

## Test plan
- [x] Node: 1338/1338 pass (`npx vitest run`)
- [x] Python: 1031/1031 pass (benchmark errors pre-existing, unrelated)
- [x] Go: run in CI (Docker not local)
- [x] New regression suites: `audit-medium-fixes.test.ts`, `audit-low-fixes.test.ts`, `test_audit_medium_fixes.py`, `signup-protection.test.ts` (13/13), `test_signup_protection.py` (13/13), Go `audit_medium_fixes_test.go`, `conformance_test.go`, `cors_redos_cap_test.go`, `signup_protection_test.go`