### PR TITLE
sca(phasec): --fail-on severity gate for non-zero exit

### DIFF
--- a/packages/arcis-rust/crates/arcis-cli/src/sca.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/sca.rs
@@ -585,7 +585,10 @@ fn print_help<W: Write>(w: &mut W) -> io::Result<()> {
         w,
         "Supply Chain Attack Scanner \u{2014} detect compromised packages from"
     )?;
-    writeln!(w, "known supply chain attacks. Runs offline by default; pass")?;
+    writeln!(
+        w,
+        "known supply chain attacks. Runs offline by default; pass"
+    )?;
     writeln!(w, "--osv to augment with live data from api.osv.dev.")?;
     writeln!(w)?;
     writeln!(w, "positional arguments:")?;
@@ -923,10 +926,7 @@ mod tests {
         // threat DB only emits critical/high/medium, so `--fail-on low`
         // would be a footgun (selects nothing additional vs `any`). If a
         // low-severity finding ever lands, add `low` here AND in the enum.
-        let argv: Vec<String> = ["--fail-on", "low"]
-            .into_iter()
-            .map(String::from)
-            .collect();
+        let argv: Vec<String> = ["--fail-on", "low"].into_iter().map(String::from).collect();
         assert!(matches!(parse_args(&argv), ParseOutcome::Err(_)));
     }
 
@@ -983,14 +983,20 @@ mod tests {
                 finding_with_severity("critical"),
                 finding_with_severity("medium"),
             ],
-            vec![finding_with_severity("medium"), finding_with_severity("high")],
+            vec![
+                finding_with_severity("medium"),
+                finding_with_severity("high"),
+            ],
         ];
         for f in &fixtures {
             let legacy = !f.is_empty();
             let any_mode = should_fail(f, FailOn::Any);
             let default_mode = should_fail(f, FailOn::default());
             assert_eq!(any_mode, legacy, "Any drifted from legacy for {f:?}");
-            assert_eq!(default_mode, legacy, "Default drifted from legacy for {f:?}");
+            assert_eq!(
+                default_mode, legacy,
+                "Default drifted from legacy for {f:?}"
+            );
             assert_eq!(any_mode, default_mode, "Default != Any for {f:?}");
         }
     }
@@ -1042,7 +1048,10 @@ mod tests {
             references: vec!["https://example.com/a".into()],
             finding_type: FindingType::CompromisedVersion,
         }];
-        print_sca_report(&mut buf, &path, &findings, 0.020, true, &manifests, 47, false).unwrap();
+        print_sca_report(
+            &mut buf, &path, &findings, 0.020, true, &manifests, 47, false,
+        )
+        .unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(out.contains("npm\n"));
         assert!(out.contains("[CRITICAL] COMPROMISED VERSION"));

--- a/packages/arcis-rust/crates/arcis-cli/src/sca.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/sca.rs
@@ -55,19 +55,14 @@ struct Args {
 /// trips on critical, `High` on critical+high, `Medium` on
 /// critical+high+medium, `Any` on any finding (current default), `None`
 /// always exits 0 even with findings (report-only mode for CI logs).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum FailOn {
     Critical,
     High,
     Medium,
+    #[default]
     Any,
     None,
-}
-
-impl Default for FailOn {
-    fn default() -> Self {
-        FailOn::Any
-    }
 }
 
 impl FailOn {
@@ -272,6 +267,10 @@ fn manifest_relname(m: &Path) -> String {
         .unwrap_or_default()
 }
 
+// Eight scalar args (one per report-row datum); a wrapper struct doesn't
+// add clarity for a single-use renderer with three callsites. Revisit if
+// this grows past ~10 args or gains another caller.
+#[allow(clippy::too_many_arguments)]
 fn print_sca_report<W: Write>(
     w: &mut W,
     path: &Path,

--- a/packages/arcis-rust/crates/arcis-cli/src/sca.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/sca.rs
@@ -16,7 +16,7 @@ use arcis_engine::sca::{
     discover_manifests, enumerate_packages, scan_project, scan_project_with_osv, Finding,
     FindingType, OsvOptions,
 };
-use arcis_engine::sca_sbom::emit_cyclonedx;
+use arcis_engine::sca_sbom::{emit_cyclonedx, emit_spdx};
 use arcis_engine::threat_db::Threat;
 
 const WIDTH: usize = 64;
@@ -94,24 +94,25 @@ impl FailOn {
 
 const FAIL_ON_VALUES: &str = "critical|high|medium|any|none";
 
-/// SBOM format selector. Today: CycloneDX 1.5 only. SPDX 2.3 lands in
-/// a follow-up commit on this same branch — the enum is kept rather
-/// than a bool so the second variant is a one-line addition.
+/// SBOM format selector. CycloneDX 1.5 and SPDX 2.3 both emit JSON; the
+/// engine picks the right shape per spec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Sbom {
     Cyclonedx,
+    Spdx,
 }
 
 impl Sbom {
     fn parse(s: &str) -> Option<Self> {
         match s.trim().to_ascii_lowercase().as_str() {
             "cyclonedx" => Some(Self::Cyclonedx),
+            "spdx" => Some(Self::Spdx),
             _ => None,
         }
     }
 }
 
-const SBOM_VALUES: &str = "cyclonedx";
+const SBOM_VALUES: &str = "cyclonedx|spdx";
 
 /// Decide whether `findings` should produce a non-zero exit under the
 /// given threshold. The severity ladder is `critical > high > medium`
@@ -724,7 +725,7 @@ fn print_help<W: Write>(w: &mut W) -> io::Result<()> {
     )?;
     writeln!(
         w,
-        "                      Values: cyclonedx (CycloneDX 1.5)."
+        "                      Values: cyclonedx (CycloneDX 1.5), spdx (SPDX 2.3)."
     )?;
     writeln!(
         w,
@@ -816,6 +817,7 @@ pub fn run(argv: &[String]) -> ExitCode {
         let emit_result: io::Result<()> = match args.output.as_ref() {
             None => match format {
                 Sbom::Cyclonedx => emit_cyclonedx(&mut out, &packages, &findings),
+                Sbom::Spdx => emit_spdx(&mut out, &packages, &findings),
             },
             Some(path) => {
                 let file = match File::create(path) {
@@ -828,6 +830,7 @@ pub fn run(argv: &[String]) -> ExitCode {
                 let mut bw = BufWriter::new(file);
                 let r = match format {
                     Sbom::Cyclonedx => emit_cyclonedx(&mut bw, &packages, &findings),
+                    Sbom::Spdx => emit_spdx(&mut bw, &packages, &findings),
                 };
                 r.and_then(|_| bw.flush())
             }
@@ -1200,13 +1203,12 @@ mod tests {
 
     #[test]
     fn parse_args_sbom_separate_value() {
-        let argv: Vec<String> = ["--sbom", "cyclonedx"]
-            .into_iter()
-            .map(String::from)
-            .collect();
-        match parse_args(&argv) {
-            ParseOutcome::Args(a) => assert_eq!(a.sbom, Some(Sbom::Cyclonedx)),
-            other => panic!("expected Args, got {other:?}"),
+        for (input, want) in [("cyclonedx", Sbom::Cyclonedx), ("spdx", Sbom::Spdx)] {
+            let argv: Vec<String> = ["--sbom", input].into_iter().map(String::from).collect();
+            match parse_args(&argv) {
+                ParseOutcome::Args(a) => assert_eq!(a.sbom, Some(want), "for {input:?}"),
+                other => panic!("expected Args for {input:?}, got {other:?}"),
+            }
         }
     }
 
@@ -1220,19 +1222,15 @@ mod tests {
     }
 
     #[test]
-    fn parse_args_sbom_rejects_unknown_value() {
-        // `spdx` lands in a follow-up commit; until then it falls through
-        // to the standard invalid-value error. `swid` covers the truly
-        // unknown case alongside.
-        for input in ["spdx", "swid"] {
-            let argv: Vec<String> = ["--sbom", input].into_iter().map(String::from).collect();
-            match parse_args(&argv) {
-                ParseOutcome::Err(msg) => {
-                    assert!(msg.contains(input), "msg should mention {input}: {msg}");
-                    assert!(msg.contains("cyclonedx"), "msg should list valid values: {msg}");
-                }
-                other => panic!("expected Err for {input}, got {other:?}"),
+    fn parse_args_sbom_invalid_value_errors() {
+        let argv: Vec<String> = ["--sbom", "swid"].into_iter().map(String::from).collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(msg) => {
+                assert!(msg.contains("swid"), "msg: {msg}");
+                assert!(msg.contains("cyclonedx"), "msg: {msg}");
+                assert!(msg.contains("spdx"), "msg: {msg}");
             }
+            other => panic!("expected Err, got {other:?}"),
         }
     }
 
@@ -1261,13 +1259,13 @@ mod tests {
 
     #[test]
     fn parse_args_sbom_with_output_file() {
-        let argv: Vec<String> = ["--sbom", "cyclonedx", "-o", "/tmp/sbom.json"]
+        let argv: Vec<String> = ["--sbom", "spdx", "-o", "/tmp/sbom.json"]
             .into_iter()
             .map(String::from)
             .collect();
         match parse_args(&argv) {
             ParseOutcome::Args(a) => {
-                assert_eq!(a.sbom, Some(Sbom::Cyclonedx));
+                assert_eq!(a.sbom, Some(Sbom::Spdx));
                 assert_eq!(a.output, Some(PathBuf::from("/tmp/sbom.json")));
             }
             other => panic!("expected Args, got {other:?}"),
@@ -1307,6 +1305,7 @@ mod tests {
             out.contains("cyclonedx (CycloneDX 1.5)"),
             "help should list cyclonedx"
         );
+        assert!(out.contains("spdx (SPDX 2.3)"), "help should list spdx");
         assert!(
             out.contains("-o, --output <file>"),
             "help missing -o/--output"

--- a/packages/arcis-rust/crates/arcis-cli/src/sca.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/sca.rs
@@ -45,6 +45,64 @@ struct Args {
     /// progress, which the Rust port doesn't render yet. Kept so users
     /// can pass `-q` without a parse error.
     _quiet: bool,
+    /// Severity ladder that gates the non-zero exit. `Any` (default)
+    /// preserves legacy behaviour: any finding → exit 1.
+    fail_on: FailOn,
+}
+
+/// Severity threshold for `arcis sca --fail-on <level>`. The CLI compares
+/// each finding's severity string against this enum: `Critical` only
+/// trips on critical, `High` on critical+high, `Medium` on
+/// critical+high+medium, `Any` on any finding (current default), `None`
+/// always exits 0 even with findings (report-only mode for CI logs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FailOn {
+    Critical,
+    High,
+    Medium,
+    Any,
+    None,
+}
+
+impl Default for FailOn {
+    fn default() -> Self {
+        FailOn::Any
+    }
+}
+
+impl FailOn {
+    /// Case-insensitive parse. Returns `None` for unknown values; the
+    /// caller turns that into a `ParseOutcome::Err` with the value list.
+    fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "critical" => Some(Self::Critical),
+            "high" => Some(Self::High),
+            "medium" => Some(Self::Medium),
+            "any" => Some(Self::Any),
+            "none" => Some(Self::None),
+            _ => None,
+        }
+    }
+}
+
+const FAIL_ON_VALUES: &str = "critical|high|medium|any|none";
+
+/// Decide whether `findings` should produce a non-zero exit under the
+/// given threshold. The severity ladder is `critical > high > medium`
+/// matching what the embedded threat DB emits today; `Any` and `None`
+/// short-circuit the ladder.
+fn should_fail(findings: &[Finding], fail_on: FailOn) -> bool {
+    match fail_on {
+        FailOn::None => false,
+        FailOn::Any => !findings.is_empty(),
+        FailOn::Critical => findings.iter().any(|f| f.severity == "critical"),
+        FailOn::High => findings
+            .iter()
+            .any(|f| matches!(f.severity.as_str(), "critical" | "high")),
+        FailOn::Medium => findings
+            .iter()
+            .any(|f| matches!(f.severity.as_str(), "critical" | "high" | "medium")),
+    }
 }
 
 #[derive(Debug)]
@@ -64,9 +122,12 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
     let mut osv = false;
     let mut no_cache = false;
     let mut quiet = false;
+    let mut fail_on = FailOn::default();
 
-    for arg in argv {
-        match arg.as_str() {
+    let mut i = 0;
+    while i < argv.len() {
+        let arg = argv[i].as_str();
+        match arg {
             "--system" => system = true,
             "--list-threats" | "--list" | "-l" => list_threats = true,
             "--no-color" => no_color = true,
@@ -74,6 +135,29 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
             "--no-cache" => no_cache = true,
             "--quiet" | "-q" => quiet = true,
             "-h" | "--help" => return ParseOutcome::Help,
+            "--fail-on" => {
+                i += 1;
+                let Some(val) = argv.get(i) else {
+                    return ParseOutcome::Err(format!(
+                        "arcis sca: --fail-on requires a value ({FAIL_ON_VALUES})"
+                    ));
+                };
+                let Some(parsed) = FailOn::parse(val) else {
+                    return ParseOutcome::Err(format!(
+                        "arcis sca: invalid --fail-on value: {val} (expected {FAIL_ON_VALUES})"
+                    ));
+                };
+                fail_on = parsed;
+            }
+            other if other.starts_with("--fail-on=") => {
+                let val = &other["--fail-on=".len()..];
+                let Some(parsed) = FailOn::parse(val) else {
+                    return ParseOutcome::Err(format!(
+                        "arcis sca: invalid --fail-on value: {val} (expected {FAIL_ON_VALUES})"
+                    ));
+                };
+                fail_on = parsed;
+            }
             other if other.starts_with("--") || (other.starts_with('-') && other.len() > 1) => {
                 return ParseOutcome::Err(format!("arcis sca: unknown flag: {other}"));
             }
@@ -86,6 +170,7 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
                 path = Some(PathBuf::from(other));
             }
         }
+        i += 1;
     }
 
     ParseOutcome::Args(Args {
@@ -96,6 +181,7 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
         osv,
         no_cache,
         _quiet: quiet,
+        fail_on,
     })
 }
 
@@ -492,7 +578,7 @@ fn print_threat_list<W: Write>(w: &mut W, threats: &[Threat], no_color: bool) ->
 fn print_help<W: Write>(w: &mut W) -> io::Result<()> {
     writeln!(
         w,
-        "usage: arcis sca [path] [--system] [--list] [--osv] [--no-cache] [--no-color] [-q]"
+        "usage: arcis sca [path] [--system] [--list] [--osv] [--no-cache] [--fail-on <level>] [--no-color] [-q]"
     )?;
     writeln!(w)?;
     writeln!(
@@ -524,6 +610,18 @@ fn print_help<W: Write>(w: &mut W) -> io::Result<()> {
     writeln!(
         w,
         "  --no-cache          Skip the on-disk OSV cache (~/.arcis/osv-cache.json)"
+    )?;
+    writeln!(
+        w,
+        "  --fail-on <level>   Minimum severity that triggers a non-zero exit."
+    )?;
+    writeln!(
+        w,
+        "                      Values: critical, high, medium, any, none."
+    )?;
+    writeln!(
+        w,
+        "                      Default: any (exit 1 on any finding)."
     )?;
     writeln!(w, "  --no-color          Disable colored output")?;
     writeln!(w, "  --quiet, -q         Suppress progress output")?;
@@ -602,10 +700,10 @@ pub fn run(argv: &[String]) -> ExitCode {
         args.osv,
     );
 
-    if findings.is_empty() {
-        ExitCode::from(0)
-    } else {
+    if should_fail(&findings, args.fail_on) {
         ExitCode::from(1)
+    } else {
+        ExitCode::from(0)
     }
 }
 
@@ -622,6 +720,7 @@ mod tests {
                 assert!(!a.system);
                 assert!(!a.list_threats);
                 assert!(!a.no_color);
+                assert_eq!(a.fail_on, FailOn::Any, "default fail_on must be Any");
             }
             other => panic!("expected Args, got {other:?}"),
         }
@@ -738,6 +837,192 @@ mod tests {
         assert!(out.contains("Clean. No known compromised packages found in 1 manifest."));
         assert!(out.contains("Compromised     0"));
         assert!(out.contains("Time            12ms"));
+    }
+
+    // ── --fail-on parsing + should_fail truth table ───────────────────────
+
+    fn finding_with_severity(sev: &str) -> Finding {
+        Finding {
+            package: "p".into(),
+            ecosystem: "npm".into(),
+            version: "1.0.0".into(),
+            severity: sev.into(),
+            location: "/tmp/lock".into(),
+            attack_vector: String::new(),
+            remediation: String::new(),
+            source: String::new(),
+            references: Vec::new(),
+            finding_type: FindingType::CompromisedVersion,
+        }
+    }
+
+    #[test]
+    fn parse_args_fail_on_separate_value() {
+        for (input, want) in [
+            ("critical", FailOn::Critical),
+            ("high", FailOn::High),
+            ("medium", FailOn::Medium),
+            ("any", FailOn::Any),
+            ("none", FailOn::None),
+        ] {
+            let argv: Vec<String> = ["--fail-on", input].into_iter().map(String::from).collect();
+            match parse_args(&argv) {
+                ParseOutcome::Args(a) => assert_eq!(a.fail_on, want, "for {input:?}"),
+                other => panic!("expected Args for {input:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn parse_args_fail_on_equals_form() {
+        let argv = vec!["--fail-on=high".to_string()];
+        match parse_args(&argv) {
+            ParseOutcome::Args(a) => assert_eq!(a.fail_on, FailOn::High),
+            other => panic!("expected Args, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_fail_on_case_insensitive() {
+        for input in ["HIGH", "High", "hIgH", " high "] {
+            let argv: Vec<String> = ["--fail-on", input].into_iter().map(String::from).collect();
+            match parse_args(&argv) {
+                ParseOutcome::Args(a) => assert_eq!(a.fail_on, FailOn::High, "for {input:?}"),
+                other => panic!("expected Args for {input:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn parse_args_fail_on_missing_value_errors() {
+        let argv = vec!["--fail-on".to_string()];
+        match parse_args(&argv) {
+            ParseOutcome::Err(msg) => assert!(msg.contains("requires a value"), "msg: {msg}"),
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_fail_on_invalid_value_errors() {
+        let argv: Vec<String> = ["--fail-on", "banana"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(msg) => {
+                assert!(msg.contains("banana"), "msg: {msg}");
+                assert!(msg.contains("expected"), "msg: {msg}");
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_rejects_low_value() {
+        // `low` is intentionally not in the value set today: the embedded
+        // threat DB only emits critical/high/medium, so `--fail-on low`
+        // would be a footgun (selects nothing additional vs `any`). If a
+        // low-severity finding ever lands, add `low` here AND in the enum.
+        let argv: Vec<String> = ["--fail-on", "low"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert!(matches!(parse_args(&argv), ParseOutcome::Err(_)));
+    }
+
+    #[test]
+    fn should_fail_truth_table() {
+        let crit = vec![finding_with_severity("critical")];
+        let high = vec![finding_with_severity("high")];
+        let med = vec![finding_with_severity("medium")];
+        let none: Vec<Finding> = vec![];
+
+        // Critical: only critical trips
+        assert!(should_fail(&crit, FailOn::Critical));
+        assert!(!should_fail(&high, FailOn::Critical));
+        assert!(!should_fail(&med, FailOn::Critical));
+        assert!(!should_fail(&none, FailOn::Critical));
+
+        // High: critical + high
+        assert!(should_fail(&crit, FailOn::High));
+        assert!(should_fail(&high, FailOn::High));
+        assert!(!should_fail(&med, FailOn::High));
+        assert!(!should_fail(&none, FailOn::High));
+
+        // Medium: critical + high + medium
+        assert!(should_fail(&crit, FailOn::Medium));
+        assert!(should_fail(&high, FailOn::Medium));
+        assert!(should_fail(&med, FailOn::Medium));
+        assert!(!should_fail(&none, FailOn::Medium));
+
+        // Any: any non-empty list
+        assert!(should_fail(&crit, FailOn::Any));
+        assert!(should_fail(&high, FailOn::Any));
+        assert!(should_fail(&med, FailOn::Any));
+        assert!(!should_fail(&none, FailOn::Any));
+
+        // None: never trips, even with critical findings
+        assert!(!should_fail(&crit, FailOn::None));
+        assert!(!should_fail(&high, FailOn::None));
+        assert!(!should_fail(&med, FailOn::None));
+        assert!(!should_fail(&none, FailOn::None));
+    }
+
+    #[test]
+    fn should_fail_any_matches_legacy_default_behaviour() {
+        // Future-proof against drift: --fail-on any must produce the
+        // same exit decision as the pre-flag predicate (`!findings.is_empty()`)
+        // for every fixture below. If the default ever changes silently,
+        // this test catches it.
+        let fixtures: Vec<Vec<Finding>> = vec![
+            vec![],
+            vec![finding_with_severity("critical")],
+            vec![finding_with_severity("high")],
+            vec![finding_with_severity("medium")],
+            vec![
+                finding_with_severity("critical"),
+                finding_with_severity("medium"),
+            ],
+            vec![finding_with_severity("medium"), finding_with_severity("high")],
+        ];
+        for f in &fixtures {
+            let legacy = !f.is_empty();
+            let any_mode = should_fail(f, FailOn::Any);
+            let default_mode = should_fail(f, FailOn::default());
+            assert_eq!(any_mode, legacy, "Any drifted from legacy for {f:?}");
+            assert_eq!(default_mode, legacy, "Default drifted from legacy for {f:?}");
+            assert_eq!(any_mode, default_mode, "Default != Any for {f:?}");
+        }
+    }
+
+    #[test]
+    fn should_fail_critical_with_high_only_findings_returns_false() {
+        // End-to-end-flavored: simulates the documented "--fail-on critical
+        // with only high findings → exit 0" amendment from the design call.
+        let findings = vec![
+            finding_with_severity("high"),
+            finding_with_severity("high"),
+            finding_with_severity("medium"),
+        ];
+        assert!(!should_fail(&findings, FailOn::Critical));
+    }
+
+    #[test]
+    fn print_help_documents_fail_on() {
+        let mut buf: Vec<u8> = Vec::new();
+        print_help(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("--fail-on"), "help missing --fail-on");
+        assert!(
+            out.contains("critical, high, medium, any, none"),
+            "help missing the value list"
+        );
+        assert!(
+            out.contains("Default: any"),
+            "help should document the default"
+        );
+        // Usage line should advertise the flag too.
+        assert!(out.contains("--fail-on <level>"), "usage missing --fail-on");
     }
 
     #[test]

--- a/packages/arcis-rust/crates/arcis-cli/src/sca.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/sca.rs
@@ -6,14 +6,17 @@
 //! the parity harness strips before byte-comparing.
 
 use std::env;
-use std::io::{self, Write};
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
 use std::path::{Component, Path, PathBuf};
 use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
 use arcis_engine::sca::{
-    discover_manifests, scan_project, scan_project_with_osv, Finding, FindingType, OsvOptions,
+    discover_manifests, enumerate_packages, scan_project, scan_project_with_osv, Finding,
+    FindingType, OsvOptions,
 };
+use arcis_engine::sca_sbom::emit_cyclonedx;
 use arcis_engine::threat_db::Threat;
 
 const WIDTH: usize = 64;
@@ -48,6 +51,15 @@ struct Args {
     /// Severity ladder that gates the non-zero exit. `Any` (default)
     /// preserves legacy behaviour: any finding → exit 1.
     fail_on: FailOn,
+    /// SBOM emit format. `None` keeps the human report; `Some` swaps in
+    /// the matching emitter and (when `output` is also `None`) suppresses
+    /// the human report on stdout.
+    sbom: Option<Sbom>,
+    /// Destination file for the SBOM. `None` writes to stdout.
+    /// Validation requires `sbom.is_some()` whenever this is set —
+    /// `-o` redirecting the human report is a separate feature, not on
+    /// this commit.
+    output: Option<PathBuf>,
 }
 
 /// Severity threshold for `arcis sca --fail-on <level>`. The CLI compares
@@ -81,6 +93,25 @@ impl FailOn {
 }
 
 const FAIL_ON_VALUES: &str = "critical|high|medium|any|none";
+
+/// SBOM format selector. Today: CycloneDX 1.5 only. SPDX 2.3 lands in
+/// a follow-up commit on this same branch — the enum is kept rather
+/// than a bool so the second variant is a one-line addition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Sbom {
+    Cyclonedx,
+}
+
+impl Sbom {
+    fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "cyclonedx" => Some(Self::Cyclonedx),
+            _ => None,
+        }
+    }
+}
+
+const SBOM_VALUES: &str = "cyclonedx";
 
 /// Decide whether `findings` should produce a non-zero exit under the
 /// given threshold. The severity ladder is `critical > high > medium`
@@ -118,6 +149,8 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
     let mut no_cache = false;
     let mut quiet = false;
     let mut fail_on = FailOn::default();
+    let mut sbom: Option<Sbom> = None;
+    let mut output: Option<PathBuf> = None;
 
     let mut i = 0;
     while i < argv.len() {
@@ -153,6 +186,54 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
                 };
                 fail_on = parsed;
             }
+            "--sbom" => {
+                i += 1;
+                let Some(val) = argv.get(i) else {
+                    return ParseOutcome::Err(format!(
+                        "arcis sca: --sbom requires a value ({SBOM_VALUES})"
+                    ));
+                };
+                let Some(parsed) = Sbom::parse(val) else {
+                    return ParseOutcome::Err(format!(
+                        "arcis sca: invalid --sbom value: {val} (expected {SBOM_VALUES})"
+                    ));
+                };
+                sbom = Some(parsed);
+            }
+            other if other.starts_with("--sbom=") => {
+                let val = &other["--sbom=".len()..];
+                let Some(parsed) = Sbom::parse(val) else {
+                    return ParseOutcome::Err(format!(
+                        "arcis sca: invalid --sbom value: {val} (expected {SBOM_VALUES})"
+                    ));
+                };
+                sbom = Some(parsed);
+            }
+            "-o" | "--output" => {
+                i += 1;
+                let Some(val) = argv.get(i) else {
+                    return ParseOutcome::Err(
+                        "arcis sca: -o/--output requires a file path".to_string(),
+                    );
+                };
+                output = Some(PathBuf::from(val));
+            }
+            other if other.starts_with("--output=") => {
+                let val = &other["--output=".len()..];
+                if val.is_empty() {
+                    return ParseOutcome::Err(
+                        "arcis sca: --output= requires a file path".to_string(),
+                    );
+                }
+                output = Some(PathBuf::from(val));
+            }
+            other if other.starts_with("-o=") => {
+                let val = &other["-o=".len()..];
+                if val.is_empty() {
+                    return ParseOutcome::Err("arcis sca: -o= requires a file path".to_string());
+                }
+                output = Some(PathBuf::from(val));
+            }
             other if other.starts_with("--") || (other.starts_with('-') && other.len() > 1) => {
                 return ParseOutcome::Err(format!("arcis sca: unknown flag: {other}"));
             }
@@ -168,6 +249,16 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
         i += 1;
     }
 
+    if output.is_some() && sbom.is_none() {
+        return ParseOutcome::Err(
+            "arcis sca: -o/--output requires --sbom (the human report cannot be redirected)"
+                .to_string(),
+        );
+    }
+
+    // note: when `arcis sca --json` lands, error here if both `--sbom`
+    // and `--json` are supplied (different machine output modes).
+
     ParseOutcome::Args(Args {
         path: path.unwrap_or_else(|| PathBuf::from(".")),
         system,
@@ -177,6 +268,8 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
         no_cache,
         _quiet: quiet,
         fail_on,
+        sbom,
+        output,
     })
 }
 
@@ -577,7 +670,7 @@ fn print_threat_list<W: Write>(w: &mut W, threats: &[Threat], no_color: bool) ->
 fn print_help<W: Write>(w: &mut W) -> io::Result<()> {
     writeln!(
         w,
-        "usage: arcis sca [path] [--system] [--list] [--osv] [--no-cache] [--fail-on <level>] [--no-color] [-q]"
+        "usage: arcis sca [path] [--system] [--list] [--osv] [--no-cache] [--fail-on <level>] [--sbom <format> [-o <file>]] [--no-color] [-q]"
     )?;
     writeln!(w)?;
     writeln!(
@@ -625,6 +718,32 @@ fn print_help<W: Write>(w: &mut W) -> io::Result<()> {
         w,
         "                      Default: any (exit 1 on any finding)."
     )?;
+    writeln!(
+        w,
+        "  --sbom <format>     Emit a Software Bill of Materials."
+    )?;
+    writeln!(
+        w,
+        "                      Values: cyclonedx (CycloneDX 1.5)."
+    )?;
+    writeln!(
+        w,
+        "                      License fields are NOASSERTION (Arcis does not"
+    )?;
+    writeln!(w, "                      track package license metadata).")?;
+    writeln!(
+        w,
+        "  -o, --output <file> Write the SBOM to <file> (requires --sbom)."
+    )?;
+    writeln!(
+        w,
+        "                      Without -o the SBOM goes to stdout and the"
+    )?;
+    writeln!(
+        w,
+        "                      human report is suppressed; with -o the human"
+    )?;
+    writeln!(w, "                      report still prints to stdout.")?;
     writeln!(w, "  --no-color          Disable colored output")?;
     writeln!(w, "  --quiet, -q         Suppress progress output")?;
     Ok(())
@@ -690,6 +809,53 @@ pub fn run(argv: &[String]) -> ExitCode {
         scan_project(&abs, args.system, &threats)
     };
     let duration = start.elapsed().as_secs_f64();
+
+    if let Some(format) = args.sbom {
+        let packages = enumerate_packages(&abs);
+        let emit_to_stdout = args.output.is_none();
+        let emit_result: io::Result<()> = match args.output.as_ref() {
+            None => match format {
+                Sbom::Cyclonedx => emit_cyclonedx(&mut out, &packages, &findings),
+            },
+            Some(path) => {
+                let file = match File::create(path) {
+                    Ok(f) => f,
+                    Err(e) => {
+                        eprintln!("arcis sca: cannot write SBOM to {}: {e}", path.display());
+                        return ExitCode::from(2);
+                    }
+                };
+                let mut bw = BufWriter::new(file);
+                let r = match format {
+                    Sbom::Cyclonedx => emit_cyclonedx(&mut bw, &packages, &findings),
+                };
+                r.and_then(|_| bw.flush())
+            }
+        };
+        if let Err(e) = emit_result {
+            eprintln!("arcis sca: SBOM emit failed: {e}");
+            return ExitCode::from(2);
+        }
+        // -o present → human report still goes to stdout. -o absent →
+        // SBOM owns stdout, no human report.
+        if !emit_to_stdout {
+            let _ = print_sca_report(
+                &mut out,
+                &abs,
+                &findings,
+                duration,
+                args.no_color,
+                &manifests,
+                threats.len(),
+                args.osv,
+            );
+        }
+        return if should_fail(&findings, args.fail_on) {
+            ExitCode::from(1)
+        } else {
+            ExitCode::from(0)
+        };
+    }
 
     let _ = print_sca_report(
         &mut out,
@@ -1028,6 +1194,133 @@ mod tests {
         );
         // Usage line should advertise the flag too.
         assert!(out.contains("--fail-on <level>"), "usage missing --fail-on");
+    }
+
+    // ── --sbom + -o parsing ───────────────────────────────────────────────
+
+    #[test]
+    fn parse_args_sbom_separate_value() {
+        let argv: Vec<String> = ["--sbom", "cyclonedx"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        match parse_args(&argv) {
+            ParseOutcome::Args(a) => assert_eq!(a.sbom, Some(Sbom::Cyclonedx)),
+            other => panic!("expected Args, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_sbom_equals_form_and_case_insensitive() {
+        let argv = vec!["--sbom=CycloneDX".to_string()];
+        match parse_args(&argv) {
+            ParseOutcome::Args(a) => assert_eq!(a.sbom, Some(Sbom::Cyclonedx)),
+            other => panic!("expected Args, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_sbom_rejects_unknown_value() {
+        // `spdx` lands in a follow-up commit; until then it falls through
+        // to the standard invalid-value error. `swid` covers the truly
+        // unknown case alongside.
+        for input in ["spdx", "swid"] {
+            let argv: Vec<String> = ["--sbom", input].into_iter().map(String::from).collect();
+            match parse_args(&argv) {
+                ParseOutcome::Err(msg) => {
+                    assert!(msg.contains(input), "msg should mention {input}: {msg}");
+                    assert!(msg.contains("cyclonedx"), "msg should list valid values: {msg}");
+                }
+                other => panic!("expected Err for {input}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn parse_args_sbom_missing_value_errors() {
+        let argv = vec!["--sbom".to_string()];
+        match parse_args(&argv) {
+            ParseOutcome::Err(msg) => assert!(msg.contains("requires a value"), "msg: {msg}"),
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_o_requires_sbom_errors() {
+        // -o without --sbom is rejected: today there's no sca --json mode
+        // and -o redirecting the human report is a separate feature.
+        let argv: Vec<String> = ["-o", "out.json"].into_iter().map(String::from).collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(msg) => assert!(
+                msg.contains("requires --sbom"),
+                "msg should explain the dependency: {msg}"
+            ),
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_sbom_with_output_file() {
+        let argv: Vec<String> = ["--sbom", "cyclonedx", "-o", "/tmp/sbom.json"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        match parse_args(&argv) {
+            ParseOutcome::Args(a) => {
+                assert_eq!(a.sbom, Some(Sbom::Cyclonedx));
+                assert_eq!(a.output, Some(PathBuf::from("/tmp/sbom.json")));
+            }
+            other => panic!("expected Args, got {other:?}"),
+        }
+        let argv: Vec<String> = ["--sbom=cyclonedx", "--output=/tmp/sbom.json"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        match parse_args(&argv) {
+            ParseOutcome::Args(a) => {
+                assert_eq!(a.sbom, Some(Sbom::Cyclonedx));
+                assert_eq!(a.output, Some(PathBuf::from("/tmp/sbom.json")));
+            }
+            other => panic!("expected Args, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_sbom_default_off() {
+        // Regression guard: bare `arcis sca` does not emit an SBOM.
+        match parse_args(&[]) {
+            ParseOutcome::Args(a) => {
+                assert!(a.sbom.is_none(), "SBOM must default to off");
+                assert!(a.output.is_none(), "output must default to None");
+            }
+            other => panic!("expected Args, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn print_help_documents_sbom() {
+        let mut buf: Vec<u8> = Vec::new();
+        print_help(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("--sbom <format>"), "help missing --sbom");
+        assert!(
+            out.contains("cyclonedx (CycloneDX 1.5)"),
+            "help should list cyclonedx"
+        );
+        assert!(
+            out.contains("-o, --output <file>"),
+            "help missing -o/--output"
+        );
+        assert!(
+            out.contains("requires --sbom"),
+            "help should document the dependency"
+        );
+        assert!(
+            out.contains("NOASSERTION"),
+            "help should disclose the license posture"
+        );
+        // Usage line should advertise --sbom too.
+        assert!(out.contains("--sbom <format>"), "usage missing --sbom");
     }
 
     #[test]

--- a/packages/arcis-rust/crates/arcis-engine/src/lib.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/lib.rs
@@ -18,6 +18,7 @@ pub mod audit;
 pub mod osv;
 pub mod osv_cache;
 pub mod sca;
+pub mod sca_sbom;
 pub mod scan;
 pub mod threat_db;
 pub mod version;

--- a/packages/arcis-rust/crates/arcis-engine/src/osv.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/osv.rs
@@ -148,7 +148,10 @@ pub async fn query(
         return Ok(Vec::new());
     }
     let body = OsvQuery {
-        package: OsvPackageRef { name, ecosystem: eco },
+        package: OsvPackageRef {
+            name,
+            ecosystem: eco,
+        },
         version,
     };
     let resp = client
@@ -166,8 +169,7 @@ pub async fn query(
     if bytes.is_empty() {
         return Err(OsvError::EmptyBody);
     }
-    let parsed: OsvResponse =
-        serde_json::from_slice(&bytes).map_err(|_| OsvError::EmptyBody)?;
+    let parsed: OsvResponse = serde_json::from_slice(&bytes).map_err(|_| OsvError::EmptyBody)?;
     Ok(parsed.vulns)
 }
 

--- a/packages/arcis-rust/crates/arcis-engine/src/sca.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/sca.rs
@@ -685,9 +685,7 @@ pub fn enumerate_packages(path: &Path) -> Vec<PackageRef> {
     enumerate_pipfile_lock(path, &mut out);
 
     let mut seen: HashSet<(String, String, String)> = HashSet::new();
-    out.retain(|p| {
-        seen.insert((p.ecosystem.clone(), p.name.clone(), p.version.clone()))
-    });
+    out.retain(|p| seen.insert((p.ecosystem.clone(), p.name.clone(), p.version.clone())));
     out
 }
 
@@ -804,10 +802,9 @@ fn enumerate_poetry_lock(path: &Path, out: &mut Vec<PackageRef>) {
         Err(_) => return,
     };
     let location = lockfile.display().to_string();
-    let block_re = Regex::new(
-        r#"\[\[package\]\][\s\S]*?name\s*=\s*"([^"]+)"[\s\S]*?version\s*=\s*"([^"]+)""#,
-    )
-    .expect("poetry block regex must compile");
+    let block_re =
+        Regex::new(r#"\[\[package\]\][\s\S]*?name\s*=\s*"([^"]+)"[\s\S]*?version\s*=\s*"([^"]+)""#)
+            .expect("poetry block regex must compile");
     for caps in block_re.captures_iter(&content) {
         out.push(PackageRef {
             ecosystem: "pypi".into(),
@@ -1015,8 +1012,7 @@ pub fn augment_with_osv(packages: &[PackageRef], opts: &OsvOptions) -> Vec<Findi
             }
 
             let vulns: Vec<OsvVuln> =
-                match osv::query(&client, &pkg.ecosystem, &pkg.name, &pkg.version, timeout).await
-                {
+                match osv::query(&client, &pkg.ecosystem, &pkg.name, &pkg.version, timeout).await {
                     Ok(v) => v,
                     Err(_) => continue,
                 };
@@ -1455,7 +1451,11 @@ mod tests {
             cache_key("npm", "safe-pkg", "1.0.0"),
             CacheEntry {
                 fetched_at: crate::osv_cache::unix_now(),
-                vulns: vec![osv_vuln("GHSA-only-osv", "advisory only on osv", Some("7.5"))],
+                vulns: vec![osv_vuln(
+                    "GHSA-only-osv",
+                    "advisory only on osv",
+                    Some("7.5"),
+                )],
             },
         );
         cache.save(&cache_path).unwrap();

--- a/packages/arcis-rust/crates/arcis-engine/src/sca.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/sca.rs
@@ -1190,7 +1190,7 @@ mod tests {
     // ── OSV layer tests ───────────────────────────────────────────────────
 
     use crate::osv::{OsvReference, OsvSeverity, OsvVuln};
-    use crate::osv_cache::{cache_key, CacheEntry, OsvCache, DEFAULT_TTL_SECS};
+    use crate::osv_cache::{cache_key, CacheEntry, OsvCache};
 
     fn osv_vuln(id: &str, summary: &str, score: Option<&str>) -> OsvVuln {
         OsvVuln {

--- a/packages/arcis-rust/crates/arcis-engine/src/sca_sbom.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/sca_sbom.rs
@@ -182,6 +182,12 @@ pub fn vuln_id(finding: &Finding) -> String {
         }
     }
     if let Some(rest) = finding.source.strip_prefix("osv:") {
+        // GHSA / CVE ids canonicalize to uppercase across both extraction
+        // paths so the same vuln gets the same id regardless of which
+        // finding source surfaced it.
+        if rest.starts_with("GHSA-") || rest.starts_with("ghsa-") || rest.starts_with("CVE-") {
+            return rest.to_ascii_uppercase();
+        }
         return rest.to_string();
     }
     format!("arcis-{}-{}", finding.package, finding.version)
@@ -900,8 +906,11 @@ mod tests {
 
     #[test]
     fn vuln_id_falls_back_to_osv_source() {
+        // Lowercase GHSA from osv: source canonicalises to uppercase, same as
+        // the references-extraction path. Vuln ids are case-insensitive but
+        // canonically uppercase per GHSA convention.
         let f = finding("npm", "x", "1.0", "high", None, "osv:GHSA-zzzz-yyyy-xxxx");
-        assert_eq!(vuln_id(&f), "GHSA-zzzz-yyyy-xxxx");
+        assert_eq!(vuln_id(&f), "GHSA-ZZZZ-YYYY-XXXX");
     }
 
     #[test]

--- a/packages/arcis-rust/crates/arcis-engine/src/sca_sbom.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/sca_sbom.rs
@@ -779,11 +779,7 @@ mod tests {
             .iter()
             .filter(|r| r["relationshipType"] == "AFFECTS")
             .collect();
-        assert_eq!(
-            affects.len(),
-            3,
-            "3 findings → 3 AFFECTS relationships"
-        );
+        assert_eq!(affects.len(), 3, "3 findings → 3 AFFECTS relationships");
 
         // Each AFFECTS links a Vulnerability SPDXID to a Package SPDXID.
         for r in &affects {

--- a/packages/arcis-rust/crates/arcis-engine/src/sca_sbom.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/sca_sbom.rs
@@ -1,18 +1,25 @@
-//! SBOM emitter for `arcis sca --sbom <format>`.
+//! SBOM emitters for `arcis sca --sbom <format>`.
 //!
-//! Today: CycloneDX 1.5 JSON — `bomFormat: "CycloneDX"`, `specVersion:
-//! "1.5"`. Components carry purl + bom-ref; vulnerabilities live at
-//! root level with `affects[].ref` pointing back to component bom-refs.
-//! SPDX 2.3 lands in a follow-up commit on this same branch.
+//! Two formats:
+//! * CycloneDX 1.5 JSON — `bomFormat: "CycloneDX"`, `specVersion: "1.5"`.
+//!   Components carry purl + bom-ref; vulnerabilities live at root level
+//!   with `affects[].ref` pointing back to component bom-refs.
+//! * SPDX 2.3 JSON — `spdxVersion: "SPDX-2.3"`, `dataLicense: "CC0-1.0"`.
+//!   Each vulnerability becomes a Package element of its own and is
+//!   linked to affected packages via a `relationships` entry with
+//!   `relationshipType: "AFFECTS"`. This is the SPDX 2.3 idiom; SPDX has
+//!   no first-class vulnerability primitive, so shoehorning the
+//!   CycloneDX `vulnerabilities` shape here would be off-spec.
 //!
 //! License fields are `NOASSERTION` everywhere — Arcis does not track
-//! license metadata today. The metadata.licenses block reflects this
-//! honestly rather than guessing or omitting.
+//! license metadata today. The metadata.licenses block (CycloneDX) and
+//! the per-package `licenseConcluded` / `licenseDeclared` fields (SPDX)
+//! both reflect this honestly rather than guessing or omitting.
 //!
 //! Determinism: components sort by purl, vulnerabilities sort by id
 //! before emit. The (timestamp, document-id) provider is injectable via
-//! `emit_cyclonedx_with` so tests can pin a fixed clock + UUID for
-//! byte-stable comparisons. Production callers use [`DefaultProvider`].
+//! `emit_*_with` so tests can pin a fixed clock + UUID for byte-stable
+//! comparisons. Production callers use [`DefaultProvider`].
 
 use std::collections::{BTreeMap, HashSet};
 use std::io::{self, Write};
@@ -36,9 +43,9 @@ const TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Inputs that vary per run: a wall-clock timestamp and a 16-byte
 /// document identifier. CycloneDX shapes the bytes as
-/// `urn:uuid:<uuid-v4>`. (When SPDX lands, it'll shape the same bytes
-/// as a URI under arcis.dev — provider is shared so a test override
-/// pins both formats with one fixture.)
+/// `urn:uuid:<uuid-v4>`; SPDX shapes them as a URI under arcis.dev. Both
+/// emitters consume the same provider so a test override pins both
+/// formats with one fixture.
 pub trait SbomProvider {
     /// ISO 8601 UTC timestamp, e.g. `2026-05-07T12:34:56Z`.
     fn timestamp(&self) -> String;
@@ -117,6 +124,17 @@ fn format_uuid_urn(raw: [u8; 16]) -> String {
     )
 }
 
+/// Format raw 16 bytes as a 32-character lowercase hex string. SPDX
+/// `documentNamespace` is a URI; the convention is a domain we control
+/// followed by a unique-per-document segment.
+fn format_hex32(raw: [u8; 16]) -> String {
+    let mut s = String::with_capacity(32);
+    for b in raw {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
 /// `pkg:<eco>/<name>@<version>` per the package-url spec. Ecosystem
 /// strings are lower-cased to match purl convention (purl uses `pypi`,
 /// not OSV's `PyPI`).
@@ -127,6 +145,24 @@ pub fn purl(ecosystem: &str, name: &str, version: &str) -> String {
         name,
         version
     )
+}
+
+/// Convert a key into a SPDXID-safe identifier. SPDXID may only contain
+/// `[A-Za-z0-9.\-+]`; everything else is replaced with `-`. Result is
+/// prefixed with `SPDXRef-` per spec.
+fn spdxid_for(prefix: &str, key: &str) -> String {
+    let mut out = String::with_capacity(prefix.len() + key.len() + 8);
+    out.push_str("SPDXRef-");
+    out.push_str(prefix);
+    out.push('-');
+    for c in key.chars() {
+        if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '+' {
+            out.push(c);
+        } else {
+            out.push('-');
+        }
+    }
+    out
 }
 
 /// Extract a stable vulnerability id from a `Finding`. Walk references
@@ -291,6 +327,162 @@ fn vuln_source_name(id: &str) -> &'static str {
     }
 }
 
+// ── SPDX 2.3 ─────────────────────────────────────────────────────────────
+
+/// Emit an SPDX 2.3 JSON document for the given packages and findings.
+/// Output is pretty-printed (2-space indent) with a trailing newline.
+pub fn emit_spdx<W: Write>(
+    w: &mut W,
+    packages: &[PackageRef],
+    findings: &[Finding],
+) -> io::Result<()> {
+    emit_spdx_with(w, packages, findings, &DefaultProvider)
+}
+
+/// Test-friendly form: the caller injects an `SbomProvider` so the
+/// timestamp + document namespace can be pinned for byte-stable
+/// assertions.
+pub fn emit_spdx_with<W: Write, P: SbomProvider + ?Sized>(
+    w: &mut W,
+    packages: &[PackageRef],
+    findings: &[Finding],
+    provider: &P,
+) -> io::Result<()> {
+    let unique = unique_packages(packages);
+    let by_purl = findings_by_purl(findings);
+
+    let mut packages_json: Vec<Value> = Vec::with_capacity(unique.len() + 1);
+    let mut relationships: Vec<Value> = Vec::new();
+
+    // Root document → DESCRIBES every component package. SPDX requires
+    // the document to declare what it describes; without this the file
+    // fails most validators.
+    let root_id = "SPDXRef-DOCUMENT";
+
+    for p in &unique {
+        let pu = purl(&p.ecosystem, &p.name, &p.version);
+        let spdx_id = spdxid_for("Package", &pu);
+        packages_json.push(json!({
+            "name": p.name,
+            "SPDXID": spdx_id,
+            "versionInfo": p.version,
+            "downloadLocation": "NOASSERTION",
+            "filesAnalyzed": false,
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "externalRefs": [{
+                "referenceCategory": "PACKAGE-MANAGER",
+                "referenceType": "purl",
+                "referenceLocator": pu,
+            }],
+        }));
+        relationships.push(json!({
+            "spdxElementId": root_id,
+            "relationshipType": "DESCRIBES",
+            "relatedSpdxElement": spdx_id,
+        }));
+    }
+
+    // Vulnerabilities — emit each as its own Package per SPDX 2.3
+    // convention (no first-class vuln primitive) and link via
+    // relationships. Severity + summary go into `comment` because SPDX
+    // doesn't have a structured rating field.
+    let mut emitted_vulns: HashSet<String> = HashSet::new();
+    let mut vuln_packages: Vec<Value> = Vec::new();
+    for (pu, group) in &by_purl {
+        let pkg_spdxid = spdxid_for("Package", pu);
+        for f in group {
+            let id = vuln_id(f);
+            let vuln_spdxid = spdxid_for("Vulnerability", &id);
+            if emitted_vulns.insert(id.clone()) {
+                let mut external_refs = vec![json!({
+                    "referenceCategory": "SECURITY",
+                    "referenceType": "advisory",
+                    "referenceLocator": advisory_url_for(&id, &f.references),
+                })];
+                if id.starts_with("CVE-") {
+                    external_refs.push(json!({
+                        "referenceCategory": "SECURITY",
+                        "referenceType": "cve",
+                        "referenceLocator": id,
+                    }));
+                }
+                vuln_packages.push(json!({
+                    "name": id,
+                    "SPDXID": vuln_spdxid,
+                    "versionInfo": "advisory",
+                    "downloadLocation": "NOASSERTION",
+                    "filesAnalyzed": false,
+                    "licenseConcluded": "NOASSERTION",
+                    "licenseDeclared": "NOASSERTION",
+                    "copyrightText": "NOASSERTION",
+                    "comment": format!("Severity: {}\nSummary: {}", f.severity, f.attack_vector),
+                    "externalRefs": external_refs,
+                }));
+            }
+            relationships.push(json!({
+                "spdxElementId": vuln_spdxid,
+                "relationshipType": "AFFECTS",
+                "relatedSpdxElement": pkg_spdxid,
+            }));
+        }
+    }
+
+    // Stable order: vulnerability packages sort by id (BTreeMap iteration
+    // above is by purl, not by id; resort defensively for byte-stable
+    // output regardless of the per-purl insertion path).
+    vuln_packages.sort_by(|a, b| {
+        a["name"]
+            .as_str()
+            .unwrap_or("")
+            .cmp(b["name"].as_str().unwrap_or(""))
+    });
+    packages_json.extend(vuln_packages);
+
+    let doc = json!({
+        "spdxVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": root_id,
+        "name": "arcis-sbom",
+        "documentNamespace": format!(
+            "https://arcis.dev/sbom/spdx/{}",
+            format_hex32(provider.raw_id())
+        ),
+        "creationInfo": {
+            "created": provider.timestamp(),
+            "creators": [format!("Tool: {TOOL_NAME}-{TOOL_VERSION}")],
+            "comment": "Arcis does not track package license metadata; all license fields in this SBOM are NOASSERTION.",
+        },
+        "packages": packages_json,
+        "relationships": relationships,
+    });
+
+    serde_json::to_writer_pretty(&mut *w, &doc).map_err(io::Error::other)?;
+    writeln!(w)?;
+    Ok(())
+}
+
+/// Pick a sensible advisory URL for the SPDX `referenceLocator`. Prefer
+/// a URL from the finding's reference list that already contains the
+/// id; fall back to the canonical github-advisories URL when the id is
+/// GHSA-shaped or NVD URL when CVE-shaped; final fallback is
+/// `NOASSERTION`.
+fn advisory_url_for(id: &str, references: &[String]) -> String {
+    for r in references {
+        if r.contains(id) {
+            return r.clone();
+        }
+    }
+    if id.starts_with("GHSA-") {
+        format!("https://github.com/advisories/{id}")
+    } else if id.starts_with("CVE-") {
+        format!("https://nvd.nist.gov/vuln/detail/{id}")
+    } else {
+        "NOASSERTION".to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -399,6 +591,12 @@ mod tests {
     fn render_cyclonedx(packages: &[PackageRef], findings: &[Finding]) -> String {
         let mut buf: Vec<u8> = Vec::new();
         emit_cyclonedx_with(&mut buf, packages, findings, &fixed()).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn render_spdx(packages: &[PackageRef], findings: &[Finding]) -> String {
+        let mut buf: Vec<u8> = Vec::new();
+        emit_spdx_with(&mut buf, packages, findings, &fixed()).unwrap();
         String::from_utf8(buf).unwrap()
     }
 
@@ -531,6 +729,110 @@ mod tests {
     }
 
     #[test]
+    fn spdx_shape() {
+        let (packages, findings) = sbom_fixture();
+        let out = render_spdx(&packages, &findings);
+        let v = parse(&out);
+
+        assert_eq!(v["spdxVersion"], "SPDX-2.3");
+        assert_eq!(v["dataLicense"], "CC0-1.0");
+        assert_eq!(v["SPDXID"], "SPDXRef-DOCUMENT");
+        let ns = v["documentNamespace"].as_str().unwrap();
+        assert!(
+            ns.starts_with("https://arcis.dev/sbom/spdx/"),
+            "documentNamespace must be under arcis.dev, got {ns}"
+        );
+
+        let packages_arr = v["packages"].as_array().unwrap();
+        // 5 components + 3 vulnerability packages = 8.
+        assert_eq!(packages_arr.len(), 5 + 3);
+
+        // Components carry purl in externalRefs and NOASSERTION license fields.
+        let component_pkgs: Vec<&Value> = packages_arr
+            .iter()
+            .filter(|p| p["versionInfo"] != "advisory")
+            .collect();
+        assert_eq!(component_pkgs.len(), 5);
+        for p in &component_pkgs {
+            assert_eq!(p["licenseConcluded"], "NOASSERTION");
+            assert_eq!(p["licenseDeclared"], "NOASSERTION");
+            assert_eq!(p["copyrightText"], "NOASSERTION");
+            let ext = p["externalRefs"][0].clone();
+            assert_eq!(ext["referenceCategory"], "PACKAGE-MANAGER");
+            assert_eq!(ext["referenceType"], "purl");
+            let purl_str = ext["referenceLocator"].as_str().unwrap();
+            assert!(
+                purl_str.starts_with("pkg:npm/") || purl_str.starts_with("pkg:pypi/"),
+                "expected purl, got {purl_str}"
+            );
+        }
+    }
+
+    #[test]
+    fn spdx_vuln_relationships() {
+        let (packages, findings) = sbom_fixture();
+        let out = render_spdx(&packages, &findings);
+        let v = parse(&out);
+
+        let rels = v["relationships"].as_array().unwrap();
+        let affects: Vec<&Value> = rels
+            .iter()
+            .filter(|r| r["relationshipType"] == "AFFECTS")
+            .collect();
+        assert_eq!(affects.len(), 3, "3 findings → 3 AFFECTS relationships");
+
+        // Each AFFECTS links a Vulnerability SPDXID to a Package SPDXID.
+        for r in &affects {
+            let v_id = r["spdxElementId"].as_str().unwrap();
+            let p_id = r["relatedSpdxElement"].as_str().unwrap();
+            assert!(
+                v_id.starts_with("SPDXRef-Vulnerability-"),
+                "spdxElementId must be a Vulnerability ref, got {v_id}"
+            );
+            assert!(
+                p_id.starts_with("SPDXRef-Package-"),
+                "relatedSpdxElement must be a Package ref, got {p_id}"
+            );
+        }
+
+        // DESCRIBES links cover every component.
+        let describes: Vec<&Value> = rels
+            .iter()
+            .filter(|r| r["relationshipType"] == "DESCRIBES")
+            .collect();
+        assert_eq!(describes.len(), 5, "root document DESCRIBES every component");
+    }
+
+    #[test]
+    fn spdx_creation_info_includes_tool() {
+        let (packages, findings) = sbom_fixture();
+        let out = render_spdx(&packages, &findings);
+        let v = parse(&out);
+
+        let creators = v["creationInfo"]["creators"].as_array().unwrap();
+        assert!(!creators.is_empty(), "creators array required by SPDX 2.3");
+        let entry = creators[0].as_str().unwrap();
+        let expected = format!("Tool: {TOOL_NAME}-{TOOL_VERSION}");
+        assert_eq!(entry, expected);
+    }
+
+    #[test]
+    fn spdx_determinism() {
+        let (packages, findings) = sbom_fixture();
+        let a = render_spdx(&packages, &findings);
+        let b = render_spdx(&packages, &findings);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn json_validity_spdx() {
+        let (packages, findings) = sbom_fixture();
+        let out = render_spdx(&packages, &findings);
+        let _ = parse(&out);
+        assert!(out.ends_with('\n'));
+    }
+
+    #[test]
     fn empty_project_emits_valid_sbom() {
         // No findings, but components present (clean project case).
         let packages = vec![
@@ -543,6 +845,17 @@ mod tests {
         let v = parse(&cyclo);
         assert_eq!(v["components"].as_array().unwrap().len(), 2);
         assert_eq!(v["vulnerabilities"].as_array().unwrap().len(), 0);
+
+        let spdx = render_spdx(&packages, &findings);
+        let v = parse(&spdx);
+        // 2 components + 0 vuln packages.
+        assert_eq!(v["packages"].as_array().unwrap().len(), 2);
+        // 2 DESCRIBES relationships, no AFFECTS.
+        let rels = v["relationships"].as_array().unwrap();
+        assert_eq!(rels.len(), 2);
+        for r in rels {
+            assert_eq!(r["relationshipType"], "DESCRIBES");
+        }
     }
 
     #[test]
@@ -561,6 +874,17 @@ mod tests {
         // here too — license posture is load-bearing for compliance).
         for c in v["components"].as_array().unwrap() {
             assert_eq!(c["licenses"][0]["license"]["id"], "NOASSERTION");
+        }
+
+        let spdx = render_spdx(&packages, &findings);
+        let v = parse(&spdx);
+        assert!(v["creationInfo"]["comment"]
+            .as_str()
+            .unwrap()
+            .contains("NOASSERTION"));
+        for p in v["packages"].as_array().unwrap() {
+            assert_eq!(p["licenseConcluded"], "NOASSERTION");
+            assert_eq!(p["licenseDeclared"], "NOASSERTION");
         }
     }
 

--- a/packages/arcis-rust/crates/arcis-engine/src/sca_sbom.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/sca_sbom.rs
@@ -607,10 +607,7 @@ mod tests {
     #[test]
     fn purl_format() {
         assert_eq!(purl("npm", "axios", "1.14.1"), "pkg:npm/axios@1.14.1");
-        assert_eq!(
-            purl("pypi", "litellm", "1.82.7"),
-            "pkg:pypi/litellm@1.82.7"
-        );
+        assert_eq!(purl("pypi", "litellm", "1.82.7"), "pkg:pypi/litellm@1.82.7");
         // Ecosystem case folds to purl spec convention.
         assert_eq!(purl("PyPI", "x", "1.0"), "pkg:pypi/x@1.0");
     }
@@ -631,7 +628,10 @@ mod tests {
 
         let components = v["components"].as_array().unwrap();
         assert_eq!(components.len(), 5);
-        let purls: Vec<&str> = components.iter().map(|c| c["purl"].as_str().unwrap()).collect();
+        let purls: Vec<&str> = components
+            .iter()
+            .map(|c| c["purl"].as_str().unwrap())
+            .collect();
         assert!(purls.contains(&"pkg:npm/axios@1.14.1"));
         assert!(purls.contains(&"pkg:npm/axios@0.30.4"));
         assert!(purls.contains(&"pkg:npm/lodash@4.17.20"));
@@ -914,10 +914,7 @@ mod tests {
         // well-known reference. Tested against a hard-coded value
         // rather than a chrono round-trip to keep the engine free of
         // date dependencies.
-        assert_eq!(
-            format_iso8601_utc(1234567890),
-            "2009-02-13T23:31:30Z"
-        );
+        assert_eq!(format_iso8601_utc(1234567890), "2009-02-13T23:31:30Z");
     }
 
     #[test]

--- a/packages/arcis-rust/crates/arcis-engine/src/sca_sbom.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/sca_sbom.rs
@@ -1,0 +1,613 @@
+//! SBOM emitter for `arcis sca --sbom <format>`.
+//!
+//! Today: CycloneDX 1.5 JSON — `bomFormat: "CycloneDX"`, `specVersion:
+//! "1.5"`. Components carry purl + bom-ref; vulnerabilities live at
+//! root level with `affects[].ref` pointing back to component bom-refs.
+//! SPDX 2.3 lands in a follow-up commit on this same branch.
+//!
+//! License fields are `NOASSERTION` everywhere — Arcis does not track
+//! license metadata today. The metadata.licenses block reflects this
+//! honestly rather than guessing or omitting.
+//!
+//! Determinism: components sort by purl, vulnerabilities sort by id
+//! before emit. The (timestamp, document-id) provider is injectable via
+//! `emit_cyclonedx_with` so tests can pin a fixed clock + UUID for
+//! byte-stable comparisons. Production callers use [`DefaultProvider`].
+
+use std::collections::{BTreeMap, HashSet};
+use std::io::{self, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use regex::Regex;
+use serde_json::{json, Value};
+use std::sync::OnceLock;
+
+use crate::sca::{Finding, PackageRef};
+
+/// Tool name embedded in CycloneDX `metadata.tools` and SPDX
+/// `creationInfo.creators`. Kept as a const so a typo can't drift across
+/// the two emitters.
+const TOOL_NAME: &str = "arcis-cli";
+const TOOL_VENDOR: &str = "Arcis";
+
+/// Engine crate version. Tracks the workspace version automatically.
+const TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Inputs that vary per run: a wall-clock timestamp and a 16-byte
+/// document identifier. CycloneDX shapes the bytes as
+/// `urn:uuid:<uuid-v4>`. (When SPDX lands, it'll shape the same bytes
+/// as a URI under arcis.dev — provider is shared so a test override
+/// pins both formats with one fixture.)
+pub trait SbomProvider {
+    /// ISO 8601 UTC timestamp, e.g. `2026-05-07T12:34:56Z`.
+    fn timestamp(&self) -> String;
+    /// Sixteen raw bytes used to seed the per-document identifier.
+    fn raw_id(&self) -> [u8; 16];
+}
+
+/// Real-clock provider: timestamp from `SystemTime::now()`, raw id from
+/// nanos + process id + a per-process counter. The bytes are formatted
+/// per RFC 4122 §4.4 (UUID v4 variant bits) when emitted as a UUID.
+pub struct DefaultProvider;
+
+impl SbomProvider for DefaultProvider {
+    fn timestamp(&self) -> String {
+        let secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        format_iso8601_utc(secs)
+    }
+
+    fn raw_id(&self) -> [u8; 16] {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+        let pid = std::process::id() as u64;
+        let count = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut out = [0u8; 16];
+        out[0..8].copy_from_slice(&nanos.to_le_bytes());
+        out[8..12].copy_from_slice(&(pid as u32).to_le_bytes());
+        out[12..16].copy_from_slice(&(count as u32).to_le_bytes());
+        out
+    }
+}
+
+/// Format `secs` since UNIX_EPOCH as `YYYY-MM-DDTHH:MM:SSZ`. We ship a
+/// hand-rolled formatter so we don't pull `chrono` for one timestamp.
+/// Algorithm follows the civil-from-days conversion documented at
+/// <https://howardhinnant.github.io/date_algorithms.html>.
+fn format_iso8601_utc(secs: u64) -> String {
+    let days = (secs / 86_400) as i64;
+    let secs_of_day = secs % 86_400;
+    let hour = secs_of_day / 3600;
+    let minute = (secs_of_day % 3600) / 60;
+    let second = secs_of_day % 60;
+
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = (yoe as i64) + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if m <= 2 { y + 1 } else { y };
+    format!("{year:04}-{m:02}-{d:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+/// Format raw 16 bytes as `urn:uuid:<uuid-v4>` per RFC 4122 §4.4. The
+/// version (4) and variant (2) bit fields are forced into the standard
+/// positions; everything else is taken verbatim from the provider.
+fn format_uuid_urn(raw: [u8; 16]) -> String {
+    let mut b = raw;
+    b[6] = (b[6] & 0x0f) | 0x40; // version 4
+    b[8] = (b[8] & 0x3f) | 0x80; // variant 10
+    format!(
+        "urn:uuid:{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        b[0], b[1], b[2], b[3],
+        b[4], b[5],
+        b[6], b[7],
+        b[8], b[9],
+        b[10], b[11], b[12], b[13], b[14], b[15],
+    )
+}
+
+/// `pkg:<eco>/<name>@<version>` per the package-url spec. Ecosystem
+/// strings are lower-cased to match purl convention (purl uses `pypi`,
+/// not OSV's `PyPI`).
+pub fn purl(ecosystem: &str, name: &str, version: &str) -> String {
+    format!(
+        "pkg:{}/{}@{}",
+        ecosystem.to_ascii_lowercase(),
+        name,
+        version
+    )
+}
+
+/// Extract a stable vulnerability id from a `Finding`. Walk references
+/// for a GHSA URL, fall back to parsing `osv:<id>` from `source`, fall
+/// back to a synthesized id keyed on package + version. The synthesized
+/// fallback is stable across runs for the same finding so determinism
+/// holds even when no advisory id is available.
+pub fn vuln_id(finding: &Finding) -> String {
+    static GHSA_RE: OnceLock<Regex> = OnceLock::new();
+    let re = GHSA_RE.get_or_init(|| {
+        // Case-insensitive match — embedded refs sometimes lowercase the segment.
+        Regex::new(r"(?i)GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}").unwrap()
+    });
+    for r in &finding.references {
+        if let Some(m) = re.find(r) {
+            return m.as_str().to_ascii_uppercase();
+        }
+    }
+    if let Some(rest) = finding.source.strip_prefix("osv:") {
+        return rest.to_string();
+    }
+    format!("arcis-{}-{}", finding.package, finding.version)
+}
+
+/// Map our internal severity strings to CycloneDX 1.5 rating values.
+/// The DB only emits `critical`/`high`/`medium`/`low` today; anything
+/// else collapses to `unknown` rather than guessing.
+fn cyclonedx_severity(sev: &str) -> &'static str {
+    match sev {
+        "critical" => "critical",
+        "high" => "high",
+        "medium" => "medium",
+        "low" => "low",
+        _ => "unknown",
+    }
+}
+
+/// Group findings by purl. The same package can have multiple findings
+/// (e.g. one DB hit + one OSV hit), and SBOMs cross-link them at the
+/// component level, so the purl-keyed group is the right unit.
+fn findings_by_purl(findings: &[Finding]) -> BTreeMap<String, Vec<&Finding>> {
+    let mut map: BTreeMap<String, Vec<&Finding>> = BTreeMap::new();
+    for f in findings {
+        let key = purl(&f.ecosystem, &f.package, &f.version);
+        map.entry(key).or_default().push(f);
+    }
+    map
+}
+
+/// Sort + dedupe packages by purl. The same package can show up in
+/// multiple manifests (`location` differs); for SBOM purposes only the
+/// `(ecosystem, name, version)` tuple matters.
+fn unique_packages(packages: &[PackageRef]) -> Vec<&PackageRef> {
+    let mut by_purl: BTreeMap<String, &PackageRef> = BTreeMap::new();
+    for p in packages {
+        let key = purl(&p.ecosystem, &p.name, &p.version);
+        by_purl.entry(key).or_insert(p);
+    }
+    by_purl.into_values().collect()
+}
+
+// ── CycloneDX 1.5 ────────────────────────────────────────────────────────
+
+/// Emit a CycloneDX 1.5 JSON document for the given packages and
+/// findings. Output is pretty-printed (2-space indent) with a trailing
+/// newline.
+pub fn emit_cyclonedx<W: Write>(
+    w: &mut W,
+    packages: &[PackageRef],
+    findings: &[Finding],
+) -> io::Result<()> {
+    emit_cyclonedx_with(w, packages, findings, &DefaultProvider)
+}
+
+/// Test-friendly form: the caller injects an `SbomProvider` so the
+/// timestamp + serial number can be pinned for byte-stable assertions.
+pub fn emit_cyclonedx_with<W: Write, P: SbomProvider + ?Sized>(
+    w: &mut W,
+    packages: &[PackageRef],
+    findings: &[Finding],
+    provider: &P,
+) -> io::Result<()> {
+    let unique = unique_packages(packages);
+    let by_purl = findings_by_purl(findings);
+
+    let components: Vec<Value> = unique
+        .iter()
+        .map(|p| {
+            let pu = purl(&p.ecosystem, &p.name, &p.version);
+            json!({
+                "type": "library",
+                "bom-ref": pu,
+                "name": p.name,
+                "version": p.version,
+                "purl": pu,
+                "licenses": [{ "license": { "id": "NOASSERTION" } }],
+            })
+        })
+        .collect();
+
+    let mut vulns: Vec<Value> = Vec::new();
+    for (pu, group) in &by_purl {
+        let mut seen_ids: HashSet<String> = HashSet::new();
+        for f in group {
+            let id = vuln_id(f);
+            if !seen_ids.insert(id.clone()) {
+                continue;
+            }
+            let entry = json!({
+                "id": id,
+                "source": { "name": vuln_source_name(&id) },
+                "ratings": [{ "severity": cyclonedx_severity(&f.severity) }],
+                "description": f.attack_vector,
+                "affects": [{ "ref": pu }],
+            });
+            vulns.push(entry);
+        }
+    }
+    vulns.sort_by(|a, b| {
+        a["id"]
+            .as_str()
+            .unwrap_or("")
+            .cmp(b["id"].as_str().unwrap_or(""))
+    });
+
+    let bom = json!({
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "serialNumber": format_uuid_urn(provider.raw_id()),
+        "version": 1,
+        "metadata": {
+            "timestamp": provider.timestamp(),
+            "tools": [{
+                "vendor": TOOL_VENDOR,
+                "name": TOOL_NAME,
+                "version": TOOL_VERSION,
+            }],
+            "licenses": [{
+                "expression": "NOASSERTION",
+                "comment": "Arcis does not track package license metadata; all license fields in this SBOM are NOASSERTION.",
+            }],
+        },
+        "components": components,
+        "vulnerabilities": vulns,
+    });
+
+    serde_json::to_writer_pretty(&mut *w, &bom).map_err(io::Error::other)?;
+    writeln!(w)?;
+    Ok(())
+}
+
+/// Pick a reasonable `vulnerabilities[].source.name` from an id. GHSA
+/// ids are explicit; CVE ids come from NVD; everything else falls into
+/// the synthesized-id bucket and gets attributed to Arcis.
+fn vuln_source_name(id: &str) -> &'static str {
+    if id.starts_with("GHSA-") {
+        "GitHub Security Advisory"
+    } else if id.starts_with("CVE-") {
+        "NVD"
+    } else {
+        "Arcis"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sca::FindingType;
+
+    /// Pinned provider for byte-stable tests.
+    struct FixedProvider {
+        ts: &'static str,
+        raw: [u8; 16],
+    }
+
+    impl SbomProvider for FixedProvider {
+        fn timestamp(&self) -> String {
+            self.ts.to_string()
+        }
+        fn raw_id(&self) -> [u8; 16] {
+            self.raw
+        }
+    }
+
+    fn fixed() -> FixedProvider {
+        FixedProvider {
+            ts: "2026-05-07T12:34:56Z",
+            raw: [
+                0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
+                0x77, 0x88,
+            ],
+        }
+    }
+
+    fn pkg(eco: &str, name: &str, version: &str) -> PackageRef {
+        PackageRef {
+            ecosystem: eco.to_string(),
+            name: name.to_string(),
+            version: version.to_string(),
+            location: format!("/tmp/proj/{name}"),
+        }
+    }
+
+    fn finding(
+        eco: &str,
+        name: &str,
+        version: &str,
+        sev: &str,
+        ghsa_ref: Option<&str>,
+        source: &str,
+    ) -> Finding {
+        let references = match ghsa_ref {
+            Some(g) => vec![format!("https://github.com/advisories/{g}")],
+            None => Vec::new(),
+        };
+        Finding {
+            package: name.to_string(),
+            ecosystem: eco.to_string(),
+            version: version.to_string(),
+            severity: sev.to_string(),
+            location: format!("/tmp/proj/{name}/lock"),
+            attack_vector: format!("{name} {version} compromise vector"),
+            remediation: "upgrade".to_string(),
+            source: source.to_string(),
+            references,
+            finding_type: FindingType::CompromisedVersion,
+        }
+    }
+
+    /// Shared fixture: 5 packages (3 npm + 2 pypi), 3 findings (axios×2 + litellm).
+    /// Mirrors the realistic mixed-ecosystem case the CLI reports today.
+    fn sbom_fixture() -> (Vec<PackageRef>, Vec<Finding>) {
+        let packages = vec![
+            pkg("npm", "axios", "1.14.1"),
+            pkg("npm", "axios", "0.30.4"),
+            pkg("npm", "lodash", "4.17.20"),
+            pkg("pypi", "litellm", "1.82.7"),
+            pkg("pypi", "requests", "2.28.1"),
+        ];
+        let findings = vec![
+            finding(
+                "npm",
+                "axios",
+                "1.14.1",
+                "critical",
+                Some("GHSA-aaaa-bbbb-cccc"),
+                "npm Security Advisory",
+            ),
+            finding(
+                "npm",
+                "axios",
+                "0.30.4",
+                "high",
+                Some("GHSA-dddd-eeee-ffff"),
+                "npm Security Advisory",
+            ),
+            finding(
+                "pypi",
+                "litellm",
+                "1.82.7",
+                "critical",
+                None,
+                "osv:GHSA-1234-5678-90ab",
+            ),
+        ];
+        (packages, findings)
+    }
+
+    /// Render to a String for ergonomic asserts.
+    fn render_cyclonedx(packages: &[PackageRef], findings: &[Finding]) -> String {
+        let mut buf: Vec<u8> = Vec::new();
+        emit_cyclonedx_with(&mut buf, packages, findings, &fixed()).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn parse(s: &str) -> Value {
+        serde_json::from_str(s).expect("emitted SBOM must parse as JSON")
+    }
+
+    #[test]
+    fn purl_format() {
+        assert_eq!(purl("npm", "axios", "1.14.1"), "pkg:npm/axios@1.14.1");
+        assert_eq!(
+            purl("pypi", "litellm", "1.82.7"),
+            "pkg:pypi/litellm@1.82.7"
+        );
+        // Ecosystem case folds to purl spec convention.
+        assert_eq!(purl("PyPI", "x", "1.0"), "pkg:pypi/x@1.0");
+    }
+
+    #[test]
+    fn cyclonedx_shape() {
+        let (packages, findings) = sbom_fixture();
+        let out = render_cyclonedx(&packages, &findings);
+        let v = parse(&out);
+
+        assert_eq!(v["bomFormat"], "CycloneDX");
+        assert_eq!(v["specVersion"], "1.5");
+        let serial = v["serialNumber"].as_str().unwrap();
+        assert!(
+            serial.starts_with("urn:uuid:") && serial.len() == 9 + 36,
+            "serialNumber must be a 36-char UUID URN, got {serial}"
+        );
+
+        let components = v["components"].as_array().unwrap();
+        assert_eq!(components.len(), 5);
+        let purls: Vec<&str> = components.iter().map(|c| c["purl"].as_str().unwrap()).collect();
+        assert!(purls.contains(&"pkg:npm/axios@1.14.1"));
+        assert!(purls.contains(&"pkg:npm/axios@0.30.4"));
+        assert!(purls.contains(&"pkg:npm/lodash@4.17.20"));
+        assert!(purls.contains(&"pkg:pypi/litellm@1.82.7"));
+        assert!(purls.contains(&"pkg:pypi/requests@2.28.1"));
+
+        // Components sorted by purl (deterministic output).
+        let sorted_purls = {
+            let mut p = purls.clone();
+            p.sort();
+            p
+        };
+        assert_eq!(purls, sorted_purls);
+
+        // License is NOASSERTION on every component.
+        for c in components {
+            assert_eq!(
+                c["licenses"][0]["license"]["id"], "NOASSERTION",
+                "component {} must declare NOASSERTION",
+                c["purl"]
+            );
+        }
+    }
+
+    #[test]
+    fn cyclonedx_vulns_cross_link() {
+        let (packages, findings) = sbom_fixture();
+        let out = render_cyclonedx(&packages, &findings);
+        let v = parse(&out);
+
+        let vulns = v["vulnerabilities"].as_array().unwrap();
+        assert_eq!(vulns.len(), 3, "3 findings → 3 vuln entries");
+
+        let ids: Vec<&str> = vulns.iter().map(|x| x["id"].as_str().unwrap()).collect();
+        assert!(ids.contains(&"GHSA-AAAA-BBBB-CCCC"));
+        assert!(ids.contains(&"GHSA-DDDD-EEEE-FFFF"));
+        assert!(ids.contains(&"GHSA-1234-5678-90AB"));
+
+        // Each vuln links to its component's purl via affects[].ref.
+        for vuln in vulns {
+            let id = vuln["id"].as_str().unwrap();
+            let affected_ref = vuln["affects"][0]["ref"].as_str().unwrap();
+            let expected = match id {
+                "GHSA-AAAA-BBBB-CCCC" => "pkg:npm/axios@1.14.1",
+                "GHSA-DDDD-EEEE-FFFF" => "pkg:npm/axios@0.30.4",
+                "GHSA-1234-5678-90AB" => "pkg:pypi/litellm@1.82.7",
+                _ => panic!("unexpected vuln id: {id}"),
+            };
+            assert_eq!(affected_ref, expected, "wrong cross-link for {id}");
+        }
+
+        // Severity rendered in CycloneDX rating shape.
+        let crit = vulns
+            .iter()
+            .find(|x| x["id"] == "GHSA-AAAA-BBBB-CCCC")
+            .unwrap();
+        assert_eq!(crit["ratings"][0]["severity"], "critical");
+    }
+
+    #[test]
+    fn cyclonedx_metadata_includes_tool() {
+        let (packages, findings) = sbom_fixture();
+        let out = render_cyclonedx(&packages, &findings);
+        let v = parse(&out);
+
+        let tools = v["metadata"]["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["vendor"], TOOL_VENDOR);
+        assert_eq!(tools[0]["name"], TOOL_NAME);
+        let version = tools[0]["version"].as_str().unwrap();
+        assert!(
+            !version.is_empty(),
+            "metadata.tools[0].version must be non-empty"
+        );
+        assert_eq!(
+            version, TOOL_VERSION,
+            "version must come from CARGO_PKG_VERSION"
+        );
+    }
+
+    #[test]
+    fn cyclonedx_determinism() {
+        let (packages, findings) = sbom_fixture();
+        let a = render_cyclonedx(&packages, &findings);
+        let b = render_cyclonedx(&packages, &findings);
+        assert_eq!(a, b, "byte-identical output for the same input");
+    }
+
+    #[test]
+    fn json_validity_cyclonedx() {
+        let (packages, findings) = sbom_fixture();
+        let out = render_cyclonedx(&packages, &findings);
+        let _ = parse(&out); // panics if invalid
+        assert!(out.ends_with('\n'), "must end with a newline");
+    }
+
+    #[test]
+    fn empty_project_emits_valid_sbom() {
+        // No findings, but components present (clean project case).
+        let packages = vec![
+            pkg("npm", "lodash", "4.17.20"),
+            pkg("pypi", "requests", "2.28.1"),
+        ];
+        let findings: Vec<Finding> = Vec::new();
+
+        let cyclo = render_cyclonedx(&packages, &findings);
+        let v = parse(&cyclo);
+        assert_eq!(v["components"].as_array().unwrap().len(), 2);
+        assert_eq!(v["vulnerabilities"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn license_field_is_noassertion() {
+        let (packages, findings) = sbom_fixture();
+
+        let cyclo = render_cyclonedx(&packages, &findings);
+        let v = parse(&cyclo);
+        // Document-level rationale.
+        assert_eq!(v["metadata"]["licenses"][0]["expression"], "NOASSERTION");
+        assert!(v["metadata"]["licenses"][0]["comment"]
+            .as_str()
+            .unwrap()
+            .contains("NOASSERTION"));
+        // Component-level (already covered in cyclonedx_shape but assert
+        // here too — license posture is load-bearing for compliance).
+        for c in v["components"].as_array().unwrap() {
+            assert_eq!(c["licenses"][0]["license"]["id"], "NOASSERTION");
+        }
+    }
+
+    #[test]
+    fn vuln_id_extracts_ghsa_from_references() {
+        let f = finding("npm", "x", "1.0", "high", Some("GHSA-aaaa-bbbb-cccc"), "");
+        assert_eq!(vuln_id(&f), "GHSA-AAAA-BBBB-CCCC");
+    }
+
+    #[test]
+    fn vuln_id_falls_back_to_osv_source() {
+        let f = finding("npm", "x", "1.0", "high", None, "osv:GHSA-zzzz-yyyy-xxxx");
+        assert_eq!(vuln_id(&f), "GHSA-zzzz-yyyy-xxxx");
+    }
+
+    #[test]
+    fn vuln_id_synthesizes_when_no_id_present() {
+        let f = finding("npm", "weird-pkg", "0.0.1", "high", None, "");
+        assert_eq!(vuln_id(&f), "arcis-weird-pkg-0.0.1");
+    }
+
+    #[test]
+    fn iso8601_format() {
+        // Epoch sanity.
+        assert_eq!(format_iso8601_utc(0), "1970-01-01T00:00:00Z");
+        // The 1234567890-second mark is 2009-02-13 23:31:30 UTC — a
+        // well-known reference. Tested against a hard-coded value
+        // rather than a chrono round-trip to keep the engine free of
+        // date dependencies.
+        assert_eq!(
+            format_iso8601_utc(1234567890),
+            "2009-02-13T23:31:30Z"
+        );
+    }
+
+    #[test]
+    fn uuid_urn_sets_v4_and_variant_bits() {
+        let raw = [0u8; 16];
+        let urn = format_uuid_urn(raw);
+        // version nibble (13th hex char, 0-indexed) must be '4'
+        let body = urn.strip_prefix("urn:uuid:").unwrap();
+        let chars: Vec<char> = body.chars().collect();
+        assert_eq!(chars[14], '4', "version nibble must be 4: {urn}");
+        // variant nibble (17th hex char) must be 8/9/a/b
+        assert!(
+            matches!(chars[19], '8' | '9' | 'a' | 'b'),
+            "variant nibble must be 8-b: {urn}"
+        );
+    }
+}

--- a/packages/arcis-rust/crates/arcis-engine/src/sca_sbom.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/sca_sbom.rs
@@ -779,7 +779,11 @@ mod tests {
             .iter()
             .filter(|r| r["relationshipType"] == "AFFECTS")
             .collect();
-        assert_eq!(affects.len(), 3, "3 findings → 3 AFFECTS relationships");
+        assert_eq!(
+            affects.len(),
+            3,
+            "3 findings → 3 AFFECTS relationships"
+        );
 
         // Each AFFECTS links a Vulnerability SPDXID to a Package SPDXID.
         for r in &affects {
@@ -800,7 +804,11 @@ mod tests {
             .iter()
             .filter(|r| r["relationshipType"] == "DESCRIBES")
             .collect();
-        assert_eq!(describes.len(), 5, "root document DESCRIBES every component");
+        assert_eq!(
+            describes.len(),
+            5,
+            "root document DESCRIBES every component"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

First commit of `cli-sca.md` Phase C: severity-aware exit codes for `arcis sca`.

- New flag `--fail-on {critical|high|medium|any|none}`
- Default `any` preserves legacy behaviour (exit 1 on any finding)
- Case-insensitive parse; both `--fail-on <value>` and `--fail-on=<value>` forms

This PR is **draft + rolling**: more Phase C items will land as additional commits on the same branch (plan order: 9 → 7 → 5 → 8). Marked ready-for-review when all four items are in.

## Why a draft PR per track

Local `cargo` isn't available in this worktree, so verification depends on `rust.yml` (cargo fmt + clippy `-D warnings` + workspace tests) firing on push. Opening the PR up front lets CI fire on every commit without paging anyone.

## Test plan

- [ ] `rust.yml` green on this commit (cargo fmt, clippy `-D warnings`, workspace tests)
- [ ] `should_fail` truth table covers all 5 modes × 4 fixtures
- [ ] `any` mode byte-identical to legacy `!findings.is_empty()` predicate across the same fixtures
- [ ] Case-insensitivity: `HIGH`, `High`, `hIgH`, `" high "` all parse to `FailOn::High`
- [ ] Error paths: missing value, invalid value, rejected `low` (intentionally not in the value set today)
- [ ] Help text documents value list, default, and usage line

## Backward compatibility

Default behaviour is unchanged: a no-flag invocation (`arcis sca .`) still exits 1 on any finding. Anyone scripting against the current exit-code contract sees no difference unless they opt in with `--fail-on`.

## Notes on `low`

`low` is deliberately omitted from the value set today. The embedded threat DB only emits `critical`/`high`/`medium` severities, so `--fail-on low` would select nothing additional vs `any` and become a footgun. If a low-severity finding is ever added later, the enum + parser + truth table need to grow together — there's a regression test (`parse_args_rejects_low_value`) that catches a half-added `low` value.