### PR TITLE
website: unify navbar + footer + changelog version-jump; ci: build node before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
           cache-dependency-path: packages/arcis-node/package-lock.json
       - run: npm ci
       - run: npm run typecheck
+      # Build before tests — tests/cli/arcis.test.ts invokes the built
+      # dispatcher (dist/cli/arcis.mjs) as a subprocess and beforeAll
+      # aborts if the artifact is missing.
+      - run: npm run build
       - run: npm test -- --run
 
   python:

--- a/website/changelog.html
+++ b/website/changelog.html
@@ -13,9 +13,9 @@
     gtag('config', 'G-TGPW4N5TR2');
   </script>
 
-  <title>Changelog — Arcis</title>
+  <title>Changelog · Arcis</title>
   <meta name="description" content="Release history for Arcis security middleware. Every version, every vector closed.">
-  <meta property="og:title" content="Arcis — Changelog">
+  <meta property="og:title" content="Arcis · Changelog">
   <meta property="og:description" content="Release history for Arcis security middleware.">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary">
@@ -56,28 +56,176 @@
 
     .container { max-width: 880px; margin: 0 auto; padding: 0 1.5rem; }
 
-    /* ─── Header ─────────────────────── */
+    /* ─── Two-pane layout: version index on the left, releases on the
+       right. The index is sticky so it stays visible while the user
+       scrolls through long histories. Collapses to a single column
+       below 920px (where the sidebar would crowd the content). */
+    .layout {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+      display: grid;
+      grid-template-columns: 220px 1fr;
+      gap: 3rem;
+      align-items: start;
+    }
+    .version-nav {
+      position: sticky;
+      top: 80px;
+      max-height: calc(100vh - 100px);
+      overflow-y: auto;
+      padding-right: 0.5rem;
+    }
+    .version-nav-title {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.65rem;
+      font-weight: 700;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: 0.85rem;
+      padding-left: 0.75rem;
+    }
+    .version-nav ul { list-style: none; padding: 0; margin: 0; }
+    .version-nav li { margin: 0; }
+    .version-nav-link {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      padding: 0.5rem 0.75rem;
+      border-radius: 8px;
+      color: var(--text-soft);
+      font-size: 0.85rem;
+      font-family: 'JetBrains Mono', monospace;
+      transition: all 0.15s ease;
+      border-left: 2px solid transparent;
+    }
+    .version-nav-link:hover {
+      background: var(--bg-alt);
+      color: var(--text);
+      text-decoration: none;
+    }
+    .version-nav-link.active {
+      background: var(--primary-soft);
+      color: var(--primary);
+      border-left-color: var(--primary);
+    }
+    .version-nav-version { font-weight: 600; }
+    .version-nav-date {
+      font-size: 0.7rem;
+      color: var(--text-muted);
+      letter-spacing: 0.04em;
+    }
+    @media (max-width: 920px) {
+      .layout { grid-template-columns: 1fr; gap: 1.5rem; }
+      .version-nav { position: static; max-height: none; padding-right: 0; }
+      .version-nav-title { margin-top: 1rem; }
+    }
+    /* Anchor offset — when jumping via #v1-4-4 the release card must
+       sit below the fixed nav, not under it. */
+    .release { scroll-margin-top: 96px; }
+
+    /* ─── Navigation — mirrors index.html so the navbar feels
+       continuous across pages. Same vars, same heights, same
+       Try/Star CTA on the right. */
     .nav {
-      position: sticky; top: 0; z-index: 50;
+      position: fixed;
+      top: 0; left: 0; right: 0;
+      height: 64px;
       background: rgba(228, 229, 224, 0.85);
-      backdrop-filter: blur(12px);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
       border-bottom: 1px solid var(--border);
-      padding: 1rem 0;
+      z-index: 1000;
+      transition: box-shadow 0.3s ease;
     }
+    .nav.scrolled { box-shadow: 0 1px 20px rgba(0,0,0,0.06); }
     .nav-inner {
-      max-width: 1100px; margin: 0 auto; padding: 0 1.5rem;
-      display: flex; align-items: center; justify-content: space-between; gap: 1.5rem;
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 0 2rem;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
     }
-    .nav-brand {
+    .nav-logo {
       font-family: 'EB Garamond', serif;
-      font-size: 1.5rem; font-weight: 600; color: var(--text);
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: var(--text);
     }
-    .nav-brand .dot { color: var(--primary); }
-    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
-    .nav-link {
-      font-size: 0.9rem; color: var(--text-soft); font-weight: 500;
+    .nav-logo span { color: var(--primary); }
+    .nav-links {
+      display: flex;
+      align-items: center;
+      gap: 2rem;
+      list-style: none;
     }
-    .nav-link:hover { color: var(--text); text-decoration: none; }
+    .nav-links a {
+      font-size: 0.9rem;
+      font-weight: 500;
+      color: var(--text-soft);
+      transition: color 0.2s;
+    }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+    .nav-cta { display: flex; align-items: center; gap: 0.75rem; }
+    .btn-star {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      border: 1.5px solid var(--border);
+      border-radius: 8px;
+      font-size: 0.85rem;
+      font-weight: 500;
+      color: var(--text-soft);
+      background: var(--bg-alt);
+      transition: all 0.2s;
+      cursor: pointer;
+    }
+    .btn-star:hover { border-color: var(--text-muted); color: var(--text); box-shadow: 0 2px 8px rgba(0,0,0,0.06); text-decoration: none; }
+    .btn-star svg { width: 16px; height: 16px; }
+    .btn-star .star-count {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      color: var(--primary);
+      font-weight: 600;
+    }
+    .btn-primary {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.55rem 1.25rem;
+      background: var(--primary);
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s;
+      text-decoration: none;
+    }
+    .btn-primary:hover { background: #007a57; transform: translateY(-1px); box-shadow: 0 4px 16px rgba(0, 153, 109, 0.25); text-decoration: none; }
+    .hamburger {
+      display: none;
+      flex-direction: column;
+      gap: 5px;
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 4px;
+    }
+    .hamburger span { display: block; width: 22px; height: 2px; background: var(--text); border-radius: 2px; transition: all 0.3s; }
+    /* Push content below the fixed nav so the hero doesn't disappear under it. */
+    body { padding-top: 64px; }
+    @media (max-width: 768px) {
+      .nav-links, .nav-cta { display: none; }
+      .hamburger { display: flex; }
+    }
 
     /* ─── Hero ─────────────────────── */
     .hero { padding: 4rem 0 2.5rem; text-align: center; }
@@ -173,13 +321,87 @@
       border: 1px solid var(--border);
     }
 
-    /* ─── Footer ─────────────────────── */
-    .foot {
-      border-top: 1px solid var(--border);
-      padding: 2rem 0; text-align: center;
-      color: var(--text-muted); font-size: 0.85rem;
+    /* ─── Footer — same dark surface as index.html so the bottom of
+       every page on the site reads as one continuous brand. Vars are
+       declared inline since changelog.html doesn't pull in docs.css. */
+    .footer {
+      background: #141413;
+      color: rgba(255,255,255,0.5);
+      padding: 3.5rem 0 2rem;
+      border-top: 1px solid rgba(255,255,255,0.08);
+      margin-top: 4rem;
     }
-    .foot a { color: var(--text-soft); margin: 0 0.6rem; }
+    .footer .container {
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 0 2rem;
+    }
+    .footer-inner {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      flex-wrap: wrap;
+      gap: 2rem;
+    }
+    .footer-brand { max-width: 300px; }
+    .footer-logo {
+      font-family: 'EB Garamond', serif;
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: #fff;
+      margin-bottom: 0.75rem;
+    }
+    .footer-logo span { color: #68D970; }
+    .footer-tagline { font-size: 0.85rem; line-height: 1.55; color: rgba(255,255,255,0.5); }
+    .footer-badges { display: flex; gap: 0.75rem; margin-top: 1.25rem; }
+    .footer-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.35rem 0.75rem;
+      background: rgba(255,255,255,0.06);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 6px;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: rgba(255,255,255,0.6);
+    }
+    .footer-columns { display: flex; gap: 4rem; flex-wrap: wrap; }
+    .footer-col h4 {
+      font-size: 0.8rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: rgba(255,255,255,0.7);
+      margin-bottom: 0.75rem;
+    }
+    .footer-col ul { list-style: none; padding: 0; margin: 0; }
+    .footer-col li { margin-bottom: 0.4rem; }
+    .footer-col a { font-size: 0.85rem; color: rgba(255,255,255,0.5); text-decoration: none; transition: color 0.2s; }
+    .footer-col a:hover { color: rgba(255,255,255,0.9); text-decoration: none; }
+    .footer-bottom {
+      margin-top: 2.5rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid rgba(255,255,255,0.08);
+      font-size: 0.8rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+    .footer-social { display: flex; gap: 1rem; }
+    .footer-social a {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px; height: 32px;
+      border-radius: 8px;
+      background: rgba(255,255,255,0.06);
+      transition: all 0.2s;
+    }
+    .footer-social a:hover { background: rgba(255,255,255,0.12); }
+    .footer-social svg { width: 16px; height: 16px; fill: rgba(255,255,255,0.6); }
 
     /* ─── Loading + error states ─────────────────────── */
     .loading {
@@ -196,14 +418,30 @@
   </style>
 </head>
 <body>
-  <nav class="nav">
+  <nav class="nav" id="nav">
     <div class="nav-inner">
-      <a href="/arcis/" class="nav-brand">Arcis<span class="dot">.</span></a>
-      <div class="nav-links">
-        <a href="/arcis/" class="nav-link">Home</a>
-        <a href="/arcis/documentation/" class="nav-link">Docs</a>
-        <a href="https://github.com/GagancM/arcis" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+      <a href="/arcis/" class="nav-logo">Arcis<span>.</span></a>
+      <ul class="nav-links">
+        <li><a href="/arcis/#how-it-works">How It Works</a></li>
+        <li><a href="/arcis/#languages">Languages</a></li>
+        <li><a href="/arcis/#threats">Threats</a></li>
+        <li><a href="/arcis/#comparison">Compare</a></li>
+        <li><a href="/arcis/documentation/">Docs</a></li>
+      </ul>
+      <div class="nav-cta">
+        <a href="https://github.com/GagancM/arcis" target="_blank" rel="noopener" class="btn-star">
+          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+          Star
+          <span class="star-count" id="starCount"></span>
+        </a>
+        <a href="/arcis/#get-started" class="btn-primary">
+          Try Arcis
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
+        </a>
       </div>
+      <button class="hamburger" aria-label="Menu">
+        <span></span><span></span><span></span>
+      </button>
     </div>
   </nav>
 
@@ -217,18 +455,72 @@
   </header>
 
   <section class="releases">
-    <div class="container">
+    <div class="layout">
+      <aside class="version-nav" aria-label="Version index">
+        <div class="version-nav-title">Versions</div>
+        <ul id="versionList">
+          <li><span class="version-nav-link" style="color: var(--text-muted);">Loading…</span></li>
+        </ul>
+      </aside>
       <div id="releases" class="loading">Loading releases…</div>
     </div>
   </section>
 
-  <footer class="foot">
+  <footer class="footer">
     <div class="container">
-      <a href="/arcis/">Home</a> ·
-      <a href="/arcis/documentation/">Docs</a> ·
-      <a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm</a> ·
-      <a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI</a> ·
-      <a href="https://github.com/GagancM/arcis" target="_blank" rel="noopener">GitHub</a>
+      <div class="footer-inner">
+        <div class="footer-brand">
+          <div class="footer-logo">Arcis<span>.</span></div>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <div class="footer-badges">
+            <span class="footer-badge">
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+              MIT License
+            </span>
+            <span class="footer-badge">Open Source</span>
+          </div>
+        </div>
+        <div class="footer-columns">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="/arcis/#how-it-works">How It Works</a></li>
+              <li><a href="/arcis/#languages">Languages</a></li>
+              <li><a href="/arcis/#threats">Threat Coverage</a></li>
+              <li><a href="/arcis/#comparison">Comparison</a></li>
+              <li><a href="/arcis/#get-started">Get Started</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>SDKs</h4>
+            <ul>
+              <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm &mdash; @arcis/node</a></li>
+              <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI &mdash; arcis</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">Go Module</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="/arcis/documentation/">Documentation</a></li>
+              <li><a href="/arcis/changelog.html">Changelog</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://github.com/Gagancm/arcis/issues" target="_blank" rel="noopener">Issues</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>MIT License &middot; Built by <a href="https://github.com/Gagancm" target="_blank" rel="noopener" style="color: rgba(255,255,255,0.7);">Gagan</a></span>
+        <div class="footer-social">
+          <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" aria-label="GitHub">
+            <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+          </a>
+          <a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener" aria-label="npm">
+            <svg viewBox="0 0 16 16"><path d="M0 0v16h16V0H0zm13 13H8V5h-2v8H3V3h10v10z"/></svg>
+          </a>
+        </div>
+      </div>
     </div>
   </footer>
 
@@ -251,6 +543,12 @@
       } catch { return iso; }
     }
 
+    // Slug a version like "1.4.4" into "v1-4-4" for use as the
+    // release card's id and the sidebar link's hash target.
+    function slugVersion(v) {
+      return 'v' + String(v).replace(/\./g, '-');
+    }
+
     function renderRelease(r, isLatest) {
       const detailsHtml = (r.details || [])
         .map(d => `<li>${escape(d)}</li>`).join('');
@@ -260,7 +558,7 @@
         ? '<span class="release-latest-tag">Latest</span>' : '';
 
       return `
-        <article class="release${isLatest ? ' latest' : ''}">
+        <article class="release${isLatest ? ' latest' : ''}" id="${slugVersion(r.version)}">
           <div class="release-header">
             <span class="release-version">v${escape(r.version)}</span>
             <span class="release-date">${escape(fmtDate(r.date))}</span>
@@ -271,6 +569,50 @@
           ${packagesHtml ? `<div class="release-packages">${packagesHtml}</div>` : ''}
         </article>
       `;
+    }
+
+    // Render the left-side version index. Each link jumps to the
+    // matching release card via hash anchor; the active state syncs
+    // with whatever the user is currently scrolling through.
+    function renderVersionList(releases) {
+      const list = document.getElementById('versionList');
+      list.innerHTML = releases
+        .map(r => `
+          <li>
+            <a href="#${slugVersion(r.version)}" class="version-nav-link" data-version="${escape(r.version)}">
+              <span class="version-nav-version">v${escape(r.version)}</span>
+              <span class="version-nav-date">${escape(fmtDate(r.date).replace(/, \d{4}$/, ''))}</span>
+            </a>
+          </li>
+        `).join('');
+    }
+
+    // Highlight whichever version's card is currently in view. Uses
+    // IntersectionObserver so we don't manually compute scroll offsets.
+    function activateScrollSpy() {
+      const links = Array.from(document.querySelectorAll('.version-nav-link'));
+      const cards = Array.from(document.querySelectorAll('.release'));
+      if (cards.length === 0) return;
+
+      const setActive = (id) => {
+        links.forEach(l => l.classList.toggle(
+          'active',
+          l.getAttribute('href') === '#' + id,
+        ));
+      };
+
+      const observer = new IntersectionObserver(entries => {
+        // Pick the highest visible card so as the user scrolls down,
+        // the active marker advances cleanly version-by-version.
+        const visible = entries
+          .filter(e => e.isIntersecting)
+          .sort((a, b) => a.target.offsetTop - b.target.offsetTop);
+        if (visible.length > 0) setActive(visible[0].target.id);
+      }, { rootMargin: '-100px 0px -60% 0px', threshold: 0 });
+
+      cards.forEach(c => observer.observe(c));
+      // Initial state so the first card is highlighted before any scroll.
+      setActive(cards[0].id);
     }
 
     fetch('changelog.json', { cache: 'no-cache' })
@@ -286,6 +628,7 @@
         if (releases.length === 0) {
           target.innerHTML = '<div class="err">No releases yet.</div>';
           pill.textContent = 'No releases';
+          document.getElementById('versionList').innerHTML = '';
           return;
         }
 
@@ -294,12 +637,39 @@
         target.innerHTML = releases
           .map((r, i) => renderRelease(r, i === 0))
           .join('');
+        renderVersionList(releases);
+        // Activate the spy after the DOM has settled so the cards have
+        // their final layout / scroll positions.
+        requestAnimationFrame(activateScrollSpy);
       })
       .catch(err => {
         document.getElementById('releases').innerHTML =
           `<div class="err">Failed to load changelog: ${escape(err.message)}<br>` +
           `<a href="https://github.com/GagancM/arcis/releases">View on GitHub</a></div>`;
       });
+
+    // Populate the navbar star count from GitHub. Fails silently — the
+    // button still works as a plain link if the API is rate-limited.
+    fetch('https://api.github.com/repos/Gagancm/arcis')
+      .then(r => r.json())
+      .then(data => {
+        const count = document.getElementById('starCount');
+        if (count && data.stargazers_count !== undefined) {
+          count.textContent = data.stargazers_count;
+        }
+      })
+      .catch(() => {});
+
+    // Add the .scrolled state to the nav once the user scrolls past the
+    // hero so the shadow lifts in — same behaviour as index.html.
+    const nav = document.getElementById('nav');
+    if (nav) {
+      const onScroll = () => {
+        nav.classList.toggle('scrolled', window.scrollY > 8);
+      };
+      window.addEventListener('scroll', onScroll, { passive: true });
+      onScroll();
+    }
   </script>
 </body>
 </html>

--- a/website/documentation/api-reference.html
+++ b/website/documentation/api-reference.html
@@ -205,10 +205,64 @@ validateUrl<span class="p">(</span><span class="s">'https://api.example.com/'</s
     </main>
   </div>
 
-  <footer class="docs-footer">
-    <div>© 2026 Arcis. MIT Licensed.</div>
-    <div><a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></div>
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="footer-brand">
+          <div class="footer-logo">Arcis<span>.</span></div>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <div class="footer-badges">
+            <span class="footer-badge">
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+              MIT License
+            </span>
+            <span class="footer-badge">Open Source</span>
+          </div>
+        </div>
+        <div class="footer-columns">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="../#how-it-works">How It Works</a></li>
+              <li><a href="../#languages">Languages</a></li>
+              <li><a href="../#threats">Threat Coverage</a></li>
+              <li><a href="../#comparison">Comparison</a></li>
+              <li><a href="../#get-started">Get Started</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>SDKs</h4>
+            <ul>
+              <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm &mdash; @arcis/node</a></li>
+              <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI &mdash; arcis</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">Go Module</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="./">Documentation</a></li>
+              <li><a href="../changelog.html">Changelog</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://github.com/Gagancm/arcis/issues" target="_blank" rel="noopener">Issues</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>MIT License &middot; Built by <a href="https://github.com/Gagancm" target="_blank" rel="noopener" style="color: rgba(255,255,255,0.7);">Gagan</a></span>
+        <div class="footer-social">
+          <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" aria-label="GitHub">
+            <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+          </a>
+          <a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener" aria-label="npm">
+            <svg viewBox="0 0 16 16"><path d="M0 0v16h16V0H0zm13 13H8V5h-2v8H3V3h10v10z"/></svg>
+          </a>
+        </div>
+      </div>
+    </div>
   </footer>
+
 
   <script>
     fetch('https://api.github.com/repos/Gagancm/arcis')

--- a/website/documentation/attack-vectors.html
+++ b/website/documentation/attack-vectors.html
@@ -170,10 +170,64 @@
     </main>
   </div>
 
-  <footer class="docs-footer">
-    <div>© 2026 Arcis. MIT Licensed.</div>
-    <div><a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></div>
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="footer-brand">
+          <div class="footer-logo">Arcis<span>.</span></div>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <div class="footer-badges">
+            <span class="footer-badge">
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+              MIT License
+            </span>
+            <span class="footer-badge">Open Source</span>
+          </div>
+        </div>
+        <div class="footer-columns">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="../#how-it-works">How It Works</a></li>
+              <li><a href="../#languages">Languages</a></li>
+              <li><a href="../#threats">Threat Coverage</a></li>
+              <li><a href="../#comparison">Comparison</a></li>
+              <li><a href="../#get-started">Get Started</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>SDKs</h4>
+            <ul>
+              <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm &mdash; @arcis/node</a></li>
+              <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI &mdash; arcis</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">Go Module</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="./">Documentation</a></li>
+              <li><a href="../changelog.html">Changelog</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://github.com/Gagancm/arcis/issues" target="_blank" rel="noopener">Issues</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>MIT License &middot; Built by <a href="https://github.com/Gagancm" target="_blank" rel="noopener" style="color: rgba(255,255,255,0.7);">Gagan</a></span>
+        <div class="footer-social">
+          <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" aria-label="GitHub">
+            <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+          </a>
+          <a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener" aria-label="npm">
+            <svg viewBox="0 0 16 16"><path d="M0 0v16h16V0H0zm13 13H8V5h-2v8H3V3h10v10z"/></svg>
+          </a>
+        </div>
+      </div>
+    </div>
   </footer>
+
 
   <script>
     fetch('https://api.github.com/repos/Gagancm/arcis')

--- a/website/documentation/cli.html
+++ b/website/documentation/cli.html
@@ -262,10 +262,64 @@ arcis scan http://localhost:8000 --route POST:/echo --field q --thorough</code><
     </main>
   </div>
 
-  <footer class="docs-footer">
-    <div>© 2026 Arcis. MIT Licensed.</div>
-    <div><a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></div>
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="footer-brand">
+          <div class="footer-logo">Arcis<span>.</span></div>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <div class="footer-badges">
+            <span class="footer-badge">
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+              MIT License
+            </span>
+            <span class="footer-badge">Open Source</span>
+          </div>
+        </div>
+        <div class="footer-columns">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="../#how-it-works">How It Works</a></li>
+              <li><a href="../#languages">Languages</a></li>
+              <li><a href="../#threats">Threat Coverage</a></li>
+              <li><a href="../#comparison">Comparison</a></li>
+              <li><a href="../#get-started">Get Started</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>SDKs</h4>
+            <ul>
+              <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm &mdash; @arcis/node</a></li>
+              <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI &mdash; arcis</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">Go Module</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="./">Documentation</a></li>
+              <li><a href="../changelog.html">Changelog</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://github.com/Gagancm/arcis/issues" target="_blank" rel="noopener">Issues</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>MIT License &middot; Built by <a href="https://github.com/Gagancm" target="_blank" rel="noopener" style="color: rgba(255,255,255,0.7);">Gagan</a></span>
+        <div class="footer-social">
+          <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" aria-label="GitHub">
+            <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+          </a>
+          <a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener" aria-label="npm">
+            <svg viewBox="0 0 16 16"><path d="M0 0v16h16V0H0zm13 13H8V5h-2v8H3V3h10v10z"/></svg>
+          </a>
+        </div>
+      </div>
+    </div>
   </footer>
+
 
   <script>
     fetch('https://api.github.com/repos/Gagancm/arcis')

--- a/website/documentation/configuration.html
+++ b/website/documentation/configuration.html
@@ -194,10 +194,64 @@ app.<span class="f">use</span><span class="p">(</span><span class="f">csrfProtec
     </main>
   </div>
 
-  <footer class="docs-footer">
-    <div>© 2026 Arcis. MIT Licensed.</div>
-    <div><a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></div>
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="footer-brand">
+          <div class="footer-logo">Arcis<span>.</span></div>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <div class="footer-badges">
+            <span class="footer-badge">
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+              MIT License
+            </span>
+            <span class="footer-badge">Open Source</span>
+          </div>
+        </div>
+        <div class="footer-columns">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="../#how-it-works">How It Works</a></li>
+              <li><a href="../#languages">Languages</a></li>
+              <li><a href="../#threats">Threat Coverage</a></li>
+              <li><a href="../#comparison">Comparison</a></li>
+              <li><a href="../#get-started">Get Started</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>SDKs</h4>
+            <ul>
+              <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm &mdash; @arcis/node</a></li>
+              <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI &mdash; arcis</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">Go Module</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="./">Documentation</a></li>
+              <li><a href="../changelog.html">Changelog</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://github.com/Gagancm/arcis/issues" target="_blank" rel="noopener">Issues</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>MIT License &middot; Built by <a href="https://github.com/Gagancm" target="_blank" rel="noopener" style="color: rgba(255,255,255,0.7);">Gagan</a></span>
+        <div class="footer-social">
+          <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" aria-label="GitHub">
+            <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+          </a>
+          <a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener" aria-label="npm">
+            <svg viewBox="0 0 16 16"><path d="M0 0v16h16V0H0zm13 13H8V5h-2v8H3V3h10v10z"/></svg>
+          </a>
+        </div>
+      </div>
+    </div>
   </footer>
+
 
   <script>
     fetch('https://api.github.com/repos/Gagancm/arcis')

--- a/website/documentation/docs.css
+++ b/website/documentation/docs.css
@@ -440,7 +440,96 @@ a:hover { color: var(--accent-hover); }
   color: var(--text);
 }
 
-/* ─── Footer ──────────────────────────────────────── */
+/* ─── Footer — shared across every page on the site so the bottom of
+   the doc, changelog, and landing pages all read as the same surface.
+   Mirrors index.html's footer; values stay in sync via the variables
+   already defined at the top of this file (--bg-dark, --accent-light,
+   --serif, --border-dark). */
+.footer {
+  background: var(--bg-dark);
+  color: rgba(255,255,255,0.5);
+  padding: 3.5rem 0 2rem;
+  border-top: 1px solid rgba(255,255,255,0.08);
+  margin-top: 4rem;
+}
+.footer .container {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+.footer-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+.footer-brand { max-width: 300px; }
+.footer-logo {
+  font-family: var(--serif, 'EB Garamond', serif);
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #fff;
+  margin-bottom: 0.75rem;
+}
+.footer-logo span { color: var(--accent-light); }
+.footer-tagline { font-size: 0.85rem; line-height: 1.55; color: rgba(255,255,255,0.5); }
+.footer-badges {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+.footer-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgba(255,255,255,0.6);
+}
+.footer-columns { display: flex; gap: 4rem; flex-wrap: wrap; }
+.footer-col h4 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255,255,255,0.7);
+  margin-bottom: 0.75rem;
+}
+.footer-col ul { list-style: none; padding: 0; margin: 0; }
+.footer-col li { margin-bottom: 0.4rem; }
+.footer-col a { font-size: 0.85rem; color: rgba(255,255,255,0.5); text-decoration: none; transition: color 0.2s; }
+.footer-col a:hover { color: rgba(255,255,255,0.9); }
+.footer-bottom {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(255,255,255,0.08);
+  font-size: 0.8rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.footer-social { display: flex; gap: 1rem; }
+.footer-social a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px; height: 32px;
+  border-radius: 8px;
+  background: rgba(255,255,255,0.06);
+  transition: all 0.2s;
+}
+.footer-social a:hover { background: rgba(255,255,255,0.12); }
+.footer-social svg { width: 16px; height: 16px; fill: rgba(255,255,255,0.6); }
+
+/* Legacy slim footer kept as a fallback for pages that haven't been
+   migrated yet. New pages should use .footer above. */
 .docs-footer {
   max-width: 1400px;
   margin: 0 auto;

--- a/website/documentation/frameworks.html
+++ b/website/documentation/frameworks.html
@@ -190,10 +190,64 @@ app = <span class="f">Flask</span><span class="p">(</span>__name__<span class="p
     </main>
   </div>
 
-  <footer class="docs-footer">
-    <div>© 2026 Arcis. MIT Licensed.</div>
-    <div><a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></div>
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="footer-brand">
+          <div class="footer-logo">Arcis<span>.</span></div>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <div class="footer-badges">
+            <span class="footer-badge">
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+              MIT License
+            </span>
+            <span class="footer-badge">Open Source</span>
+          </div>
+        </div>
+        <div class="footer-columns">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="../#how-it-works">How It Works</a></li>
+              <li><a href="../#languages">Languages</a></li>
+              <li><a href="../#threats">Threat Coverage</a></li>
+              <li><a href="../#comparison">Comparison</a></li>
+              <li><a href="../#get-started">Get Started</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>SDKs</h4>
+            <ul>
+              <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm &mdash; @arcis/node</a></li>
+              <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI &mdash; arcis</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">Go Module</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="./">Documentation</a></li>
+              <li><a href="../changelog.html">Changelog</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://github.com/Gagancm/arcis/issues" target="_blank" rel="noopener">Issues</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>MIT License &middot; Built by <a href="https://github.com/Gagancm" target="_blank" rel="noopener" style="color: rgba(255,255,255,0.7);">Gagan</a></span>
+        <div class="footer-social">
+          <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" aria-label="GitHub">
+            <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+          </a>
+          <a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener" aria-label="npm">
+            <svg viewBox="0 0 16 16"><path d="M0 0v16h16V0H0zm13 13H8V5h-2v8H3V3h10v10z"/></svg>
+          </a>
+        </div>
+      </div>
+    </div>
   </footer>
+
 
   <script>
     fetch('https://api.github.com/repos/Gagancm/arcis')

--- a/website/documentation/getting-started.html
+++ b/website/documentation/getting-started.html
@@ -248,10 +248,64 @@ curl <span class="s">'http://localhost:3000/?q=&lt;script&gt;alert(1)&lt;/script
     </main>
   </div>
 
-  <footer class="docs-footer">
-    <div>© 2026 Arcis. MIT Licensed.</div>
-    <div><a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></div>
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="footer-brand">
+          <div class="footer-logo">Arcis<span>.</span></div>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <div class="footer-badges">
+            <span class="footer-badge">
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+              MIT License
+            </span>
+            <span class="footer-badge">Open Source</span>
+          </div>
+        </div>
+        <div class="footer-columns">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="../#how-it-works">How It Works</a></li>
+              <li><a href="../#languages">Languages</a></li>
+              <li><a href="../#threats">Threat Coverage</a></li>
+              <li><a href="../#comparison">Comparison</a></li>
+              <li><a href="../#get-started">Get Started</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>SDKs</h4>
+            <ul>
+              <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm &mdash; @arcis/node</a></li>
+              <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI &mdash; arcis</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">Go Module</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="./">Documentation</a></li>
+              <li><a href="../changelog.html">Changelog</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://github.com/Gagancm/arcis/issues" target="_blank" rel="noopener">Issues</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>MIT License &middot; Built by <a href="https://github.com/Gagancm" target="_blank" rel="noopener" style="color: rgba(255,255,255,0.7);">Gagan</a></span>
+        <div class="footer-social">
+          <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" aria-label="GitHub">
+            <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+          </a>
+          <a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener" aria-label="npm">
+            <svg viewBox="0 0 16 16"><path d="M0 0v16h16V0H0zm13 13H8V5h-2v8H3V3h10v10z"/></svg>
+          </a>
+        </div>
+      </div>
+    </div>
   </footer>
+
 
   <script>
     document.querySelectorAll('.tab-btn').forEach(btn => {

--- a/website/documentation/index.html
+++ b/website/documentation/index.html
@@ -210,12 +210,64 @@ go get github.com/GagancM/arcis
   </div>
 
   <!-- Footer -->
-  <footer class="docs-footer">
-    <div>© 2026 Arcis. MIT Licensed.</div>
-    <div>
-      <a href="../">Home</a> · <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a>
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="footer-brand">
+          <div class="footer-logo">Arcis<span>.</span></div>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <div class="footer-badges">
+            <span class="footer-badge">
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+              MIT License
+            </span>
+            <span class="footer-badge">Open Source</span>
+          </div>
+        </div>
+        <div class="footer-columns">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="../#how-it-works">How It Works</a></li>
+              <li><a href="../#languages">Languages</a></li>
+              <li><a href="../#threats">Threat Coverage</a></li>
+              <li><a href="../#comparison">Comparison</a></li>
+              <li><a href="../#get-started">Get Started</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>SDKs</h4>
+            <ul>
+              <li><a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener">npm &mdash; @arcis/node</a></li>
+              <li><a href="https://pypi.org/project/arcis/" target="_blank" rel="noopener">PyPI &mdash; arcis</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">Go Module</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="./">Documentation</a></li>
+              <li><a href="../changelog.html">Changelog</a></li>
+              <li><a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://github.com/Gagancm/arcis/issues" target="_blank" rel="noopener">Issues</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>MIT License &middot; Built by <a href="https://github.com/Gagancm" target="_blank" rel="noopener" style="color: rgba(255,255,255,0.7);">Gagan</a></span>
+        <div class="footer-social">
+          <a href="https://github.com/Gagancm/arcis" target="_blank" rel="noopener" aria-label="GitHub">
+            <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+          </a>
+          <a href="https://www.npmjs.com/package/@arcis/node" target="_blank" rel="noopener" aria-label="npm">
+            <svg viewBox="0 0 16 16"><path d="M0 0v16h16V0H0zm13 13H8V5h-2v8H3V3h10v10z"/></svg>
+          </a>
+        </div>
+      </div>
     </div>
   </footer>
+
 
   <script>
     // Tab switching


### PR DESCRIPTION
## Summary

**Website (most of the diff)**
- Rebuild the changelog page navbar to match index.html (fixed position, backdrop blur, live GitHub Star count, Try Arcis CTA, hamburger). Title em-dash replaced with a middle dot.
- Add a sticky version-jump sidebar to the changelog so users can click any version (v1.4.4, v1.4.3, ...) and land on its release card. Active marker advances via IntersectionObserver while scrolling.
- Roll the dark Product / SDKs / Resources footer from index.html out to every documentation page and the changelog. Shared via docs.css for the doc pages, inlined for the changelog. Resources column now links to the Changelog from every page.

**CI fix (one line in `.github/workflows/ci.yml`)**
- `tests/cli/arcis.test.ts` invokes the built CLI dispatcher (`dist/cli/arcis.mjs`) as a subprocess and `beforeAll` throws if the artifact is missing. Workflow only ran `npm test`, never `npm run build` — so every PR after the v1.4.4 CLI dispatcher merged had a red Node check. Adds the build step before the test step.

## Test plan
- [ ] Open /arcis/changelog.html — navbar matches /arcis/, Star count shows real number, version sidebar lists every release
- [ ] Click any version link — release card scrolls into view below the navbar; sidebar marker follows scroll
- [ ] Open each /arcis/documentation/*.html page — same dark footer renders, Resources column links work
- [ ] Mobile: navbar collapses, footer columns wrap, version sidebar stacks above content below 920px
- [ ] CI: Node check passes (was failing because `dist/cli/arcis.mjs` was missing)