### PR TITLE
feat(telemetry): Node + Python SDK telemetry — v1.4.3

### DIFF
--- a/packages/arcis-node/package-lock.json
+++ b/packages/arcis-node/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@arcis/node",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcis/node",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.6",
         "@types/node": "^25.5.0",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.58.0",
+        "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^10.1.0",
         "express": "^5.2.1",
         "tsup": "^8.0.1",
@@ -26,10 +27,70 @@
         "express": ">=4.0.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -39,9 +100,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -688,9 +749,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -707,9 +768,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -717,9 +778,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -734,9 +795,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -751,9 +812,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -768,9 +829,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -785,9 +846,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -802,13 +863,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -819,13 +883,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -836,13 +903,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -853,13 +923,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -870,13 +943,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -887,13 +963,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -904,9 +983,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -921,9 +1000,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
@@ -931,18 +1010,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -957,9 +1036,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -974,9 +1053,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1858,17 +1937,48 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1877,13 +1987,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1904,9 +2014,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1917,13 +2027,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1931,14 +2041,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1947,9 +2057,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1957,13 +2067,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2040,6 +2150,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2941,6 +3063,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -2966,6 +3098,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -3079,6 +3218,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -3088,6 +3266,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -3277,6 +3462,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3298,6 +3486,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3319,6 +3510,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3340,6 +3534,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3449,6 +3646,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3793,9 +4018,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -3955,14 +4180,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3971,21 +4196,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/rollup": {
@@ -4297,6 +4522,19 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -4335,14 +4573,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4559,17 +4797,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4637,19 +4875,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4677,12 +4915,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/packages/arcis-node/package.json
+++ b/packages/arcis-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/node",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Zero-dependency security middleware for Node.js. Protects against XSS, SQL injection, CSRF, SSRF, HPP, rate limiting, bot detection, and 15+ more attack types. Supply chain attack scanner included.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -45,6 +45,11 @@
       "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.mjs",
       "require": "./dist/utils/index.js"
+    },
+    "./telemetry": {
+      "types": "./dist/telemetry/index.d.ts",
+      "import": "./dist/telemetry/index.mjs",
+      "require": "./dist/telemetry/index.js"
     }
   },
   "files": [
@@ -96,6 +101,7 @@
     "@types/node": "^25.5.0",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
+    "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^10.1.0",
     "express": "^5.2.1",
     "tsup": "^8.0.1",

--- a/packages/arcis-node/src/core/types.ts
+++ b/packages/arcis-node/src/core/types.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import type { TelemetryOptions } from '../telemetry/types';
 
 // =============================================================================
 // MAIN CONFIGURATION
@@ -19,6 +20,11 @@ export interface ArcisOptions {
   headers?: boolean | HeaderOptions;
   /** Enable/configure safe logging. Default: true */
   logging?: boolean | LogOptions;
+  /**
+   * Stream decision events to a dashboard endpoint. Opt-in: zero overhead when omitted.
+   * See spec/API_SPEC.md §9.
+   */
+  telemetry?: TelemetryOptions;
 }
 
 // =============================================================================

--- a/packages/arcis-node/src/index.ts
+++ b/packages/arcis-node/src/index.ts
@@ -95,6 +95,17 @@ export { fingerprint } from './utils/fingerprint';
 export { createSafeLogger, createRedactor, safeLog } from './logging/redactor';
 
 // =============================================================================
+// TELEMETRY
+// =============================================================================
+export { TelemetryClient, TelemetryHttpError } from './telemetry/client';
+export type {
+  TelemetryEvent,
+  TelemetryOptions,
+  TelemetryDecision,
+  TelemetrySeverity,
+} from './telemetry/types';
+
+// =============================================================================
 // STORES
 // =============================================================================
 export { MemoryStore } from './stores/memory';

--- a/packages/arcis-node/src/middleware/main.ts
+++ b/packages/arcis-node/src/middleware/main.ts
@@ -15,9 +15,41 @@ import type {
 import { createHeaders } from './headers';
 import { createRateLimiter } from './rate-limit';
 import { createErrorHandler } from './error-handler';
+import { createTelemetryEmitter, tapSanitizerThreats } from './telemetry';
 import { createSanitizer } from '../sanitizers';
 import { validate } from '../validation';
 import { createSafeLogger } from '../logging';
+import { TelemetryClient } from '../telemetry/client';
+import type { TelemetryOptions } from '../telemetry/types';
+
+/**
+ * Build TelemetryOptions from `ARCIS_*` environment variables when the user
+ * didn't pass `telemetry` in `arcis({...})`. Returns undefined if `ARCIS_ENDPOINT`
+ * isn't set — preserving zero-overhead opt-in.
+ *
+ * Recognized env vars:
+ *   - `ARCIS_ENDPOINT`           (required to activate)
+ *   - `ARCIS_WORKSPACE_ID`       (optional; sent as x-workspace-id)
+ *   - `ARCIS_KEY`                (optional; sent as Authorization: Bearer <key>)
+ *   - `ARCIS_BATCH_SIZE`         (optional integer; default 50)
+ *   - `ARCIS_FLUSH_INTERVAL_MS`  (optional integer; default 5000)
+ *
+ * Explicit `options.telemetry` always wins over env. This preserves the
+ * existing opt-in contract and lets callers override env in tests.
+ */
+function buildTelemetryFromEnv(): TelemetryOptions | undefined {
+  const env = typeof process !== 'undefined' ? process.env : undefined;
+  const endpoint = env?.ARCIS_ENDPOINT;
+  if (!endpoint) return undefined;
+  const opts: TelemetryOptions = { endpoint };
+  if (env?.ARCIS_WORKSPACE_ID) opts.workspaceId = env.ARCIS_WORKSPACE_ID;
+  if (env?.ARCIS_KEY) opts.apiKey = env.ARCIS_KEY;
+  const batch = env?.ARCIS_BATCH_SIZE ? parseInt(env.ARCIS_BATCH_SIZE, 10) : NaN;
+  if (!Number.isNaN(batch)) opts.batchSize = batch;
+  const flush = env?.ARCIS_FLUSH_INTERVAL_MS ? parseInt(env.ARCIS_FLUSH_INTERVAL_MS, 10) : NaN;
+  if (!Number.isNaN(flush)) opts.flushIntervalMs = flush;
+  return opts;
+}
 
 /**
  * Create Arcis middleware with all protections enabled.
@@ -53,30 +85,48 @@ export function arcis(options: ArcisOptions = {}): ArcisMiddlewareStack {
   const middlewares: RequestHandler[] = [];
   const cleanupFns: (() => void)[] = [];
 
-  // Security headers (first, always)
+  // Telemetry emitter — first, so latency includes the full middleware chain.
+  // Opt-in: zero overhead unless options.telemetry.endpoint is set, OR
+  // ARCIS_ENDPOINT is present in the environment. Explicit options win.
+  let telemetryClient: TelemetryClient | undefined;
+  const telemetryOpts = options.telemetry?.endpoint
+    ? options.telemetry
+    : buildTelemetryFromEnv();
+  if (telemetryOpts) {
+    const client = new TelemetryClient(telemetryOpts);
+    telemetryClient = client;
+    middlewares.push(createTelemetryEmitter(client));
+    cleanupFns.push(() => {
+      void client.close();
+    });
+  }
+
+  // Security headers (always before rate-limit/sanitize)
   if (options.headers !== false) {
-    const headerOpts: HeaderOptions = typeof options.headers === 'object' 
-      ? options.headers 
+    const headerOpts: HeaderOptions = typeof options.headers === 'object'
+      ? options.headers
       : {};
     middlewares.push(createHeaders(headerOpts));
   }
 
-  // Rate limiting
+  // Rate limiting — emitter detects 429 from response status, no wrap needed.
   if (options.rateLimit !== false) {
-    const rateLimitOpts: RateLimitOptions = typeof options.rateLimit === 'object' 
-      ? options.rateLimit 
+    const rateLimitOpts: RateLimitOptions = typeof options.rateLimit === 'object'
+      ? options.rateLimit
       : {};
     const rateLimiter = createRateLimiter(rateLimitOpts);
     middlewares.push(rateLimiter);
     cleanupFns.push(() => rateLimiter.close());
   }
 
-  // Input sanitization (last, after body parsing)
+  // Input sanitization — wrap with telemetry tap so SecurityThreatError
+  // populates req.__arcis with vector/rule/severity for the emitter.
   if (options.sanitize !== false) {
-    const sanitizeOpts: SanitizeOptions = typeof options.sanitize === 'object' 
-      ? options.sanitize 
+    const sanitizeOpts: SanitizeOptions = typeof options.sanitize === 'object'
+      ? options.sanitize
       : {};
-    middlewares.push(createSanitizer(sanitizeOpts));
+    const sanitizer = createSanitizer(sanitizeOpts);
+    middlewares.push(telemetryClient ? tapSanitizerThreats(sanitizer) : sanitizer);
   }
 
   // Attach close() directly on the array so callers can clean up without any-casts.

--- a/packages/arcis-node/src/middleware/telemetry.ts
+++ b/packages/arcis-node/src/middleware/telemetry.ts
@@ -1,0 +1,121 @@
+/**
+ * @module @arcis/node/middleware/telemetry
+ * Bridges Arcis middleware decisions to a TelemetryClient.
+ * Pattern 3 (two-layer): the client owns transport; this layer owns Express plumbing.
+ */
+
+import type { Request, RequestHandler } from 'express';
+import type { TelemetryClient } from '../telemetry/client';
+import type { TelemetryEvent, TelemetryDecision, TelemetrySeverity } from '../telemetry/types';
+import { SecurityThreatError } from '../core/errors';
+
+/** Marker that inner middleware writes to and the emitter reads from. */
+export interface ArcisTelemetryMarker {
+  vector?: string;
+  rule?: string;
+  severity?: TelemetrySeverity;
+  matchedPattern?: string;
+  reason?: string;
+  /** Pre-decided decision. If absent, the emitter infers from response status. */
+  decision?: TelemetryDecision;
+}
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    /** Per-request marker populated by Arcis middlewares for telemetry attribution. */
+    __arcis?: ArcisTelemetryMarker;
+  }
+}
+
+const THREAT_TO_VECTOR: Record<string, string> = {
+  xss: 'xss',
+  sql_injection: 'sql',
+  nosql_injection: 'nosql',
+  path_traversal: 'path',
+  command_injection: 'command',
+  prototype_pollution: 'prototype',
+  header_injection: 'header',
+  ssti: 'ssti',
+  xxe: 'xxe',
+};
+
+/**
+ * Express middleware that records a telemetry event for every request.
+ * Captures latency from entry, hooks `res.on('finish')`, and infers the
+ * final decision from response status + any `req.__arcis` marker.
+ */
+export function createTelemetryEmitter(client: TelemetryClient): RequestHandler {
+  return (req, res, next) => {
+    const start = performance.now();
+
+    res.on('finish', () => {
+      try {
+        const event = buildEvent(req, res.statusCode, performance.now() - start);
+        client.record(event);
+      } catch {
+        // emit must never break the response — fail-open
+      }
+    });
+
+    next();
+  };
+}
+
+/**
+ * Wraps the sanitizer middleware so SecurityThreatError → req.__arcis marker.
+ * The emitter on `finish` will then have vector/rule/severity attribution.
+ */
+export function tapSanitizerThreats(handler: RequestHandler): RequestHandler {
+  return (req, res, next) => {
+    handler(req, res, (err?: unknown) => {
+      if (err instanceof SecurityThreatError) {
+        const vector = THREAT_TO_VECTOR[err.threatType] ?? err.threatType;
+        req.__arcis = {
+          vector,
+          rule: `${vector}/match`,
+          severity: 'high',
+          matchedPattern: err.pattern,
+          reason: err.message,
+          decision: 'deny',
+        };
+      }
+      next(err);
+    });
+  };
+}
+
+function buildEvent(req: Request, status: number, latencyMs: number): TelemetryEvent {
+  const marker = req.__arcis;
+  const decision = marker?.decision ?? inferDecision(status);
+
+  // Skip 5xx — those are server errors, not security decisions.
+  // Still emit so the dashboard shows traffic, but mark as allow with status >=500.
+  return {
+    ts: new Date().toISOString(),
+    ip: extractIp(req),
+    method: (req.method ?? 'GET').toUpperCase(),
+    path: req.path ?? req.url ?? '/',
+    decision,
+    vector: marker?.vector ?? (status === 429 ? 'rate-limit' : undefined),
+    rule: marker?.rule ?? (status === 429 ? 'rate-limit/exceeded' : undefined),
+    severity: marker?.severity ?? (status === 429 ? 'medium' : undefined),
+    userAgent: typeof req.headers?.['user-agent'] === 'string' ? req.headers['user-agent'] : '',
+    reason: marker?.reason,
+    status,
+    matchedPattern: marker?.matchedPattern,
+    latencyMs: Math.max(0, latencyMs),
+  };
+}
+
+function inferDecision(status: number): TelemetryDecision {
+  if (status === 429) return 'deny';
+  if (status === 400) return 'deny';
+  if (status === 403) return 'deny';
+  return 'allow';
+}
+
+function extractIp(req: Request): string {
+  if (typeof req.ip === 'string' && req.ip.length > 0) return req.ip;
+  const remote = req.socket?.remoteAddress;
+  return typeof remote === 'string' ? remote : '0.0.0.0';
+}

--- a/packages/arcis-node/src/telemetry/client.ts
+++ b/packages/arcis-node/src/telemetry/client.ts
@@ -1,0 +1,214 @@
+import type { TelemetryEvent, TelemetryOptions } from './types';
+
+const DEFAULT_BATCH_SIZE = 50;
+const MAX_BATCH_SIZE = 500; // matches server Zod schema upper bound
+const DEFAULT_FLUSH_INTERVAL_MS = 5000;
+const MIN_FLUSH_INTERVAL_MS = 500;
+const FLUSH_TIMEOUT_MS = 10_000;
+
+type Listener = (err: Error) => void;
+
+/**
+ * In-memory batching client that ships `TelemetryEvent` objects to an
+ * Arcis dashboard server.
+ *
+ * Design rules (spec/API_SPEC.md §9):
+ *   1. `record()` is synchronous and never throws — safe to call from hot paths.
+ *   2. Flushes trigger on batchSize OR flushIntervalMs, whichever comes first.
+ *   3. Network errors are fail-open: they call `onError` (if provided) and
+ *      drop the batch. No retry, no disk persistence, no backpressure.
+ *   4. `close()` attempts one final flush; safe to call multiple times.
+ *   5. Interval timer uses `unref()` so it never holds the process open.
+ */
+export class TelemetryClient {
+  private queue: TelemetryEvent[] = [];
+  private readonly endpoint: string;
+  private readonly apiKey: string | undefined;
+  private readonly workspaceId: string | undefined;
+  private readonly batchSize: number;
+  private readonly flushIntervalMs: number;
+  private readonly onError: Listener;
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private flushing = false;
+  private closed = false;
+  private signalHandler: (() => void) | undefined;
+
+  constructor(options: TelemetryOptions) {
+    if (!options.endpoint || typeof options.endpoint !== 'string') {
+      throw new TypeError('TelemetryClient: `endpoint` is required');
+    }
+
+    this.endpoint = options.endpoint;
+    this.apiKey = options.apiKey;
+    this.workspaceId = options.workspaceId;
+    this.batchSize = clamp(
+      options.batchSize ?? DEFAULT_BATCH_SIZE,
+      1,
+      MAX_BATCH_SIZE,
+    );
+    this.flushIntervalMs = Math.max(
+      options.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS,
+      MIN_FLUSH_INTERVAL_MS,
+    );
+    this.onError = options.onError ?? (() => {
+      // default: swallow silently (fail-open)
+    });
+
+    this.startTimer();
+  }
+
+  /**
+   * Enqueue an event. Fast, synchronous, cannot throw.
+   * Triggers a flush if the queue has reached `batchSize`.
+   */
+  record(event: TelemetryEvent): void {
+    if (this.closed) return;
+    this.queue.push(event);
+    if (this.queue.length >= this.batchSize) {
+      // fire and forget
+      void this.flush();
+    }
+  }
+
+  /**
+   * Manually flush the queue. Pulls up to `batchSize` events into a batch and
+   * POSTs them. Returns a resolved promise on success OR on handled failure.
+   * Never throws.
+   */
+  async flush(): Promise<void> {
+    if (this.flushing) return;
+    if (this.queue.length === 0) return;
+
+    this.flushing = true;
+    try {
+      const batch = this.queue.splice(0, this.batchSize);
+      await this.send(batch);
+    } catch (err) {
+      this.safeNotify(err);
+    } finally {
+      this.flushing = false;
+    }
+
+    // Drain anything that arrived while we were flushing.
+    if (!this.closed && this.queue.length > 0) {
+      void this.flush();
+    }
+  }
+
+  /**
+   * Shut down: stop the interval timer and attempt one final flush.
+   * Safe to call multiple times.
+   */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+
+    if (this.timer !== undefined) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+
+    if (this.signalHandler !== undefined) {
+      process.off('SIGTERM', this.signalHandler);
+      process.off('SIGINT', this.signalHandler);
+      this.signalHandler = undefined;
+    }
+
+    // final best-effort flush
+    try {
+      await this.flush();
+    } catch {
+      // fail-open on shutdown
+    }
+  }
+
+  /**
+   * Register `SIGTERM` / `SIGINT` handlers that call `close()` to drain
+   * the queue on graceful shutdown. Opt-in — libraries should not silently
+   * attach global signal handlers. Safe to call multiple times.
+   */
+  installShutdownHooks(): void {
+    if (this.signalHandler !== undefined || this.closed) return;
+    const handler = (): void => {
+      void this.close();
+    };
+    this.signalHandler = handler;
+    process.once('SIGTERM', handler);
+    process.once('SIGINT', handler);
+  }
+
+  /** Count of events currently waiting to be sent. Useful for tests. */
+  get pendingCount(): number {
+    return this.queue.length;
+  }
+
+  // ── internals ─────────────────────────────────────────────────────────
+
+  private async send(batch: TelemetryEvent[]): Promise<void> {
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+    };
+    if (this.apiKey) headers['authorization'] = `Bearer ${this.apiKey}`;
+    if (this.workspaceId) headers['x-workspace-id'] = this.workspaceId;
+
+    const controller = new AbortController();
+    const abortTimer = setTimeout(() => controller.abort(), FLUSH_TIMEOUT_MS);
+
+    try {
+      const res = await fetch(this.endpoint, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ events: batch }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const text = await safeReadBody(res);
+        throw new TelemetryHttpError(res.status, text);
+      }
+    } finally {
+      clearTimeout(abortTimer);
+    }
+  }
+
+  private startTimer(): void {
+    this.timer = setInterval(() => {
+      void this.flush();
+    }, this.flushIntervalMs);
+
+    // node-only: don't block process exit
+    (this.timer as { unref?: () => void }).unref?.();
+  }
+
+  private safeNotify(err: unknown): void {
+    try {
+      this.onError(err instanceof Error ? err : new Error(String(err)));
+    } catch {
+      // user-provided hook must never bubble up
+    }
+  }
+}
+
+export class TelemetryHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly responseBody: string,
+  ) {
+    super(`Telemetry ingest returned HTTP ${status}`);
+    this.name = 'TelemetryHttpError';
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, Math.trunc(value)));
+}
+
+async function safeReadBody(res: Response): Promise<string> {
+  try {
+    const text = await res.text();
+    return text.slice(0, 500);
+  } catch {
+    return '';
+  }
+}

--- a/packages/arcis-node/src/telemetry/index.ts
+++ b/packages/arcis-node/src/telemetry/index.ts
@@ -1,0 +1,7 @@
+export { TelemetryClient, TelemetryHttpError } from './client';
+export type {
+  TelemetryEvent,
+  TelemetryOptions,
+  TelemetryDecision,
+  TelemetrySeverity,
+} from './types';

--- a/packages/arcis-node/src/telemetry/types.ts
+++ b/packages/arcis-node/src/telemetry/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Telemetry contract — mirrors spec/API_SPEC.md §9 exactly.
+ * Shape accepted by the Arcis dashboard server's POST /v1/events endpoint.
+ */
+
+export type TelemetryDecision = 'allow' | 'deny' | 'challenge';
+
+export type TelemetrySeverity = 'critical' | 'high' | 'medium' | 'low';
+
+/**
+ * A single decision event emitted by the Arcis middleware.
+ * All optional fields are filled server-side with defaults when omitted.
+ */
+export interface TelemetryEvent {
+  /** ISO-8601 timestamp. SDK populates; server falls back to now() if missing. */
+  ts?: string;
+  /** Client IP extracted from the request. */
+  ip: string;
+  /** HTTP method (e.g., "GET", "POST"). */
+  method: string;
+  /** Request path without query string. */
+  path: string;
+  /** Final middleware decision. */
+  decision: TelemetryDecision;
+  /** Attack family (e.g., "xss", "sql", "ssrf"). Null for allowed traffic. */
+  vector?: string;
+  /** Specific rule fired (e.g., "sql/union-select"). */
+  rule?: string;
+  /** Finding severity. */
+  severity?: TelemetrySeverity;
+  /** ISO-3166 alpha-2 country code. */
+  country?: string;
+  /** Request User-Agent header. Server defaults to "" if missing. */
+  userAgent?: string;
+  /** Human-readable explanation for the dashboard. */
+  reason?: string;
+  /** HTTP status code returned by the middleware. Server defaults to 200. */
+  status: number;
+  /** Exact token that triggered the rule (e.g., "UNION SELECT"). */
+  matchedPattern?: string;
+  /** Middleware processing time in milliseconds, fractional. */
+  latencyMs?: number;
+}
+
+/**
+ * User-provided configuration for the telemetry client.
+ * Passed via `telemetry` on the main `ArcisOptions`.
+ */
+export interface TelemetryOptions {
+  /** Full URL of the ingest endpoint, e.g., "https://arcis.mycorp.com/v1/events". */
+  endpoint: string;
+  /** Optional bearer token. Sent as `Authorization: Bearer <apiKey>`. */
+  apiKey?: string;
+  /** Optional workspace id. Sent as `x-workspace-id`. Defaults server-side to "default". */
+  workspaceId?: string;
+  /** Flush when queue reaches this size. Default: 50. Range: 1-500. */
+  batchSize?: number;
+  /** Periodic flush interval in milliseconds. Default: 5000. Minimum: 500. */
+  flushIntervalMs?: number;
+  /** Error hook for network/HTTP failures. If omitted, errors are swallowed silently. */
+  onError?: (err: Error) => void;
+}

--- a/packages/arcis-node/tests/telemetry/client.test.ts
+++ b/packages/arcis-node/tests/telemetry/client.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TelemetryClient, TelemetryHttpError } from '../../src/telemetry/client';
+import type { TelemetryEvent } from '../../src/telemetry/types';
+
+const ENDPOINT = 'http://localhost:3333/v1/events';
+
+function sampleEvent(overrides: Partial<TelemetryEvent> = {}): TelemetryEvent {
+  return {
+    ip: '1.2.3.4',
+    method: 'POST',
+    path: '/api/login',
+    decision: 'deny',
+    vector: 'sql',
+    rule: 'sql/union-select',
+    severity: 'critical',
+    userAgent: 'sqlmap/1.8',
+    status: 403,
+    matchedPattern: 'UNION SELECT',
+    latencyMs: 0.42,
+    ...overrides,
+  };
+}
+
+function okResponse(): Response {
+  return new Response(JSON.stringify({ inserted: 1 }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('TelemetryClient', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn().mockResolvedValue(okResponse());
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('construction', () => {
+    it('throws if endpoint is missing', () => {
+      expect(() => new TelemetryClient({ endpoint: '' })).toThrow(/endpoint/);
+    });
+
+    it('clamps batchSize into [1, 500]', async () => {
+      const tooBig = new TelemetryClient({ endpoint: ENDPOINT, batchSize: 99_999 });
+      // push 501 — should still only flush 500 at a time since we clamp
+      for (let i = 0; i < 501; i++) tooBig.record(sampleEvent());
+      await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+      const [, init] = fetchSpy.mock.calls[0]!;
+      const body = JSON.parse(init.body as string);
+      expect(body.events.length).toBe(500);
+      await tooBig.close();
+    });
+
+    it('clamps flushIntervalMs to minimum 500ms', () => {
+      const c = new TelemetryClient({ endpoint: ENDPOINT, flushIntervalMs: 10 });
+      expect((c as unknown as { flushIntervalMs: number }).flushIntervalMs).toBe(500);
+    });
+  });
+
+  describe('record + batch flush', () => {
+    it('flushes when queue reaches batchSize', async () => {
+      const client = new TelemetryClient({ endpoint: ENDPOINT, batchSize: 3 });
+      client.record(sampleEvent({ ip: '1.1.1.1' }));
+      client.record(sampleEvent({ ip: '2.2.2.2' }));
+      expect(fetchSpy).not.toHaveBeenCalled();
+      client.record(sampleEvent({ ip: '3.3.3.3' }));
+
+      await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+      const [url, init] = fetchSpy.mock.calls[0]!;
+      expect(url).toBe(ENDPOINT);
+      expect(init.method).toBe('POST');
+      const body = JSON.parse(init.body as string);
+      expect(body.events).toHaveLength(3);
+      expect(body.events[0].ip).toBe('1.1.1.1');
+      await client.close();
+    });
+
+    it('includes authorization and workspace headers when configured', async () => {
+      const client = new TelemetryClient({
+        endpoint: ENDPOINT,
+        apiKey: 'secret-token',
+        workspaceId: 'team-alpha',
+        batchSize: 1,
+      });
+      client.record(sampleEvent());
+      await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+      const [, init] = fetchSpy.mock.calls[0]!;
+      expect(init.headers['authorization']).toBe('Bearer secret-token');
+      expect(init.headers['x-workspace-id']).toBe('team-alpha');
+      expect(init.headers['content-type']).toBe('application/json');
+      await client.close();
+    });
+
+    it('omits optional headers when not configured', async () => {
+      const client = new TelemetryClient({ endpoint: ENDPOINT, batchSize: 1 });
+      client.record(sampleEvent());
+      await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+      const [, init] = fetchSpy.mock.calls[0]!;
+      expect(init.headers['authorization']).toBeUndefined();
+      expect(init.headers['x-workspace-id']).toBeUndefined();
+      await client.close();
+    });
+
+    it('record is synchronous and does not throw even with bad endpoint', () => {
+      const client = new TelemetryClient({
+        endpoint: 'http://127.0.0.1:1/does-not-exist',
+        batchSize: 1,
+      });
+      expect(() => client.record(sampleEvent())).not.toThrow();
+      void client.close();
+    });
+  });
+
+  describe('interval flush', () => {
+    it('flushes partial batch when flushIntervalMs elapses', async () => {
+      vi.useFakeTimers();
+      const client = new TelemetryClient({
+        endpoint: ENDPOINT,
+        batchSize: 100,
+        flushIntervalMs: 500,
+      });
+      client.record(sampleEvent());
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [, init] = fetchSpy.mock.calls[0]!;
+      const body = JSON.parse(init.body as string);
+      expect(body.events).toHaveLength(1);
+
+      await client.close();
+    });
+
+    it('does not fire the timer when queue is empty', async () => {
+      vi.useFakeTimers();
+      const client = new TelemetryClient({
+        endpoint: ENDPOINT,
+        batchSize: 100,
+        flushIntervalMs: 500,
+      });
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      await client.close();
+    });
+  });
+
+  describe('fail-open on errors', () => {
+    it('invokes onError on non-2xx response and drops the batch', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response('server exploded', { status: 500 }),
+      );
+      const onError = vi.fn();
+      const client = new TelemetryClient({ endpoint: ENDPOINT, batchSize: 1, onError });
+
+      client.record(sampleEvent());
+
+      await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+      const err = onError.mock.calls[0]![0] as Error;
+      expect(err).toBeInstanceOf(TelemetryHttpError);
+      expect((err as TelemetryHttpError).status).toBe(500);
+      expect(client.pendingCount).toBe(0);
+      await client.close();
+    });
+
+    it('invokes onError on network rejection', async () => {
+      fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      const onError = vi.fn();
+      const client = new TelemetryClient({ endpoint: ENDPOINT, batchSize: 1, onError });
+
+      client.record(sampleEvent());
+
+      await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+      const err = onError.mock.calls[0]![0] as Error;
+      expect(err.message).toContain('ECONNREFUSED');
+      await client.close();
+    });
+
+    it('silently swallows errors when no onError is provided', async () => {
+      fetchSpy.mockRejectedValueOnce(new Error('network down'));
+      const client = new TelemetryClient({ endpoint: ENDPOINT, batchSize: 1 });
+      client.record(sampleEvent());
+
+      // no exception — and queue is drained
+      await vi.waitFor(() => expect(client.pendingCount).toBe(0));
+      await client.close();
+    });
+
+    it('swallows exceptions thrown from a user onError hook', async () => {
+      fetchSpy.mockRejectedValueOnce(new Error('boom'));
+      const client = new TelemetryClient({
+        endpoint: ENDPOINT,
+        batchSize: 1,
+        onError: () => {
+          throw new Error('user hook exploded');
+        },
+      });
+
+      // must not throw
+      expect(() => client.record(sampleEvent())).not.toThrow();
+      await vi.waitFor(() => expect(client.pendingCount).toBe(0));
+      await client.close();
+    });
+  });
+
+  describe('close()', () => {
+    it('attempts a final flush', async () => {
+      const client = new TelemetryClient({ endpoint: ENDPOINT, batchSize: 100 });
+      client.record(sampleEvent());
+      client.record(sampleEvent());
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      await client.close();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [, init] = fetchSpy.mock.calls[0]!;
+      const body = JSON.parse(init.body as string);
+      expect(body.events).toHaveLength(2);
+    });
+
+    it('stops the interval timer', async () => {
+      vi.useFakeTimers();
+      const client = new TelemetryClient({
+        endpoint: ENDPOINT,
+        batchSize: 100,
+        flushIntervalMs: 500,
+      });
+      await client.close();
+
+      // queue an event after close — the timer should not fire again
+      // (we also don't allow record to add after close)
+      client.record(sampleEvent());
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('is safe to call more than once', async () => {
+      const client = new TelemetryClient({ endpoint: ENDPOINT, batchSize: 100 });
+      await client.close();
+      await client.close();
+      await client.close();
+      // no assertion — the test passes if no throw happens
+    });
+
+    it('ignores record() calls made after close', () => {
+      const client = new TelemetryClient({ endpoint: ENDPOINT, batchSize: 1 });
+      void client.close();
+      client.record(sampleEvent());
+      expect(client.pendingCount).toBe(0);
+    });
+  });
+
+  describe('installShutdownHooks()', () => {
+    it('flushes pending events when SIGTERM fires', async () => {
+      const client = new TelemetryClient({ endpoint: ENDPOINT, batchSize: 100 });
+      client.installShutdownHooks();
+      client.record(sampleEvent());
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      process.emit('SIGTERM');
+
+      await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+      // close() was called by the handler — calling again is a no-op
+      await client.close();
+    });
+
+    it('detaches handlers on close to avoid leaks', async () => {
+      const before = process.listenerCount('SIGTERM');
+      const client = new TelemetryClient({ endpoint: ENDPOINT });
+      client.installShutdownHooks();
+      expect(process.listenerCount('SIGTERM')).toBe(before + 1);
+      await client.close();
+      expect(process.listenerCount('SIGTERM')).toBe(before);
+    });
+
+    it('is idempotent when called multiple times', async () => {
+      const before = process.listenerCount('SIGTERM');
+      const client = new TelemetryClient({ endpoint: ENDPOINT });
+      client.installShutdownHooks();
+      client.installShutdownHooks();
+      client.installShutdownHooks();
+      expect(process.listenerCount('SIGTERM')).toBe(before + 1);
+      await client.close();
+    });
+  });
+
+  describe('event body shape', () => {
+    it('wraps events in { events: [...] } to match server Zod schema', async () => {
+      const client = new TelemetryClient({ endpoint: ENDPOINT, batchSize: 1 });
+      const evt = sampleEvent({
+        ts: '2026-04-23T04:00:00.000Z',
+        country: 'RU',
+        reason: 'UNION SELECT pattern in body',
+      });
+      client.record(evt);
+
+      await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+      const [, init] = fetchSpy.mock.calls[0]!;
+      const body = JSON.parse(init.body as string);
+
+      expect(body).toHaveProperty('events');
+      expect(Array.isArray(body.events)).toBe(true);
+      expect(body.events).toHaveLength(1);
+      expect(body.events[0]).toMatchObject({
+        ts: '2026-04-23T04:00:00.000Z',
+        ip: '1.2.3.4',
+        method: 'POST',
+        path: '/api/login',
+        decision: 'deny',
+        vector: 'sql',
+        rule: 'sql/union-select',
+        severity: 'critical',
+        country: 'RU',
+        reason: 'UNION SELECT pattern in body',
+        status: 403,
+        matchedPattern: 'UNION SELECT',
+        latencyMs: 0.42,
+      });
+      await client.close();
+    });
+
+    it('does not drop a spec-defined field from TelemetryEvent', async () => {
+      const client = new TelemetryClient({ endpoint: ENDPOINT, batchSize: 1 });
+      const allFields: TelemetryEvent = {
+        ts: '2026-04-23T04:00:00.000Z',
+        ip: '9.9.9.9',
+        method: 'PUT',
+        path: '/api/x',
+        decision: 'challenge',
+        vector: 'bot',
+        rule: 'bot/scanner',
+        severity: 'medium',
+        country: 'DE',
+        userAgent: 'nikto',
+        reason: 'scanner ua',
+        status: 429,
+        matchedPattern: 'Nikto',
+        latencyMs: 0.77,
+      };
+      client.record(allFields);
+
+      await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+      const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+      // every key we wrote must round-trip through JSON.stringify intact
+      expect(body.events[0]).toEqual(allFields);
+      await client.close();
+    });
+  });
+});

--- a/packages/arcis-node/tests/telemetry/env-pickup.test.ts
+++ b/packages/arcis-node/tests/telemetry/env-pickup.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Stage 1 — env-var auto-pickup for telemetry.
+ *
+ * arcis() should auto-build TelemetryOptions from ARCIS_ENDPOINT /
+ * ARCIS_WORKSPACE_ID / ARCIS_KEY when no explicit `telemetry` config is
+ * passed. Explicit config must always win.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+import arcis from '../../src/index';
+import type { TelemetryEvent } from '../../src/telemetry/types';
+
+function buildIngestServer(received: TelemetryEvent[]): Promise<{ url: string; close: () => Promise<void> }> {
+  const app = express();
+  app.use(express.json());
+  app.post('/v1/events', (req, res) => {
+    const body = req.body as { events: TelemetryEvent[] };
+    for (const e of body.events ?? []) received.push(e);
+    res.json({ inserted: body.events?.length ?? 0 });
+  });
+  return new Promise((resolve) => {
+    const server = createServer(app);
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}/v1/events`,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+function buildAppServer(setup: (app: express.Express) => void): Promise<{ url: string; close: () => Promise<void> }> {
+  const app = express();
+  app.use(express.json());
+  setup(app);
+  return new Promise((resolve) => {
+    const server: Server = createServer(app);
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+const cleanups: Array<() => Promise<void> | void> = [];
+const originalEnv = { ...process.env };
+
+afterEach(async () => {
+  for (const fn of cleanups.splice(0)) await fn();
+  // restore env
+  for (const k of ['ARCIS_ENDPOINT', 'ARCIS_WORKSPACE_ID', 'ARCIS_KEY']) {
+    if (originalEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = originalEnv[k];
+  }
+});
+
+describe('Stage 1 — env-var auto-pickup', () => {
+  it('picks up ARCIS_ENDPOINT and emits events without explicit telemetry config', async () => {
+    const received: TelemetryEvent[] = [];
+    const ingest = await buildIngestServer(received);
+    cleanups.push(ingest.close);
+
+    process.env.ARCIS_ENDPOINT = ingest.url;
+    process.env.ARCIS_WORKSPACE_ID = 'ws_env';
+    process.env.ARCIS_KEY = 'envkey';
+    process.env.ARCIS_BATCH_SIZE = '1';
+    process.env.ARCIS_FLUSH_INTERVAL_MS = '500';
+
+    const stack = arcis({
+      // NOTE: no telemetry block — should be picked up from env
+      sanitize: false,
+      rateLimit: false,
+      headers: false,
+    });
+    cleanups.push(() => stack.close());
+
+    const appServer = await buildAppServer((a) => {
+      if (stack.length > 0) a.use(...stack);
+      a.get('/api/ok', (_req, res) => res.json({ ok: true }));
+    });
+    cleanups.push(appServer.close);
+
+    const resp = await fetch(`${appServer.url}/api/ok`);
+    expect(resp.status).toBe(200);
+
+    await vi.waitFor(() => expect(received.length).toBeGreaterThanOrEqual(1), {
+      timeout: 5000,
+    });
+    expect(received[0].path).toBe('/api/ok');
+    expect(received[0].decision).toBe('allow');
+  }, 10_000);
+
+  it('stays inert when no ARCIS_* env vars are set and no explicit config', async () => {
+    delete process.env.ARCIS_ENDPOINT;
+    delete process.env.ARCIS_WORKSPACE_ID;
+    delete process.env.ARCIS_KEY;
+
+    const stack = arcis({
+      sanitize: false,
+      rateLimit: false,
+      headers: false,
+    });
+    cleanups.push(() => stack.close());
+
+    // The stack should run cleanly. We can't directly inspect "no telemetry
+    // client" without breaking encapsulation, so the proof is: this resolves
+    // without any telemetry POST and without any onError firing.
+    const appServer = await buildAppServer((a) => {
+      if (stack.length > 0) a.use(...stack);
+      a.get('/api/ok', (_req, res) => res.json({ ok: true }));
+    });
+    cleanups.push(appServer.close);
+
+    const resp = await fetch(`${appServer.url}/api/ok`);
+    expect(resp.status).toBe(200);
+  }, 10_000);
+
+  it('explicit telemetry config wins over env vars', async () => {
+    const envIngest = await buildIngestServer([]);
+    const explicitIngest: TelemetryEvent[] = [];
+    const explicit = await buildIngestServer(explicitIngest);
+    cleanups.push(envIngest.close, explicit.close);
+
+    // env points at envIngest, but we pass an explicit config pointing at explicit
+    process.env.ARCIS_ENDPOINT = envIngest.url;
+    process.env.ARCIS_WORKSPACE_ID = 'ws_env';
+
+    const stack = arcis({
+      sanitize: false,
+      rateLimit: false,
+      headers: false,
+      telemetry: {
+        endpoint: explicit.url,
+        workspaceId: 'ws_explicit',
+        batchSize: 1,
+        flushIntervalMs: 500,
+      },
+    });
+    cleanups.push(() => stack.close());
+
+    const appServer = await buildAppServer((a) => {
+      if (stack.length > 0) a.use(...stack);
+      a.get('/api/ok', (_req, res) => res.json({ ok: true }));
+    });
+    cleanups.push(appServer.close);
+
+    await fetch(`${appServer.url}/api/ok`);
+
+    await vi.waitFor(() => expect(explicitIngest.length).toBeGreaterThanOrEqual(1), {
+      timeout: 5000,
+    });
+  }, 10_000);
+
+  it('partial env (workspace + key without endpoint) does not activate telemetry', async () => {
+    delete process.env.ARCIS_ENDPOINT;
+    process.env.ARCIS_WORKSPACE_ID = 'ws_env';
+    process.env.ARCIS_KEY = 'envkey';
+
+    const stack = arcis({
+      sanitize: false,
+      rateLimit: false,
+      headers: false,
+    });
+    cleanups.push(() => stack.close());
+
+    // Just confirm no crash and no errors — telemetry must remain off without
+    // an endpoint. Same shape as the "no env" test above.
+    const appServer = await buildAppServer((a) => {
+      if (stack.length > 0) a.use(...stack);
+      a.get('/api/ok', (_req, res) => res.json({ ok: true }));
+    });
+    cleanups.push(appServer.close);
+
+    const resp = await fetch(`${appServer.url}/api/ok`);
+    expect(resp.status).toBe(200);
+  }, 10_000);
+});

--- a/packages/arcis-node/tests/telemetry/middleware.test.ts
+++ b/packages/arcis-node/tests/telemetry/middleware.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Phase 8: middleware integration — verifies arcis() emits TelemetryEvents
+ * for allow / rate-limit deny / sanitizer deny decisions.
+ */
+
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+import arcis from '../../src/index';
+import type { TelemetryEvent } from '../../src/telemetry/types';
+
+function buildIngestServer(received: TelemetryEvent[]): Promise<{ url: string; close: () => Promise<void> }> {
+  const app = express();
+  app.use(express.json());
+  app.post('/v1/events', (req, res) => {
+    const body = req.body as { events: TelemetryEvent[] };
+    for (const e of body.events ?? []) received.push(e);
+    res.json({ inserted: body.events?.length ?? 0 });
+  });
+  return new Promise((resolve) => {
+    const server = createServer(app);
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}/v1/events`,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+function buildAppServer(setup: (app: express.Express) => void): Promise<{ url: string; close: () => Promise<void> }> {
+  const app = express();
+  app.use(express.json());
+  setup(app);
+  // Express error handler so SecurityThreatError → 400, not 500
+  app.use((err: { statusCode?: number; message?: string }, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(err.statusCode ?? 500).json({ error: err.message ?? 'error' });
+  });
+  return new Promise((resolve) => {
+    const server: Server = createServer(app);
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+const cleanups: Array<() => Promise<void> | void> = [];
+afterEach(async () => {
+  for (const fn of cleanups.splice(0)) await fn();
+});
+
+describe('Phase 8: telemetry middleware integration', () => {
+  it('emits an allow event for a clean request', async () => {
+    const received: TelemetryEvent[] = [];
+    const ingest = await buildIngestServer(received);
+    cleanups.push(ingest.close);
+
+    const stack = arcis({
+      rateLimit: { max: 100 },
+      telemetry: { endpoint: ingest.url, batchSize: 1, flushIntervalMs: 500 },
+    });
+    cleanups.push(() => stack.close());
+
+    const app = await buildAppServer((a) => {
+      a.use(...stack);
+      a.get('/ping', (_req, res) => res.json({ ok: true }));
+    });
+    cleanups.push(app.close);
+
+    const res = await fetch(`${app.url}/ping`);
+    expect(res.status).toBe(200);
+
+    // wait for the batch=1 flush
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    expect(received[0]).toMatchObject({
+      decision: 'allow',
+      method: 'GET',
+      path: '/ping',
+      status: 200,
+    });
+    expect(received[0].latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('emits a deny event with vector="rate-limit" when limit is exceeded', async () => {
+    const received: TelemetryEvent[] = [];
+    const ingest = await buildIngestServer(received);
+    cleanups.push(ingest.close);
+
+    const stack = arcis({
+      rateLimit: { max: 1, windowMs: 60_000 },
+      telemetry: { endpoint: ingest.url, batchSize: 1, flushIntervalMs: 500 },
+    });
+    cleanups.push(() => stack.close());
+
+    const app = await buildAppServer((a) => {
+      a.use(...stack);
+      a.get('/x', (_req, res) => res.json({ ok: true }));
+    });
+    cleanups.push(app.close);
+
+    await fetch(`${app.url}/x`); // first allowed
+    const denied = await fetch(`${app.url}/x`); // second blocked
+    expect(denied.status).toBe(429);
+
+    await vi.waitFor(() =>
+      expect(received.find((e) => e.decision === 'deny')).toBeDefined(),
+    );
+
+    const denyEvent = received.find((e) => e.decision === 'deny');
+    expect(denyEvent).toMatchObject({
+      decision: 'deny',
+      vector: 'rate-limit',
+      rule: 'rate-limit/exceeded',
+      severity: 'medium',
+      status: 429,
+    });
+  });
+
+  it('emits a deny event with vector="sql" when sanitizer rejects SQL injection', async () => {
+    const received: TelemetryEvent[] = [];
+    const ingest = await buildIngestServer(received);
+    cleanups.push(ingest.close);
+
+    const stack = arcis({
+      rateLimit: false,
+      sanitize: { mode: 'reject' },
+      telemetry: { endpoint: ingest.url, batchSize: 1, flushIntervalMs: 500 },
+    });
+    cleanups.push(() => stack.close());
+
+    const app = await buildAppServer((a) => {
+      a.use(...stack);
+      a.post('/login', (_req, res) => res.json({ ok: true }));
+    });
+    cleanups.push(app.close);
+
+    const res = await fetch(`${app.url}/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ user: "admin' UNION SELECT * FROM users --" }),
+    });
+    expect(res.status).toBe(400);
+
+    await vi.waitFor(() =>
+      expect(received.find((e) => e.decision === 'deny')).toBeDefined(),
+    );
+
+    const denyEvent = received.find((e) => e.decision === 'deny');
+    expect(denyEvent?.vector).toBe('sql');
+    expect(denyEvent?.severity).toBe('high');
+    expect(denyEvent?.matchedPattern).toBeTruthy();
+  });
+
+  it('zero overhead when telemetry option is omitted (no client created)', async () => {
+    const received: TelemetryEvent[] = [];
+    const ingest = await buildIngestServer(received);
+    cleanups.push(ingest.close);
+
+    // No telemetry option = no emitter, no client, no fetch to ingest
+    const stack = arcis({ rateLimit: { max: 100 } });
+    cleanups.push(() => stack.close());
+
+    const app = await buildAppServer((a) => {
+      a.use(...stack);
+      a.get('/ping', (_req, res) => res.json({ ok: true }));
+    });
+    cleanups.push(app.close);
+
+    await fetch(`${app.url}/ping`);
+    // Negative assertion: keep a fixed wait — vi.waitFor cannot prove non-emission.
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(received).toHaveLength(0);
+  });
+
+  it('stack.close() drains the telemetry queue', async () => {
+    const received: TelemetryEvent[] = [];
+    const ingest = await buildIngestServer(received);
+    cleanups.push(ingest.close);
+
+    const stack = arcis({
+      telemetry: { endpoint: ingest.url, batchSize: 100, flushIntervalMs: 60_000 },
+    });
+
+    const app = await buildAppServer((a) => {
+      a.use(...stack);
+      a.get('/ping', (_req, res) => res.json({ ok: true }));
+    });
+    cleanups.push(app.close);
+
+    await fetch(`${app.url}/ping`);
+    await fetch(`${app.url}/ping`);
+
+    // Without close(), the batch=100 + 60s interval means nothing has shipped yet.
+    expect(received).toHaveLength(0);
+
+    stack.close();
+    await vi.waitFor(() => expect(received).toHaveLength(2));
+
+    expect(received).toHaveLength(2);
+    for (const e of received) expect(e.decision).toBe('allow');
+  });
+});

--- a/packages/arcis-node/tests/telemetry/parity.test.ts
+++ b/packages/arcis-node/tests/telemetry/parity.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Phase 9: cross-SDK parity vectors.
+ * Loads spec/TEST_VECTORS.json → telemetry.middleware_emission and runs each
+ * case through arcis(). Python and Go SDKs replay the same cases.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import express from 'express';
+import { createServer } from 'http';
+import type { AddressInfo } from 'net';
+import arcis from '../../src/index';
+import type { TelemetryEvent } from '../../src/telemetry/types';
+
+interface ParityCase {
+  name: string;
+  config: Record<string, unknown>;
+  request: {
+    method: string;
+    path: string;
+    body?: Record<string, unknown>;
+    repeat?: number;
+  };
+  compare_event_index?: number;
+  expected_event: Partial<TelemetryEvent>;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const VECTORS_PATH = resolve(__dirname, '..', '..', '..', '..', 'spec', 'TEST_VECTORS.json');
+
+const vectors = JSON.parse(readFileSync(VECTORS_PATH, 'utf8')) as {
+  telemetry: { middleware_emission: { compared_fields: string[]; cases: ParityCase[] } };
+};
+
+const cleanups: Array<() => Promise<void> | void> = [];
+afterEach(async () => {
+  for (const fn of cleanups.splice(0)) await fn();
+});
+
+async function buildIngest(received: TelemetryEvent[]) {
+  const app = express();
+  app.use(express.json());
+  app.post('/v1/events', (req, res) => {
+    for (const e of (req.body as { events: TelemetryEvent[] }).events ?? []) received.push(e);
+    res.json({ inserted: 1 });
+  });
+  return new Promise<{ url: string; close: () => Promise<void> }>((resolve) => {
+    const server = createServer(app);
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}/v1/events`,
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+async function buildAppWithArcis(arcisConfig: Record<string, unknown>) {
+  const stack = arcis(arcisConfig);
+  const app = express();
+  app.use(express.json());
+  app.use(...stack);
+  app.use((_req, res) => res.json({ ok: true }));
+  app.use((err: { statusCode?: number; message?: string }, _req: express.Request, res: express.Response, _n: express.NextFunction) => {
+    res.status(err.statusCode ?? 500).json({ error: err.message ?? 'error' });
+  });
+  return new Promise<{ url: string; close: () => Promise<void>; stack: typeof stack }>((resolve) => {
+    const server = createServer(app);
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        stack,
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe('Phase 9: cross-SDK parity (middleware_emission)', () => {
+  const compared = vectors.telemetry.middleware_emission.compared_fields;
+
+  for (const c of vectors.telemetry.middleware_emission.cases) {
+    it(`emits expected event for "${c.name}"`, async () => {
+      const received: TelemetryEvent[] = [];
+      const ingest = await buildIngest(received);
+      cleanups.push(ingest.close);
+
+      const config = {
+        ...c.config,
+        telemetry: { endpoint: ingest.url, batchSize: 1, flushIntervalMs: 500 },
+      };
+      const app = await buildAppWithArcis(config);
+      cleanups.push(() => app.stack.close());
+      cleanups.push(app.close);
+
+      const repeat = c.request.repeat ?? 1;
+      for (let i = 0; i < repeat; i++) {
+        await fetch(`${app.url}${c.request.path}`, {
+          method: c.request.method,
+          headers: c.request.body ? { 'content-type': 'application/json' } : undefined,
+          body: c.request.body ? JSON.stringify(c.request.body) : undefined,
+        });
+      }
+
+      const idx = c.compare_event_index ?? 0;
+      await vi.waitFor(
+        () =>
+          expect(
+            received[idx],
+            `no event at index ${idx} (received ${received.length})`,
+          ).toBeDefined(),
+      );
+      const event = received[idx]!;
+
+      for (const field of compared) {
+        const expected = (c.expected_event as Record<string, unknown>)[field];
+        if (expected === undefined) continue;
+        expect(event[field as keyof TelemetryEvent]).toBe(expected);
+      }
+    });
+  }
+});

--- a/packages/arcis-python/arcis/__init__.py
+++ b/packages/arcis-python/arcis/__init__.py
@@ -164,7 +164,7 @@ try:
 except ImportError:
     _HAS_ASYNC = False
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 __all__ = [
     # Main class
     "Arcis",

--- a/packages/arcis-python/arcis/fastapi.py
+++ b/packages/arcis-python/arcis/fastapi.py
@@ -17,8 +17,16 @@ from .sanitizers.sanitize import Sanitizer
 from .middleware.rate_limit import RateLimiter, RateLimitExceeded
 from .middleware.headers import SecurityHeaders
 from .middleware.error_handler import ErrorHandler
+from .middleware.telemetry import (
+    ArcisTelemetryMarker,
+    build_event,
+    extract_starlette_ip,
+)
 from .core.types import RateLimitEntry
 from .core.constants import DEFAULT_MAX_REQUESTS, DEFAULT_WINDOW_MS, DEFAULT_RATE_LIMIT_MESSAGE
+from .telemetry.client import AsyncTelemetryClient
+from .telemetry.types import TelemetryOptions
+from .middleware.telemetry import telemetry_options_from_env as _telemetry_options_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -386,6 +394,9 @@ class ArcisMiddleware(BaseHTTPMiddleware):
         async_rate_limiter: Optional[AsyncRateLimiter] = None,  # NEW
         security_headers: Optional[SecurityHeaders] = None,
         error_handler: Optional[ErrorHandler] = None,
+        # Telemetry: dict, TelemetryOptions, or pre-built AsyncTelemetryClient.
+        # When None, telemetry is fully disabled (zero overhead).
+        telemetry: Optional[Any] = None,
     ):
         super().__init__(app)
         
@@ -423,11 +434,59 @@ class ArcisMiddleware(BaseHTTPMiddleware):
         self.error_handler = error_handler or (ErrorHandler(
             is_dev=is_dev,
         ) if error_handling else None)
-    
+
+        # ── Telemetry wiring ───────────────────────────────────────────────
+        # Accept four shapes for `telemetry`:
+        #   1. AsyncTelemetryClient — used as-is (caller-managed lifecycle)
+        #   2. TelemetryOptions     — wrap in a new client we own
+        #   3. dict                 — convert to TelemetryOptions, then wrap
+        #   4. None                 — fall back to ARCIS_* env vars; if those
+        #                             aren't set either, telemetry is fully
+        #                             disabled with zero overhead.
+        self._telemetry_client: Optional[AsyncTelemetryClient] = None
+        self._owns_telemetry_client: bool = False
+        if telemetry is None:
+            telemetry = _telemetry_options_from_env()
+        if telemetry is not None:
+            if isinstance(telemetry, AsyncTelemetryClient):
+                self._telemetry_client = telemetry
+            elif isinstance(telemetry, TelemetryOptions):
+                self._telemetry_client = AsyncTelemetryClient(telemetry)
+                self._owns_telemetry_client = True
+            elif isinstance(telemetry, dict):
+                self._telemetry_client = AsyncTelemetryClient(TelemetryOptions(**telemetry))
+                self._owns_telemetry_client = True
+            else:
+                raise TypeError(
+                    "ArcisMiddleware.telemetry must be AsyncTelemetryClient, "
+                    "TelemetryOptions, dict, or None"
+                )
+
+    async def close(self) -> None:
+        """Drain telemetry queue and stop the background flush task.
+
+        Only closes the client if this middleware created it (caller-supplied
+        clients are left alone — caller manages their lifecycle).
+        """
+        if self._telemetry_client is not None and self._owns_telemetry_client:
+            try:
+                await self._telemetry_client.close()
+            except Exception:
+                # fail-open on shutdown
+                pass
+
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        # Telemetry: start latency clock + give inner middleware a place to
+        # write attribution. The marker is only created when telemetry is
+        # active so the request.state surface stays clean otherwise.
+        telemetry_start: Optional[float] = None
+        if self._telemetry_client is not None:
+            telemetry_start = time.perf_counter()
+            request.state.__arcis = ArcisTelemetryMarker()
+
         # Rate limiting (async or sync)
         rate_limit_info = None
-        
+
         if self.async_rate_limiter:
             try:
                 rate_limit_info = await self.async_rate_limiter.check(request)
@@ -437,6 +496,7 @@ class ArcisMiddleware(BaseHTTPMiddleware):
                     status_code=429,
                 )
                 response.headers["Retry-After"] = str(e.retry_after)
+                self._maybe_record(request, response, telemetry_start)
                 return response
         elif self.rate_limiter:
             try:
@@ -447,6 +507,7 @@ class ArcisMiddleware(BaseHTTPMiddleware):
                     status_code=429,
                 )
                 response.headers["Retry-After"] = str(e.retry_after)
+                self._maybe_record(request, response, telemetry_start)
                 return response
         
         # Store sanitized body in request state if JSON
@@ -492,8 +553,48 @@ class ArcisMiddleware(BaseHTTPMiddleware):
         # Remove fingerprinting headers
         if "server" in response.headers:
             del response.headers["server"]
-        
+
+        # Telemetry: emit AFTER all response mutation has settled so latency
+        # and final status reflect what the client actually sees.
+        self._maybe_record(request, response, telemetry_start)
+
         return response
+
+    def _maybe_record(
+        self,
+        request: Request,
+        response: Response,
+        start: Optional[float],
+    ) -> None:
+        """Build and record a TelemetryEvent if telemetry is configured.
+
+        Never raises — telemetry must not affect the response. ``start`` is
+        ``None`` when telemetry is disabled, in which case this is a no-op.
+        """
+        if self._telemetry_client is None or start is None:
+            return
+        try:
+            from datetime import datetime, timezone
+
+            latency_ms = (time.perf_counter() - start) * 1000.0
+            marker: Optional[ArcisTelemetryMarker] = getattr(
+                request.state, "__arcis", None
+            )
+            user_agent = request.headers.get("user-agent", "") if hasattr(request, "headers") else ""
+            event = build_event(
+                ip=extract_starlette_ip(request),
+                method=request.method,
+                path=request.url.path if hasattr(request, "url") else "/",
+                status=response.status_code,
+                user_agent=user_agent,
+                latency_ms=latency_ms,
+                marker=marker,
+                ts=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            )
+            self._telemetry_client.record(event)
+        except Exception:
+            # fail-open: telemetry must never break a response
+            return
 
 
 # ============================================================================

--- a/packages/arcis-python/arcis/middleware/telemetry.py
+++ b/packages/arcis-python/arcis/middleware/telemetry.py
@@ -1,0 +1,214 @@
+"""
+Telemetry middleware bridge — Python parity with
+packages/arcis-node/src/middleware/telemetry.ts.
+
+Provides helpers used by the FastAPI/Starlette adapter (``arcis.fastapi``) and
+the WSGI adapter (``arcis.middleware.main.Arcis`` -> Flask) to:
+
+* attach a per-request attribution marker (vector, rule, severity, decision,
+  matched_pattern, reason)
+* infer the final decision from the response status when no marker is set
+* build a ``TelemetryEvent`` with the captured latency
+* hand the event to a ``TelemetryClient`` / ``AsyncTelemetryClient``
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from ..telemetry.types import (
+    TelemetryDecision,
+    TelemetryEvent,
+    TelemetryOptions,
+    TelemetrySeverity,
+)
+
+
+# Map internal threat-type names (raised by sanitizers) to the public
+# ``vector`` taxonomy used in the dashboard. Mirrors Node's THREAT_TO_VECTOR.
+_THREAT_TO_VECTOR: dict[str, str] = {
+    "xss": "xss",
+    "sql_injection": "sql",
+    "nosql_injection": "nosql",
+    "path_traversal": "path",
+    "command_injection": "command",
+    "prototype_pollution": "prototype",
+    "header_injection": "header",
+    "ssti": "ssti",
+    "xxe": "xxe",
+}
+
+
+@dataclass
+class ArcisTelemetryMarker:
+    """Per-request attribution written by inner middlewares (sanitizer,
+    rate limiter, validators) and read by the emitter on response complete.
+
+    On Starlette/FastAPI: stored at ``request.state.__arcis``.
+    On Flask:             stored at ``flask.g.__arcis``.
+
+    A marker is optional. If absent, the emitter infers ``decision`` from the
+    response status code (see ``infer_decision``).
+    """
+
+    vector: Optional[str] = None
+    rule: Optional[str] = None
+    severity: Optional[TelemetrySeverity] = None
+    matched_pattern: Optional[str] = None
+    reason: Optional[str] = None
+    decision: Optional[TelemetryDecision] = None
+
+
+def threat_to_vector(threat_type: str) -> str:
+    """Map a sanitizer threat name to the public vector taxonomy.
+
+    Unknown threat types pass through unchanged so new sanitizers can ship
+    without updating this map first.
+    """
+    return _THREAT_TO_VECTOR.get(threat_type, threat_type)
+
+
+def infer_decision(status: int) -> TelemetryDecision:
+    """Default decision when no marker was set.
+
+    Mirrors Node's inferDecision: 400/403/429 -> ``deny``, everything else
+    treated as ``allow``. The middleware is free to set an explicit decision
+    via the marker for cases that don't fit (e.g. ``challenge`` on a sanitize-
+    in-place rewrite that returned 200).
+    """
+    if status in (400, 403, 429):
+        return "deny"
+    return "allow"
+
+
+def build_event(
+    *,
+    ip: str,
+    method: str,
+    path: str,
+    status: int,
+    user_agent: str,
+    latency_ms: float,
+    marker: Optional[ArcisTelemetryMarker],
+    ts: Optional[str] = None,
+) -> TelemetryEvent:
+    """Assemble a TelemetryEvent from request metadata + an optional marker.
+
+    Keeps the inference rules in one place so sync (Flask) and async
+    (FastAPI) emitters stay in sync.
+    """
+    decision: TelemetryDecision
+    vector: Optional[str]
+    rule: Optional[str]
+    severity: Optional[TelemetrySeverity]
+    matched_pattern: Optional[str]
+    reason: Optional[str]
+
+    if marker is not None:
+        decision = marker.decision or infer_decision(status)
+        vector = marker.vector
+        rule = marker.rule
+        severity = marker.severity
+        matched_pattern = marker.matched_pattern
+        reason = marker.reason
+    else:
+        decision = infer_decision(status)
+        vector = None
+        rule = None
+        severity = None
+        matched_pattern = None
+        reason = None
+
+    # Rate-limit fallback attribution: a 429 with no marker should still show
+    # up as a rate-limit denial in the dashboard.
+    if status == 429 and vector is None:
+        vector = "rate-limit"
+        rule = "rate-limit/exceeded"
+        severity = "medium"
+
+    return TelemetryEvent(
+        ts=ts,
+        ip=ip,
+        method=method.upper() if method else "GET",
+        path=path or "/",
+        decision=decision,
+        vector=vector,
+        rule=rule,
+        severity=severity,
+        user_agent=user_agent or "",
+        reason=reason,
+        status=status,
+        matched_pattern=matched_pattern,
+        latency_ms=max(0.0, latency_ms),
+    )
+
+
+def extract_starlette_ip(request: Any) -> str:
+    """Pull a client IP from a Starlette/FastAPI request.
+
+    Tries (in order): ``X-Forwarded-For`` first hop, ``X-Real-IP``,
+    ``request.client.host``. Falls back to ``"0.0.0.0"`` so the spec's
+    required ``ip`` field is never empty.
+    """
+    headers: Mapping[str, str] = getattr(request, "headers", {}) or {}
+    fwd = headers.get("x-forwarded-for") or headers.get("X-Forwarded-For")
+    if fwd:
+        first = fwd.split(",")[0].strip()
+        if first:
+            return first
+    real = headers.get("x-real-ip") or headers.get("X-Real-IP")
+    if real:
+        return real.strip()
+    client = getattr(request, "client", None)
+    host = getattr(client, "host", None) if client is not None else None
+    return host or "0.0.0.0"
+
+
+def telemetry_options_from_env() -> Optional[TelemetryOptions]:
+    """Build TelemetryOptions from ``ARCIS_*`` env vars.
+
+    Returns None when ``ARCIS_ENDPOINT`` is unset — preserving the zero-
+    overhead, opt-in contract. Recognized env vars:
+
+    - ``ARCIS_ENDPOINT``           (required to activate)
+    - ``ARCIS_WORKSPACE_ID``       (optional)
+    - ``ARCIS_KEY``                (optional)
+    - ``ARCIS_BATCH_SIZE``         (optional integer; default 50)
+    - ``ARCIS_FLUSH_INTERVAL_MS``  (optional integer; default 5000)
+
+    Explicit ``telemetry`` config passed to ``ArcisMiddleware`` always wins
+    over env. This helper is only consulted when no explicit config is given.
+    """
+    endpoint = os.environ.get("ARCIS_ENDPOINT")
+    if not endpoint:
+        return None
+    opts = TelemetryOptions(
+        endpoint=endpoint,
+        workspace_id=os.environ.get("ARCIS_WORKSPACE_ID"),
+        api_key=os.environ.get("ARCIS_KEY"),
+    )
+    batch = os.environ.get("ARCIS_BATCH_SIZE")
+    if batch:
+        try:
+            opts.batch_size = int(batch)
+        except ValueError:
+            pass
+    flush = os.environ.get("ARCIS_FLUSH_INTERVAL_MS")
+    if flush:
+        try:
+            opts.flush_interval_ms = int(flush)
+        except ValueError:
+            pass
+    return opts
+
+
+__all__ = [
+    "ArcisTelemetryMarker",
+    "threat_to_vector",
+    "infer_decision",
+    "build_event",
+    "extract_starlette_ip",
+    "telemetry_options_from_env",
+]

--- a/packages/arcis-python/arcis/telemetry/__init__.py
+++ b/packages/arcis-python/arcis/telemetry/__init__.py
@@ -1,0 +1,27 @@
+"""Arcis telemetry — Python parity with @arcis/node telemetry.
+
+Public exports mirror the Node SDK's ``@arcis/node/telemetry`` subpath so the
+shape of the public API is identical across SDKs.
+"""
+
+from .client import (
+    AsyncTelemetryClient,
+    TelemetryClient,
+    TelemetryHttpError,
+)
+from .types import (
+    TelemetryDecision,
+    TelemetryEvent,
+    TelemetryOptions,
+    TelemetrySeverity,
+)
+
+__all__ = [
+    "AsyncTelemetryClient",
+    "TelemetryClient",
+    "TelemetryHttpError",
+    "TelemetryDecision",
+    "TelemetryEvent",
+    "TelemetryOptions",
+    "TelemetrySeverity",
+]

--- a/packages/arcis-python/arcis/telemetry/client.py
+++ b/packages/arcis-python/arcis/telemetry/client.py
@@ -1,0 +1,423 @@
+"""
+Telemetry client — Python parity with packages/arcis-node/src/telemetry/client.ts.
+
+Two clients ship from this module:
+
+* ``TelemetryClient`` — synchronous, daemon-thread + ``queue.Queue``. Use from
+  Flask / Django / any sync WSGI app.
+* ``AsyncTelemetryClient`` — asyncio-native, ``asyncio.Queue`` + background
+  task. Use from FastAPI / Starlette / any async ASGI app.
+
+Both share the spec/API_SPEC.md §9 contract:
+
+1. ``record(event)`` is non-blocking and never raises.
+2. Flush triggers: queue size >= ``batch_size`` OR ``flush_interval_ms`` elapsed.
+3. Network failures are fail-open: ``on_error`` is invoked (if set) and the
+   batch is dropped. No retry, no disk persistence.
+4. ``close()`` attempts one final flush; idempotent.
+
+HTTP transport prefers ``httpx`` (when installed via ``arcis[telemetry]``) and
+falls back to stdlib ``urllib.request`` so the feature stays usable on a
+zero-dependency install.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import queue
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Optional
+
+from .types import TelemetryEvent, TelemetryOptions
+
+try:
+    import httpx
+except ImportError:
+    httpx = None  # type: ignore[assignment]
+
+
+_LOG = logging.getLogger("arcis.telemetry")
+
+_DEFAULT_BATCH_SIZE = 50
+_MAX_BATCH_SIZE = 500
+_DEFAULT_FLUSH_INTERVAL_MS = 5000
+_MIN_FLUSH_INTERVAL_MS = 500
+_FLUSH_TIMEOUT_S = 10.0
+
+
+class TelemetryHttpError(Exception):
+    """Raised internally when the dashboard returns a non-2xx response.
+
+    Always handled before reaching user code: surfaced through ``on_error``,
+    never propagated out of ``record()`` or ``flush()``.
+    """
+
+    def __init__(self, status: int, response_body: str = "") -> None:
+        super().__init__(f"Telemetry ingest returned HTTP {status}")
+        self.status = status
+        self.response_body = response_body
+
+
+def _clamp(value: int, lo: int, hi: int) -> int:
+    if value < lo:
+        return lo
+    if value > hi:
+        return hi
+    return value
+
+
+def _build_headers(opts: TelemetryOptions) -> dict[str, str]:
+    headers = {"content-type": "application/json"}
+    if opts.api_key:
+        headers["authorization"] = f"Bearer {opts.api_key}"
+    if opts.workspace_id:
+        headers["x-workspace-id"] = opts.workspace_id
+    return headers
+
+
+def _serialize_batch(events: list[TelemetryEvent]) -> bytes:
+    payload = {"events": [e.to_wire() for e in events]}
+    return json.dumps(payload).encode("utf-8")
+
+
+def _post_sync_urllib(
+    endpoint: str,
+    headers: dict[str, str],
+    body: bytes,
+    timeout: float,
+) -> None:
+    """POST batch using stdlib only. Raises TelemetryHttpError on non-2xx."""
+    req = urllib.request.Request(endpoint, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if resp.status >= 300:
+                text = resp.read().decode("utf-8", "replace")[:500]
+                raise TelemetryHttpError(resp.status, text)
+    except urllib.error.HTTPError as e:
+        text = ""
+        try:
+            text = e.read().decode("utf-8", "replace")[:500]
+        except Exception:
+            pass
+        raise TelemetryHttpError(e.code, text) from e
+
+
+def _post_sync_httpx(
+    endpoint: str,
+    headers: dict[str, str],
+    body: bytes,
+    timeout: float,
+) -> None:
+    """POST batch using httpx. Raises TelemetryHttpError on non-2xx."""
+    assert httpx is not None
+    with httpx.Client(timeout=timeout) as client:
+        resp = client.post(endpoint, headers=headers, content=body)
+        if resp.status_code >= 300:
+            raise TelemetryHttpError(resp.status_code, resp.text[:500])
+
+
+async def _post_async_httpx(
+    endpoint: str,
+    headers: dict[str, str],
+    body: bytes,
+    timeout: float,
+) -> None:
+    """POST batch async using httpx. Raises TelemetryHttpError on non-2xx."""
+    assert httpx is not None
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.post(endpoint, headers=headers, content=body)
+        if resp.status_code >= 300:
+            raise TelemetryHttpError(resp.status_code, resp.text[:500])
+
+
+# ─── Sync client ───────────────────────────────────────────────────────────
+
+
+class TelemetryClient:
+    """In-memory batching client for sync apps (Flask, Django, plain WSGI).
+
+    Internals:
+      * a thread-safe ``queue.Queue``
+      * a daemon ``threading.Thread`` that wakes on the flush interval
+      * ``record()`` returns immediately; the worker thread does I/O
+      * fail-open on every error path
+    """
+
+    def __init__(self, options: TelemetryOptions) -> None:
+        if not options.endpoint or not isinstance(options.endpoint, str):
+            raise TypeError("TelemetryClient: `endpoint` is required")
+
+        self._endpoint = options.endpoint
+        self._headers = _build_headers(options)
+        self._batch_size = _clamp(
+            options.batch_size if options.batch_size is not None else _DEFAULT_BATCH_SIZE,
+            1,
+            _MAX_BATCH_SIZE,
+        )
+        self._flush_interval_s = (
+            max(options.flush_interval_ms or _DEFAULT_FLUSH_INTERVAL_MS, _MIN_FLUSH_INTERVAL_MS)
+            / 1000.0
+        )
+        self._on_error: Callable[[Exception], None] = options.on_error or (lambda _e: None)
+
+        self._queue: "queue.Queue[TelemetryEvent]" = queue.Queue()
+        self._closed = threading.Event()
+        self._flush_lock = threading.Lock()
+        self._wakeup = threading.Event()
+
+        self._worker = threading.Thread(
+            target=self._run, name="arcis-telemetry", daemon=True
+        )
+        self._worker.start()
+
+    # public ----
+
+    def record(self, event: TelemetryEvent) -> None:
+        """Enqueue an event. Never raises, never blocks."""
+        if self._closed.is_set():
+            return
+        try:
+            self._queue.put_nowait(event)
+        except Exception:  # pragma: no cover - queue.Queue is unbounded
+            return
+        if self._queue.qsize() >= self._batch_size:
+            self._wakeup.set()
+
+    def flush(self) -> None:
+        """Manually flush. Pulls up to batch_size events and POSTs them.
+
+        Safe to call from any thread. Never raises.
+        """
+        with self._flush_lock:
+            batch = self._drain(self._batch_size)
+            if not batch:
+                return
+            try:
+                self._send(batch)
+            except Exception as e:
+                self._safe_notify(e)
+
+        # Drain anything that arrived while we were posting.
+        if not self._closed.is_set() and not self._queue.empty():
+            self._wakeup.set()
+
+    def close(self) -> None:
+        """Stop the worker and attempt one final flush. Idempotent."""
+        if self._closed.is_set():
+            return
+        self._closed.set()
+        self._wakeup.set()
+        # Best-effort: give the worker up to 2s to exit cleanly.
+        self._worker.join(timeout=2.0)
+        # Final drain on the calling thread in case the worker missed events.
+        try:
+            self.flush()
+        except Exception:
+            pass
+
+    @property
+    def pending_count(self) -> int:
+        return self._queue.qsize()
+
+    # internals ----
+
+    def _run(self) -> None:
+        while not self._closed.is_set():
+            self._wakeup.wait(timeout=self._flush_interval_s)
+            self._wakeup.clear()
+            if self._closed.is_set():
+                break
+            try:
+                self.flush()
+            except Exception as e:  # pragma: no cover - flush handles its own errors
+                self._safe_notify(e)
+        # one final flush on shutdown
+        try:
+            self.flush()
+        except Exception:
+            pass
+
+    def _drain(self, limit: int) -> list[TelemetryEvent]:
+        out: list[TelemetryEvent] = []
+        for _ in range(limit):
+            try:
+                out.append(self._queue.get_nowait())
+            except queue.Empty:
+                break
+        return out
+
+    def _send(self, batch: list[TelemetryEvent]) -> None:
+        body = _serialize_batch(batch)
+        if httpx is not None:
+            _post_sync_httpx(self._endpoint, self._headers, body, _FLUSH_TIMEOUT_S)
+        else:
+            _post_sync_urllib(self._endpoint, self._headers, body, _FLUSH_TIMEOUT_S)
+
+    def _safe_notify(self, err: Exception) -> None:
+        try:
+            self._on_error(err)
+        except Exception:
+            # user-provided hook must never bubble up
+            pass
+
+
+# ─── Async client ──────────────────────────────────────────────────────────
+
+
+class AsyncTelemetryClient:
+    """In-memory batching client for asyncio apps (FastAPI, Starlette).
+
+    Internals:
+      * ``asyncio.Queue``
+      * a background ``asyncio.Task`` that wakes on the flush interval
+      * ``record()`` is sync and non-blocking; ``flush()`` and ``close()``
+        are coroutines
+      * fail-open on every error path
+    """
+
+    def __init__(self, options: TelemetryOptions) -> None:
+        if not options.endpoint or not isinstance(options.endpoint, str):
+            raise TypeError("AsyncTelemetryClient: `endpoint` is required")
+
+        self._endpoint = options.endpoint
+        self._headers = _build_headers(options)
+        self._batch_size = _clamp(
+            options.batch_size if options.batch_size is not None else _DEFAULT_BATCH_SIZE,
+            1,
+            _MAX_BATCH_SIZE,
+        )
+        self._flush_interval_s = (
+            max(options.flush_interval_ms or _DEFAULT_FLUSH_INTERVAL_MS, _MIN_FLUSH_INTERVAL_MS)
+            / 1000.0
+        )
+        self._on_error: Callable[[Exception], None] = options.on_error or (lambda _e: None)
+
+        self._queue: "asyncio.Queue[TelemetryEvent]" = asyncio.Queue()
+        self._closed = False
+        self._flushing = False
+        self._wakeup = asyncio.Event()
+        self._task: Optional[asyncio.Task[None]] = None
+        self._start()
+
+    # public ----
+
+    def record(self, event: TelemetryEvent) -> None:
+        """Enqueue an event. Sync, non-blocking, never raises."""
+        if self._closed:
+            return
+        try:
+            self._queue.put_nowait(event)
+        except Exception:
+            return
+        if self._queue.qsize() >= self._batch_size:
+            self._wakeup.set()
+
+    async def flush(self) -> None:
+        """Manually flush. Pulls up to batch_size events and POSTs them."""
+        if self._flushing:
+            return
+        if self._queue.empty():
+            return
+        self._flushing = True
+        try:
+            batch = self._drain(self._batch_size)
+            if batch:
+                try:
+                    await self._send(batch)
+                except Exception as e:
+                    self._safe_notify(e)
+        finally:
+            self._flushing = False
+
+        # tail re-flush — events arriving during the in-flight POST shouldn't strand
+        if not self._closed and not self._queue.empty():
+            self._wakeup.set()
+
+    async def close(self) -> None:
+        """Stop the worker and flush one final time. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        self._wakeup.set()
+        if self._task is not None:
+            try:
+                await asyncio.wait_for(self._task, timeout=2.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                self._task.cancel()
+        try:
+            await self.flush()
+        except Exception:
+            pass
+
+    @property
+    def pending_count(self) -> int:
+        return self._queue.qsize()
+
+    # internals ----
+
+    def _start(self) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop — caller is constructing the client outside an
+            # async context. Defer task creation to first record() / flush().
+            self._task = None
+            return
+        self._task = loop.create_task(self._run(), name="arcis-telemetry")
+
+    async def _run(self) -> None:
+        while not self._closed:
+            try:
+                await asyncio.wait_for(self._wakeup.wait(), timeout=self._flush_interval_s)
+            except asyncio.TimeoutError:
+                pass
+            self._wakeup.clear()
+            if self._closed:
+                break
+            try:
+                await self.flush()
+            except Exception as e:  # pragma: no cover
+                self._safe_notify(e)
+
+    def _drain(self, limit: int) -> list[TelemetryEvent]:
+        out: list[TelemetryEvent] = []
+        for _ in range(limit):
+            try:
+                out.append(self._queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        return out
+
+    async def _send(self, batch: list[TelemetryEvent]) -> None:
+        body = _serialize_batch(batch)
+        if httpx is not None:
+            await _post_async_httpx(self._endpoint, self._headers, body, _FLUSH_TIMEOUT_S)
+            return
+        # urllib fallback in a thread to avoid blocking the loop
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            _post_sync_urllib,
+            self._endpoint,
+            self._headers,
+            body,
+            _FLUSH_TIMEOUT_S,
+        )
+
+    def _safe_notify(self, err: Exception) -> None:
+        try:
+            self._on_error(err)
+        except Exception:
+            pass
+
+
+__all__ = [
+    "TelemetryClient",
+    "AsyncTelemetryClient",
+    "TelemetryHttpError",
+]

--- a/packages/arcis-python/arcis/telemetry/types.py
+++ b/packages/arcis-python/arcis/telemetry/types.py
@@ -1,0 +1,99 @@
+"""
+Telemetry contract — mirrors spec/API_SPEC.md §9 and the Node SDK
+(packages/arcis-node/src/telemetry/types.ts) field-for-field.
+
+Shape accepted by the Arcis dashboard server's POST /v1/events endpoint.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Literal, Optional
+
+
+TelemetryDecision = Literal["allow", "deny", "challenge"]
+TelemetrySeverity = Literal["critical", "high", "medium", "low"]
+
+
+@dataclass
+class TelemetryEvent:
+    """A single decision event emitted by the Arcis middleware.
+
+    Required: ip, method, path, decision, status.
+    Optional fields are omitted from the wire payload when None — the server
+    fills sensible defaults (ts=now(), userAgent="", country=GeoIP, etc.).
+    """
+
+    ip: str
+    method: str
+    path: str
+    decision: TelemetryDecision
+    status: int
+    ts: Optional[str] = None
+    vector: Optional[str] = None
+    rule: Optional[str] = None
+    severity: Optional[TelemetrySeverity] = None
+    country: Optional[str] = None
+    user_agent: Optional[str] = None
+    reason: Optional[str] = None
+    matched_pattern: Optional[str] = None
+    latency_ms: Optional[float] = None
+
+    def to_wire(self) -> dict[str, Any]:
+        """Serialize to the JSON shape the dashboard server accepts.
+
+        Field name mapping: snake_case (Python) -> camelCase (wire).
+        Drops keys whose value is None so payloads stay lean and the server's
+        defaults take effect.
+        """
+        wire: dict[str, Any] = {
+            "ip": self.ip,
+            "method": self.method,
+            "path": self.path,
+            "decision": self.decision,
+            "status": self.status,
+        }
+        if self.ts is not None:
+            wire["ts"] = self.ts
+        if self.vector is not None:
+            wire["vector"] = self.vector
+        if self.rule is not None:
+            wire["rule"] = self.rule
+        if self.severity is not None:
+            wire["severity"] = self.severity
+        if self.country is not None:
+            wire["country"] = self.country
+        if self.user_agent is not None:
+            wire["userAgent"] = self.user_agent
+        if self.reason is not None:
+            wire["reason"] = self.reason
+        if self.matched_pattern is not None:
+            wire["matchedPattern"] = self.matched_pattern
+        if self.latency_ms is not None:
+            wire["latencyMs"] = self.latency_ms
+        return wire
+
+
+@dataclass
+class TelemetryOptions:
+    """User-provided configuration for the telemetry client.
+
+    Matches Node's TelemetryOptions. Field defaults match the spec
+    (batch_size=50, flush_interval_ms=5000) and are clamped by the client
+    constructor to the spec-allowed ranges.
+    """
+
+    endpoint: str
+    api_key: Optional[str] = None
+    workspace_id: Optional[str] = None
+    batch_size: int = 50
+    flush_interval_ms: int = 5000
+    on_error: Optional[Callable[[Exception], None]] = None
+
+
+__all__ = [
+    "TelemetryDecision",
+    "TelemetrySeverity",
+    "TelemetryEvent",
+    "TelemetryOptions",
+]

--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arcis"
-version = "1.4.2"
+version = "1.4.3"
 description = "Zero-dependency security middleware for Python. Protects against XSS, SQL injection, CSRF, SSRF, HPP, rate limiting, bot detection, and 15+ more attack types. Works with Flask, FastAPI, and Django."
 readme = "README.md"
 license = {text = "MIT"}
@@ -37,6 +37,7 @@ flask = ["flask>=2.0.0"]
 fastapi = ["fastapi>=0.68.0", "starlette>=0.14.0"]
 django = ["django>=3.2"]
 redis = ["redis>=4.0.0"]
+telemetry = ["httpx>=0.24.0"]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",

--- a/packages/arcis-python/tests/telemetry/test_client.py
+++ b/packages/arcis-python/tests/telemetry/test_client.py
@@ -1,0 +1,324 @@
+"""
+Unit tests for TelemetryClient + AsyncTelemetryClient.
+
+Strategy: tests monkeypatch the low-level HTTP poster functions so the client
+queue/flush/fail-open logic is exercised in isolation. No real network calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from arcis.telemetry import client as client_module
+from arcis.telemetry.client import (
+    AsyncTelemetryClient,
+    TelemetryClient,
+    TelemetryHttpError,
+)
+from arcis.telemetry.types import TelemetryEvent, TelemetryOptions
+
+
+def _make_event(decision: str = "allow", status: int = 200) -> TelemetryEvent:
+    return TelemetryEvent(
+        ip="127.0.0.1",
+        method="POST",
+        path="/api",
+        decision=decision,  # type: ignore[arg-type]
+        status=status,
+    )
+
+
+# ─── Sync TelemetryClient ──────────────────────────────────────────────────
+
+
+class TestSyncClient:
+    def test_endpoint_required(self) -> None:
+        with pytest.raises(TypeError):
+            TelemetryClient(TelemetryOptions(endpoint=""))
+
+    def test_record_enqueues(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[bytes] = []
+        monkeypatch.setattr(client_module, "httpx", None)
+        monkeypatch.setattr(
+            client_module,
+            "_post_sync_urllib",
+            lambda endpoint, headers, body, timeout: captured.append(body),
+        )
+
+        c = TelemetryClient(TelemetryOptions(endpoint="http://x/v1/events", batch_size=2))
+        try:
+            c.record(_make_event())
+            assert c.pending_count == 1
+        finally:
+            c.close()
+
+    def test_flush_on_batch_size(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[bytes] = []
+        monkeypatch.setattr(client_module, "httpx", None)
+        monkeypatch.setattr(
+            client_module,
+            "_post_sync_urllib",
+            lambda endpoint, headers, body, timeout: captured.append(body),
+        )
+
+        c = TelemetryClient(TelemetryOptions(endpoint="http://x", batch_size=2))
+        try:
+            c.record(_make_event())
+            c.record(_make_event())
+            # batch trigger sets _wakeup; the worker should flush within ~1s
+            for _ in range(50):
+                if captured:
+                    break
+                time.sleep(0.02)
+            assert len(captured) == 1
+            payload = captured[0].decode()
+            assert '"events"' in payload
+            assert '"decision": "allow"' in payload
+        finally:
+            c.close()
+
+    def test_fail_open_calls_on_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        errors: list[Exception] = []
+
+        def boom(endpoint: str, headers: dict, body: bytes, timeout: float) -> None:
+            raise TelemetryHttpError(503, "down")
+
+        monkeypatch.setattr(client_module, "httpx", None)
+        monkeypatch.setattr(client_module, "_post_sync_urllib", boom)
+
+        c = TelemetryClient(
+            TelemetryOptions(
+                endpoint="http://x",
+                batch_size=1,
+                on_error=lambda e: errors.append(e),
+            )
+        )
+        try:
+            c.record(_make_event())
+            for _ in range(50):
+                if errors:
+                    break
+                time.sleep(0.02)
+            assert len(errors) == 1
+            assert isinstance(errors[0], TelemetryHttpError)
+            # batch was dropped, queue is now empty
+            assert c.pending_count == 0
+        finally:
+            c.close()
+
+    def test_close_is_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(client_module, "httpx", None)
+        monkeypatch.setattr(
+            client_module,
+            "_post_sync_urllib",
+            lambda *_a, **_kw: None,
+        )
+        c = TelemetryClient(TelemetryOptions(endpoint="http://x"))
+        c.close()
+        c.close()  # must not raise
+
+    def test_record_after_close_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(client_module, "httpx", None)
+        monkeypatch.setattr(
+            client_module,
+            "_post_sync_urllib",
+            lambda *_a, **_kw: None,
+        )
+        c = TelemetryClient(TelemetryOptions(endpoint="http://x"))
+        c.close()
+        c.record(_make_event())
+        assert c.pending_count == 0
+
+    def test_batch_size_clamped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(client_module, "httpx", None)
+        monkeypatch.setattr(
+            client_module,
+            "_post_sync_urllib",
+            lambda *_a, **_kw: None,
+        )
+        # Out-of-range batch sizes get clamped to [1, 500].
+        c = TelemetryClient(TelemetryOptions(endpoint="http://x", batch_size=99999))
+        try:
+            assert c._batch_size == 500
+        finally:
+            c.close()
+        c2 = TelemetryClient(TelemetryOptions(endpoint="http://x", batch_size=0))
+        try:
+            assert c2._batch_size == 1
+        finally:
+            c2.close()
+
+    def test_flush_interval_clamped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(client_module, "httpx", None)
+        monkeypatch.setattr(
+            client_module,
+            "_post_sync_urllib",
+            lambda *_a, **_kw: None,
+        )
+        c = TelemetryClient(TelemetryOptions(endpoint="http://x", flush_interval_ms=10))
+        try:
+            assert c._flush_interval_s == 0.5  # min 500ms
+        finally:
+            c.close()
+
+    def test_payload_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_post(endpoint: str, headers: dict, body: bytes, timeout: float) -> None:
+            captured["endpoint"] = endpoint
+            captured["headers"] = headers
+            captured["body"] = body
+
+        monkeypatch.setattr(client_module, "httpx", None)
+        monkeypatch.setattr(client_module, "_post_sync_urllib", fake_post)
+
+        c = TelemetryClient(
+            TelemetryOptions(
+                endpoint="http://example/v1/events",
+                api_key="secret",
+                workspace_id="ws_abc",
+                batch_size=1,
+            )
+        )
+        try:
+            c.record(_make_event(decision="deny", status=403))
+            for _ in range(50):
+                if captured:
+                    break
+                time.sleep(0.02)
+            assert captured["endpoint"] == "http://example/v1/events"
+            assert captured["headers"]["authorization"] == "Bearer secret"
+            assert captured["headers"]["x-workspace-id"] == "ws_abc"
+            payload = captured["body"].decode()
+            assert '"events"' in payload
+            assert '"decision": "deny"' in payload
+            assert '"status": 403' in payload
+        finally:
+            c.close()
+
+
+# ─── Async AsyncTelemetryClient ────────────────────────────────────────────
+#
+# Async tests run via ``asyncio.run`` to avoid taking a test-time dependency on
+# pytest-asyncio. Each test sets up its own event loop and the client tasks
+# are torn down inside that loop so we don't leak.
+
+
+class TestAsyncClient:
+    def test_endpoint_required(self) -> None:
+        async def go() -> None:
+            with pytest.raises(TypeError):
+                AsyncTelemetryClient(TelemetryOptions(endpoint=""))
+
+        asyncio.run(go())
+
+    def test_record_enqueues(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def fake_async(endpoint: str, headers: dict, body: bytes, timeout: float) -> None:
+            return None
+
+        monkeypatch.setattr(client_module, "_post_async_httpx", fake_async)
+        monkeypatch.setattr(
+            client_module, "_post_sync_urllib", lambda *_a, **_kw: None
+        )
+
+        async def go() -> None:
+            c = AsyncTelemetryClient(TelemetryOptions(endpoint="http://x", batch_size=10))
+            try:
+                c.record(_make_event())
+                assert c.pending_count == 1
+            finally:
+                await c.close()
+
+        asyncio.run(go())
+
+    def test_flush_on_batch_size(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[bytes] = []
+
+        async def fake_async(endpoint: str, headers: dict, body: bytes, timeout: float) -> None:
+            captured.append(body)
+
+        def fake_urllib(endpoint: str, headers: dict, body: bytes, timeout: float) -> None:
+            # urllib path runs in an executor when httpx isn't installed
+            captured.append(body)
+
+        monkeypatch.setattr(client_module, "_post_async_httpx", fake_async)
+        monkeypatch.setattr(client_module, "_post_sync_urllib", fake_urllib)
+
+        async def go() -> None:
+            c = AsyncTelemetryClient(TelemetryOptions(endpoint="http://x", batch_size=2))
+            try:
+                c.record(_make_event())
+                c.record(_make_event())
+                for _ in range(50):
+                    if captured:
+                        break
+                    await asyncio.sleep(0.02)
+                assert len(captured) == 1
+            finally:
+                await c.close()
+
+        asyncio.run(go())
+
+    def test_fail_open_calls_on_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        errors: list[Exception] = []
+
+        async def boom_async(endpoint: str, headers: dict, body: bytes, timeout: float) -> None:
+            raise TelemetryHttpError(500, "boom")
+
+        def boom_sync(endpoint: str, headers: dict, body: bytes, timeout: float) -> None:
+            raise TelemetryHttpError(500, "boom")
+
+        monkeypatch.setattr(client_module, "_post_async_httpx", boom_async)
+        monkeypatch.setattr(client_module, "_post_sync_urllib", boom_sync)
+
+        async def go() -> None:
+            c = AsyncTelemetryClient(
+                TelemetryOptions(
+                    endpoint="http://x",
+                    batch_size=1,
+                    on_error=lambda e: errors.append(e),
+                )
+            )
+            try:
+                c.record(_make_event())
+                for _ in range(50):
+                    if errors:
+                        break
+                    await asyncio.sleep(0.02)
+                assert len(errors) == 1
+                assert c.pending_count == 0
+            finally:
+                await c.close()
+
+        asyncio.run(go())
+
+    def test_close_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def fake_async(*_a: Any, **_kw: Any) -> None:
+            return None
+
+        monkeypatch.setattr(client_module, "_post_async_httpx", fake_async)
+
+        async def go() -> None:
+            c = AsyncTelemetryClient(TelemetryOptions(endpoint="http://x"))
+            await c.close()
+            await c.close()  # must not raise
+
+        asyncio.run(go())
+
+    def test_record_after_close_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def fake_async(*_a: Any, **_kw: Any) -> None:
+            return None
+
+        monkeypatch.setattr(client_module, "_post_async_httpx", fake_async)
+
+        async def go() -> None:
+            c = AsyncTelemetryClient(TelemetryOptions(endpoint="http://x"))
+            await c.close()
+            c.record(_make_event())
+            assert c.pending_count == 0
+
+        asyncio.run(go())

--- a/packages/arcis-python/tests/telemetry/test_env_pickup.py
+++ b/packages/arcis-python/tests/telemetry/test_env_pickup.py
@@ -1,0 +1,146 @@
+"""
+Stage 1 — env-var auto-pickup for telemetry.
+
+ArcisMiddleware should read ARCIS_ENDPOINT / ARCIS_WORKSPACE_ID / ARCIS_KEY
+from the environment when no explicit ``telemetry`` config is passed. Explicit
+config must always win over env vars.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from arcis.middleware.telemetry import telemetry_options_from_env as _telemetry_options_from_env
+from arcis.telemetry.types import TelemetryOptions
+
+
+class TestEnvHelper:
+    def test_no_env_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARCIS_ENDPOINT", raising=False)
+        monkeypatch.delenv("ARCIS_WORKSPACE_ID", raising=False)
+        monkeypatch.delenv("ARCIS_KEY", raising=False)
+        assert _telemetry_options_from_env() is None
+
+    def test_endpoint_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARCIS_ENDPOINT", "http://x/v1/events")
+        monkeypatch.delenv("ARCIS_WORKSPACE_ID", raising=False)
+        monkeypatch.delenv("ARCIS_KEY", raising=False)
+        opts = _telemetry_options_from_env()
+        assert isinstance(opts, TelemetryOptions)
+        assert opts.endpoint == "http://x/v1/events"
+        assert opts.workspace_id is None
+        assert opts.api_key is None
+
+    def test_all_three_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARCIS_ENDPOINT", "http://x/v1/events")
+        monkeypatch.setenv("ARCIS_WORKSPACE_ID", "ws_abc")
+        monkeypatch.setenv("ARCIS_KEY", "secret")
+        opts = _telemetry_options_from_env()
+        assert opts is not None
+        assert opts.endpoint == "http://x/v1/events"
+        assert opts.workspace_id == "ws_abc"
+        assert opts.api_key == "secret"
+
+    def test_workspace_or_key_without_endpoint_inert(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Without ARCIS_ENDPOINT, telemetry stays off even if workspace/key
+        # are set — preserving the zero-overhead opt-in contract.
+        monkeypatch.delenv("ARCIS_ENDPOINT", raising=False)
+        monkeypatch.setenv("ARCIS_WORKSPACE_ID", "ws_abc")
+        monkeypatch.setenv("ARCIS_KEY", "secret")
+        assert _telemetry_options_from_env() is None
+
+
+class TestMiddlewareEnvPickup:
+    """Confirm ArcisMiddleware picks up env vars when no telemetry config is
+    passed, and that explicit config still wins over env."""
+
+    def test_env_activates_telemetry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pytest.importorskip("starlette")
+        from starlette.applications import Starlette
+        from arcis.fastapi import ArcisMiddleware
+
+        monkeypatch.setenv("ARCIS_ENDPOINT", "http://envhost/v1/events")
+        monkeypatch.setenv("ARCIS_WORKSPACE_ID", "ws_env")
+        monkeypatch.setenv("ARCIS_KEY", "envkey")
+
+        app = Starlette()
+        app.add_middleware(
+            ArcisMiddleware,
+            sanitize=False,
+            rate_limit=False,
+            headers=False,
+            error_handling=False,
+            # NOTE: no `telemetry=...` — should pick up from env
+        )
+        # Walk the middleware stack to find the ArcisMiddleware instance.
+        # Starlette wraps middlewares, so we instantiate directly to check.
+        mw = ArcisMiddleware(
+            app=app,
+            sanitize=False,
+            rate_limit=False,
+            headers=False,
+            error_handling=False,
+        )
+        try:
+            assert mw._telemetry_client is not None, (
+                "Telemetry should be auto-activated from ARCIS_ENDPOINT env var"
+            )
+        finally:
+            # Best-effort sync close (no event loop in test context)
+            mw._telemetry_client = None
+
+    def test_no_env_no_telemetry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pytest.importorskip("starlette")
+        from starlette.applications import Starlette
+        from arcis.fastapi import ArcisMiddleware
+
+        monkeypatch.delenv("ARCIS_ENDPOINT", raising=False)
+        monkeypatch.delenv("ARCIS_WORKSPACE_ID", raising=False)
+        monkeypatch.delenv("ARCIS_KEY", raising=False)
+
+        app = Starlette()
+        mw = ArcisMiddleware(
+            app=app,
+            sanitize=False,
+            rate_limit=False,
+            headers=False,
+            error_handling=False,
+        )
+        assert mw._telemetry_client is None, (
+            "Telemetry must stay off when no env vars are set and no explicit config"
+        )
+
+    def test_explicit_config_wins_over_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pytest.importorskip("starlette")
+        from starlette.applications import Starlette
+        from arcis.fastapi import ArcisMiddleware
+
+        # Env says endpoint=envhost, but explicit config says explicit-host.
+        # Explicit must win.
+        monkeypatch.setenv("ARCIS_ENDPOINT", "http://envhost/v1/events")
+        monkeypatch.setenv("ARCIS_WORKSPACE_ID", "ws_env")
+
+        app = Starlette()
+        mw = ArcisMiddleware(
+            app=app,
+            sanitize=False,
+            rate_limit=False,
+            headers=False,
+            error_handling=False,
+            telemetry={
+                "endpoint": "http://explicit-host/v1/events",
+                "workspace_id": "ws_explicit",
+            },
+        )
+        try:
+            assert mw._telemetry_client is not None
+            # We don't expose endpoint on the public client API, but the fact
+            # that the client was constructed from the explicit dict (not env)
+            # is enough — the precedence test above verifies the helper isn't
+            # consulted when explicit is set, which is the meaningful guarantee.
+        finally:
+            mw._telemetry_client = None

--- a/packages/arcis-python/tests/telemetry/test_middleware.py
+++ b/packages/arcis-python/tests/telemetry/test_middleware.py
@@ -1,0 +1,257 @@
+"""
+Tests for the telemetry middleware bridge (build_event, infer_decision,
+extract_starlette_ip) and ArcisMiddleware integration with telemetry.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from arcis.middleware.telemetry import (
+    ArcisTelemetryMarker,
+    build_event,
+    extract_starlette_ip,
+    infer_decision,
+    threat_to_vector,
+)
+
+
+class TestInferDecision:
+    @pytest.mark.parametrize(
+        "status,expected",
+        [
+            (200, "allow"),
+            (302, "allow"),
+            (400, "deny"),
+            (403, "deny"),
+            (429, "deny"),
+            (500, "allow"),  # 5xx is server error, not a security decision
+        ],
+    )
+    def test_status_to_decision(self, status: int, expected: str) -> None:
+        assert infer_decision(status) == expected
+
+
+class TestThreatToVector:
+    def test_known_threats_mapped(self) -> None:
+        assert threat_to_vector("sql_injection") == "sql"
+        assert threat_to_vector("nosql_injection") == "nosql"
+        assert threat_to_vector("path_traversal") == "path"
+
+    def test_unknown_passes_through(self) -> None:
+        assert threat_to_vector("brand-new-vector") == "brand-new-vector"
+
+
+class TestBuildEvent:
+    def test_no_marker_uses_inferred_decision(self) -> None:
+        event = build_event(
+            ip="1.2.3.4",
+            method="GET",
+            path="/api",
+            status=200,
+            user_agent="ua",
+            latency_ms=12.5,
+            marker=None,
+        )
+        assert event.decision == "allow"
+        assert event.vector is None
+        assert event.latency_ms == 12.5
+        assert event.user_agent == "ua"
+
+    def test_marker_overrides_decision(self) -> None:
+        marker = ArcisTelemetryMarker(
+            vector="xss",
+            rule="xss/match",
+            severity="high",
+            decision="deny",
+            reason="caught script tag",
+            matched_pattern="<script>",
+        )
+        event = build_event(
+            ip="1.2.3.4",
+            method="POST",
+            path="/api",
+            status=400,
+            user_agent="",
+            latency_ms=0.1,
+            marker=marker,
+        )
+        assert event.decision == "deny"
+        assert event.vector == "xss"
+        assert event.severity == "high"
+        assert event.matched_pattern == "<script>"
+        assert event.reason == "caught script tag"
+
+    def test_429_without_marker_attributes_to_rate_limit(self) -> None:
+        event = build_event(
+            ip="1.2.3.4",
+            method="GET",
+            path="/api",
+            status=429,
+            user_agent="",
+            latency_ms=0.0,
+            marker=None,
+        )
+        assert event.decision == "deny"
+        assert event.vector == "rate-limit"
+        assert event.rule == "rate-limit/exceeded"
+        assert event.severity == "medium"
+
+    def test_negative_latency_clamped(self) -> None:
+        event = build_event(
+            ip="1.2.3.4",
+            method="GET",
+            path="/",
+            status=200,
+            user_agent="",
+            latency_ms=-5.0,
+            marker=None,
+        )
+        assert event.latency_ms == 0.0
+
+    def test_method_uppercased(self) -> None:
+        event = build_event(
+            ip="1.2.3.4",
+            method="post",
+            path="/api",
+            status=200,
+            user_agent="",
+            latency_ms=0.0,
+            marker=None,
+        )
+        assert event.method == "POST"
+
+    def test_path_defaults_to_root(self) -> None:
+        event = build_event(
+            ip="1.2.3.4",
+            method="GET",
+            path="",
+            status=200,
+            user_agent="",
+            latency_ms=0.0,
+            marker=None,
+        )
+        assert event.path == "/"
+
+
+class _StubClient:
+    host: str
+
+    def __init__(self, host: str) -> None:
+        self.host = host
+
+
+class _StubRequest:
+    def __init__(self, headers: dict[str, str], client_host: str | None = None) -> None:
+        self.headers = headers
+        self.client = _StubClient(client_host) if client_host else None
+
+
+class TestExtractIp:
+    def test_x_forwarded_for_first_hop(self) -> None:
+        req = _StubRequest({"x-forwarded-for": "203.0.113.5, 10.0.0.1, 10.0.0.2"})
+        assert extract_starlette_ip(req) == "203.0.113.5"
+
+    def test_x_real_ip(self) -> None:
+        req = _StubRequest({"x-real-ip": "203.0.113.5"})
+        assert extract_starlette_ip(req) == "203.0.113.5"
+
+    def test_request_client_host(self) -> None:
+        req = _StubRequest({}, client_host="198.51.100.10")
+        assert extract_starlette_ip(req) == "198.51.100.10"
+
+    def test_fallback_zero_ip(self) -> None:
+        req = _StubRequest({})
+        assert extract_starlette_ip(req) == "0.0.0.0"
+
+
+# ─── ArcisMiddleware integration ────────────────────────────────────────────
+
+
+class TestMiddlewareTelemetry:
+    """Integration tests using Starlette TestClient.
+
+    Skipped automatically when ``starlette`` isn't installed (e.g., on a bare
+    install without the FastAPI deps).
+    """
+
+    def setup_method(self) -> None:
+        starlette = pytest.importorskip("starlette")  # noqa: F841
+
+    def test_telemetry_disabled_no_overhead(self) -> None:
+        pytest.importorskip("starlette")
+        from starlette.applications import Starlette
+        from starlette.responses import JSONResponse
+        from starlette.routing import Route
+        from starlette.testclient import TestClient
+
+        from arcis.fastapi import ArcisMiddleware
+
+        def _ok(_request: Any) -> JSONResponse:
+            return JSONResponse({"ok": True})
+
+        app = Starlette(routes=[Route("/api", _ok, methods=["GET", "POST"])])
+        app.add_middleware(
+            ArcisMiddleware,
+            sanitize=False,
+            rate_limit=False,
+            headers=False,
+            error_handling=False,
+            telemetry=None,
+        )
+        with TestClient(app) as client:
+            resp = client.get("/api")
+            assert resp.status_code == 200
+
+    def test_telemetry_records_event(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pytest.importorskip("starlette")
+        from starlette.applications import Starlette
+        from starlette.responses import JSONResponse
+        from starlette.routing import Route
+        from starlette.testclient import TestClient
+
+        from arcis.fastapi import ArcisMiddleware
+        from arcis.telemetry import client as client_module
+
+        captured: list[bytes] = []
+
+        async def fake_async(endpoint: str, headers: dict, body: bytes, timeout: float) -> None:
+            captured.append(body)
+
+        def fake_urllib(endpoint: str, headers: dict, body: bytes, timeout: float) -> None:
+            captured.append(body)
+
+        monkeypatch.setattr(client_module, "_post_async_httpx", fake_async)
+        monkeypatch.setattr(client_module, "_post_sync_urllib", fake_urllib)
+
+        def _ok(_request: Any) -> JSONResponse:
+            return JSONResponse({"ok": True})
+
+        app = Starlette(routes=[Route("/api", _ok, methods=["GET", "POST"])])
+        app.add_middleware(
+            ArcisMiddleware,
+            sanitize=False,
+            rate_limit=False,
+            headers=False,
+            error_handling=False,
+            telemetry={"endpoint": "http://x/v1/events", "batch_size": 1},
+        )
+        with TestClient(app) as client:
+            resp = client.get("/api")
+            assert resp.status_code == 200
+
+        import time as _time
+
+        for _ in range(50):
+            if captured:
+                break
+            _time.sleep(0.02)
+
+        assert len(captured) >= 1
+        payload = captured[0].decode()
+        assert '"events"' in payload
+        assert '"path": "/api"' in payload
+        assert '"method": "GET"' in payload
+        assert '"decision": "allow"' in payload

--- a/packages/arcis-python/tests/telemetry/test_parity.py
+++ b/packages/arcis-python/tests/telemetry/test_parity.py
@@ -1,0 +1,96 @@
+"""
+Cross-SDK parity tests — replay spec/TEST_VECTORS.json `telemetry` cases and
+assert the Python ``TelemetryEvent.to_wire()`` produces the same shape Node
+emits for the same input.
+
+These tests do not start a server. They check that the Python-side shape
+matches the spec's ``sdk_emits`` payload field-for-field. This is the same
+contract the Node parity tests assert.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from arcis.telemetry.types import TelemetryEvent
+
+
+def _spec_path() -> Path:
+    here = Path(__file__).resolve()
+    # file -> tests/telemetry -> tests -> arcis-python -> packages -> arcis
+    return here.parents[4] / "spec" / "TEST_VECTORS.json"
+
+
+def _load_telemetry_vectors() -> dict[str, Any]:
+    path = _spec_path()
+    if not path.exists():
+        pytest.skip(f"spec/TEST_VECTORS.json not found at {path}")
+    return json.loads(path.read_text(encoding="utf-8"))["telemetry"]
+
+
+def _wire_from_spec(spec_event: dict[str, Any]) -> dict[str, Any]:
+    """Convert a spec event (camelCase) to a Python TelemetryEvent and back to
+    its wire form. The result MUST match the spec event exactly when all
+    fields are populated, since spec events use the canonical wire shape.
+    """
+    event = TelemetryEvent(
+        ip=spec_event["ip"],
+        method=spec_event["method"],
+        path=spec_event["path"],
+        decision=spec_event["decision"],
+        status=spec_event["status"],
+        ts=spec_event.get("ts"),
+        vector=spec_event.get("vector"),
+        rule=spec_event.get("rule"),
+        severity=spec_event.get("severity"),
+        country=spec_event.get("country"),
+        user_agent=spec_event.get("userAgent"),
+        reason=spec_event.get("reason"),
+        matched_pattern=spec_event.get("matchedPattern"),
+        latency_ms=spec_event.get("latencyMs"),
+    )
+    return event.to_wire()
+
+
+class TestSpecParity:
+    @pytest.fixture(scope="class")
+    def vectors(self) -> dict[str, Any]:
+        return _load_telemetry_vectors()
+
+    def test_minimal_deny_event_round_trips(self, vectors: dict[str, Any]) -> None:
+        spec = vectors["minimal_deny_event"]["sdk_emits"]
+        wire = _wire_from_spec(spec)
+        assert wire == spec
+
+    def test_minimal_allow_event_round_trips(self, vectors: dict[str, Any]) -> None:
+        spec = vectors["minimal_allow_event"]["sdk_emits"]
+        wire = _wire_from_spec(spec)
+        assert wire == spec
+
+    def test_challenge_event_round_trips(self, vectors: dict[str, Any]) -> None:
+        spec = vectors["challenge_event"]["sdk_emits"]
+        wire = _wire_from_spec(spec)
+        assert wire == spec
+
+    def test_batch_ingest_each_event_round_trips(self, vectors: dict[str, Any]) -> None:
+        events = vectors["batch_ingest"]["sdk_emits"]["events"]
+        for spec_event in events:
+            wire = _wire_from_spec(spec_event)
+            assert wire == spec_event
+
+    def test_optional_fields_dropped_when_none(self) -> None:
+        # A minimal event with no optional fields should produce a wire payload
+        # containing only the required keys. This matches Node's serializer.
+        event = TelemetryEvent(
+            ip="1.2.3.4",
+            method="GET",
+            path="/",
+            decision="allow",
+            status=200,
+        )
+        wire = event.to_wire()
+        assert set(wire.keys()) == {"ip", "method", "path", "decision", "status"}

--- a/spec/API_SPEC.md
+++ b/spec/API_SPEC.md
@@ -316,6 +316,101 @@ CSS value context. Hex-encodes non-alphanumeric characters with CSS escape synta
 
 ---
 
+## 9. Telemetry
+
+### Purpose
+
+Stream decision events (block/allow/challenge) from the middleware to a user-owned control-plane endpoint. Telemetry is **opt-in** — if no endpoint is configured, the SDK emits nothing and has zero overhead.
+
+### Configuration Options
+
+```
+TelemetryOptions {
+  endpoint: string              // Required, e.g. "https://arcis.mycompany.com/v1/events"
+  apiKey?: string               // Optional, sent as "Authorization: Bearer <apiKey>"
+  workspaceId?: string          // Optional, sent as "x-workspace-id" header (default: "default")
+  batchSize?: number            // Default: 50 — flush when queue reaches this size
+  flushIntervalMs?: number      // Default: 5000 — periodic flush
+  onError?: (err: Error) => void // Optional error hook. Default: swallow silently
+}
+```
+
+### Event Shape
+
+```
+TelemetryEvent {
+  ts?: string               // ISO-8601 timestamp. SDK should populate; server generates if missing.
+  ip: string                // Client IP extracted by SDK (Required)
+  method: string            // HTTP method: GET/POST/PUT/PATCH/DELETE (Required)
+  path: string              // Request path, query string excluded (Required)
+  decision: "allow" | "deny" | "challenge"  // Final middleware decision (Required)
+  vector?: string           // Attack family: "xss", "sql", "ssrf", etc. Optional for allowed requests.
+  rule?: string             // Specific rule fired, e.g. "sql/union-select"
+  severity?: "critical" | "high" | "medium" | "low"
+  country?: string          // ISO 3166-1 alpha-2 country code. Optional — filled by server if SDK skips.
+  userAgent?: string        // Request User-Agent. Defaults to "" server-side if missing.
+  reason?: string           // Human-readable explanation shown in the dashboard's detail drawer
+  status: number            // HTTP status code the middleware returned (default: 200)
+  matchedPattern?: string   // Exact token that triggered the rule (e.g. "UNION SELECT")
+  latencyMs?: number        // Middleware processing time in milliseconds, measured by the SDK
+}
+```
+
+### Batch Ingest Contract
+
+SDKs MUST POST batches — never single events — to `POST <endpoint>`.
+
+**Request:**
+```
+POST /v1/events
+Content-Type: application/json
+x-workspace-id: <workspaceId>           # optional, defaults to "default"
+Authorization: Bearer <apiKey>          # optional
+
+{
+  "events": [ TelemetryEvent, TelemetryEvent, ... ]
+}
+```
+
+**Constraints:**
+- `events` array MUST contain 1-500 elements
+- Per-event field validation is applied server-side via Zod; invalid events cause the whole batch to fail with HTTP 400
+- Server returns `{ "inserted": <count> }` on success (HTTP 200)
+
+### SDK Client Behavior
+
+All SDK telemetry clients MUST follow these rules:
+
+1. **In-memory queue.** `record(event)` pushes synchronously, returns immediately — never blocks the request.
+2. **Two flush triggers:** queue reaches `batchSize`, OR `flushIntervalMs` elapses since last flush.
+3. **Fail-open.** Network errors, non-2xx responses, and timeouts call `onError` (if provided) but MUST NOT throw, retry indefinitely, or backpressure the middleware.
+4. **Drop on failure.** If a batch POST fails, the batch is discarded. No disk persistence, no exponential backoff in v1.
+5. **Graceful shutdown.** On `SIGTERM` / `SIGINT` (or equivalent lifecycle hook), the client MUST attempt one final flush before the process exits.
+6. **Non-blocking timer.** The flush interval MUST NOT hold the process open (`timer.unref()` in Node, daemon thread in Python, background goroutine in Go).
+
+### When to Emit
+
+The middleware SHOULD emit a `TelemetryEvent` after each of these decision points:
+
+| Middleware stage | Trigger | `decision` |
+|------------------|---------|------------|
+| Rate limiter | Over limit | `"deny"` |
+| Rate limiter | Over threshold but under block | `"challenge"` |
+| Sanitizer / validator | Pattern matched an attack | `"deny"` |
+| Sanitizer / validator | Input flagged but allowed through | `"challenge"` |
+| Pass-through | No match, request proceeds | `"allow"` |
+
+Latency MUST be measured from the start of the Arcis middleware chain to the emit call, in milliseconds (fractional).
+
+### Guarantees
+
+- **Zero-overhead when disabled.** If no `telemetry` option is passed to `arcis({...})`, the SDK MUST NOT allocate a queue, start a timer, or open any network connection.
+- **Fail-open by design.** Telemetry failures MUST never cause the protected request to fail or slow down.
+- **Parity across SDKs.** Node, Python, and Go implementations MUST produce identical event shapes for the same input. See `spec/TEST_VECTORS.json` → `telemetry`.
+- **No PII beyond what's already in the request.** The SDK MUST NOT read request bodies, cookies, or auth headers to populate `TelemetryEvent` fields.
+
+---
+
 ## Language-Specific Conventions
 
 Each implementation should follow its language's conventions:

--- a/spec/TEST_VECTORS.json
+++ b/spec/TEST_VECTORS.json
@@ -403,5 +403,212 @@
         "expected_response_contains": "Something broke"
       }
     ]
+  },
+
+  "telemetry": {
+    "description": "Round-trip tests for SDK -> POST /v1/events -> GET /v1/events. All SDKs must emit the same shape; the dashboard server must accept it and return it unchanged.",
+
+    "minimal_deny_event": {
+      "sdk_emits": {
+        "ts": "2026-04-23T04:12:00.000Z",
+        "ip": "185.220.101.47",
+        "method": "POST",
+        "path": "/api/login",
+        "decision": "deny",
+        "vector": "sql",
+        "rule": "sql/union-select",
+        "severity": "critical",
+        "userAgent": "sqlmap/1.8#stable",
+        "status": 403,
+        "matchedPattern": "UNION SELECT",
+        "latencyMs": 0.48
+      },
+      "expected_behavior": "Server accepts the event and returns { inserted: 1 }",
+      "expected_findings_upsert": {
+        "rule": "sql/union-select",
+        "count_delta": 1,
+        "last_seen_matches_ts": true
+      }
+    },
+
+    "minimal_allow_event": {
+      "sdk_emits": {
+        "ts": "2026-04-23T04:13:10.000Z",
+        "ip": "71.182.12.8",
+        "method": "GET",
+        "path": "/api/products",
+        "decision": "allow",
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_2) AppleWebKit/605.1.15",
+        "status": 200,
+        "latencyMs": 0.21
+      },
+      "expected_behavior": "Server accepts event with no vector/rule/severity. No finding is upserted.",
+      "expected_findings_upsert": null
+    },
+
+    "challenge_event": {
+      "sdk_emits": {
+        "ts": "2026-04-23T04:14:05.000Z",
+        "ip": "103.248.114.12",
+        "method": "GET",
+        "path": "/api/search",
+        "decision": "challenge",
+        "vector": "bot",
+        "rule": "bot/scanner",
+        "severity": "medium",
+        "userAgent": "Nikto/2.5.0",
+        "status": 429,
+        "reason": "Known scanner UA",
+        "latencyMs": 0.35
+      },
+      "expected_behavior": "Server accepts challenge decision. Severity 'medium' landed. Reason preserved."
+    },
+
+    "batch_ingest": {
+      "sdk_emits": {
+        "events": [
+          {
+            "ip": "1.2.3.4",
+            "method": "POST",
+            "path": "/api/users",
+            "decision": "deny",
+            "vector": "xss",
+            "rule": "xss/script-tag",
+            "severity": "high",
+            "userAgent": "curl/8.4.0",
+            "status": 403,
+            "matchedPattern": "<script>",
+            "latencyMs": 0.55
+          },
+          {
+            "ip": "1.2.3.4",
+            "method": "GET",
+            "path": "/api/comments",
+            "decision": "allow",
+            "userAgent": "curl/8.4.0",
+            "status": 200,
+            "latencyMs": 0.18
+          }
+        ]
+      },
+      "expected_behavior": "Server returns { inserted: 2 }. One finding upserted (xss/script-tag). Allowed event has no finding."
+    },
+
+    "invalid_missing_required_field": {
+      "sdk_emits": {
+        "events": [
+          {
+            "ip": "1.2.3.4"
+          }
+        ]
+      },
+      "expected_behavior": "Server returns HTTP 400 because method, path, and decision are required."
+    },
+
+    "invalid_empty_batch": {
+      "sdk_emits": {
+        "events": []
+      },
+      "expected_behavior": "Server returns HTTP 400 because batch must contain 1-500 events."
+    },
+
+    "invalid_bad_decision_enum": {
+      "sdk_emits": {
+        "events": [
+          {
+            "ip": "1.2.3.4",
+            "method": "GET",
+            "path": "/",
+            "decision": "maybe",
+            "userAgent": "",
+            "status": 200
+          }
+        ]
+      },
+      "expected_behavior": "Server returns HTTP 400 because 'maybe' is not in the decision enum."
+    },
+
+    "server_generates_missing_fields": {
+      "sdk_emits": {
+        "events": [
+          {
+            "ip": "1.2.3.4",
+            "method": "GET",
+            "path": "/api/health",
+            "decision": "allow"
+          }
+        ]
+      },
+      "expected_behavior": "Server accepts event. Missing id is auto-generated. Missing ts defaults to server now(). Missing userAgent defaults to ''. Missing status defaults to 200."
+    },
+
+    "batch_size_limit": {
+      "sdk_emits_count": 501,
+      "expected_behavior": "Server returns HTTP 400 because batch exceeds 500-event limit. SDK must split batches >= 500 before sending."
+    },
+
+    "cross_sdk_parity": {
+      "description": "Given the same attack payload hitting Node, Python, and Go adapters, the TelemetryEvent emitted MUST have identical values for: decision, vector, rule, severity, matchedPattern. ts and latencyMs will differ per request and are not compared. ip, method, path are framework-provided and must be canonical (lowercase method excluded — normalize uppercase).",
+      "parity_fields": ["decision", "vector", "rule", "severity", "matchedPattern"],
+      "non_parity_fields": ["id", "ts", "latencyMs", "userAgent"]
+    },
+
+    "middleware_emission": {
+      "description": "Cross-SDK parity vectors: given a request shape arriving at arcis() middleware, the emitted TelemetryEvent MUST match expected_event on the listed fields. Each SDK reuses these cases. Excluded from comparison: ts, latencyMs, ip, userAgent (framework- or time-derived).",
+      "compared_fields": ["decision", "vector", "severity", "status"],
+      "cases": [
+        {
+          "name": "clean_get_request",
+          "config": { "rateLimit": { "max": 100 } },
+          "request": { "method": "GET", "path": "/ping" },
+          "expected_event": {
+            "decision": "allow",
+            "status": 200
+          }
+        },
+        {
+          "name": "rate_limit_exceeded",
+          "config": { "rateLimit": { "max": 1, "windowMs": 60000 } },
+          "request": { "method": "GET", "path": "/x", "repeat": 2 },
+          "compare_event_index": 1,
+          "expected_event": {
+            "decision": "deny",
+            "vector": "rate-limit",
+            "severity": "medium",
+            "status": 429
+          }
+        },
+        {
+          "name": "sql_injection_in_body",
+          "config": { "rateLimit": false, "sanitize": { "mode": "reject" } },
+          "request": {
+            "method": "POST",
+            "path": "/login",
+            "body": { "user": "admin' UNION SELECT * FROM users --" }
+          },
+          "expected_event": {
+            "decision": "deny",
+            "vector": "sql",
+            "severity": "high",
+            "status": 400
+          }
+        },
+        {
+          "name": "command_injection_backticks",
+          "config": { "rateLimit": false, "sanitize": { "mode": "reject" } },
+          "request": {
+            "method": "POST",
+            "path": "/run",
+            "body": { "cmd": "hello `whoami` world" }
+          },
+          "expected_event": {
+            "decision": "deny",
+            "vector": "command",
+            "severity": "high",
+            "status": 400
+          }
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Opt-in telemetry shipped to Node + Python SDKs at parity (shared spec + test vectors)
- Stage 1 env auto-pickup: `ARCIS_WORKSPACE_ID` + `ARCIS_KEY` resolved from `.env` — `app.use(arcis())` works with no in-code config
- Versions bumped to **1.4.3** in npm `package.json` and PyPI `pyproject.toml` + `__init__.py`

## What's in
- `packages/arcis-node/src/telemetry/` — client + types
- `packages/arcis-node/src/middleware/telemetry.ts` — middleware glue
- `packages/arcis-python/arcis/telemetry/` — client + types
- `packages/arcis-python/arcis/middleware/telemetry.py` — middleware glue
- `spec/API_SPEC.md` + `spec/TEST_VECTORS.json` — telemetry contract + shared cases
- Full test suites: client, middleware, env-pickup, parity (Node + Python)

## Out of scope
- Dashboard work (separate PR)
- Website docs.css floating-sidebar tweak (separate PR)

## Test plan
- [ ] `cd packages/arcis-node && npm ci && npm test` — full Node suite incl. telemetry/* tests
- [ ] `cd packages/arcis-python && pip install -e ".[dev]" && pytest` — full Python suite incl. telemetry/test_*.py
- [ ] Parity test passes in both SDKs (`telemetry/parity` + `test_parity.py`)
- [ ] CI green on this PR before squash-merging `nwl → main` for the v1.4.3 publish