### PR TITLE
audit(ergo): finding-id determinism + suppress comments + .arcisignore (cli-audit.md items 6, 7, 10)

### DIFF
--- a/packages/arcis-rust/Cargo.lock
+++ b/packages/arcis-rust/Cargo.lock
@@ -85,7 +85,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -93,12 +93,14 @@ name = "arcis-engine"
 version = "0.1.0"
 dependencies = [
  "arcis-data",
+ "dirs",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "urlencoding",
  "walkdir",
@@ -121,6 +123,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -201,6 +212,56 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "displaydoc"
@@ -287,6 +348,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -612,6 +683,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +743,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "percent-encoding"
@@ -727,7 +813,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -748,7 +834,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -816,6 +902,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1037,6 +1134,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,11 +1236,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1278,6 +1406,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1458,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1503,6 +1643,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -1526,6 +1675,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1563,6 +1727,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -1575,6 +1745,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1584,6 +1760,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1611,6 +1793,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1620,6 +1808,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1635,6 +1829,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1644,6 +1844,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/packages/arcis-rust/Cargo.lock
+++ b/packages/arcis-rust/Cargo.lock
@@ -94,6 +94,7 @@ version = "0.1.0"
 dependencies = [
  "arcis-data",
  "dirs",
+ "ignore",
  "regex",
  "reqwest",
  "serde",
@@ -131,6 +132,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -221,6 +232,31 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -398,6 +434,19 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -626,6 +675,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]

--- a/packages/arcis-rust/Cargo.toml
+++ b/packages/arcis-rust/Cargo.toml
@@ -47,6 +47,10 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 # Cross-platform home-dir resolution for the OSV cache file at
 # `~/.arcis/osv-cache.json`. cli-sca.md Phase B (designed 2026-05-07).
 dirs = "5.0"
+# SHA-256 for deterministic finding IDs in `arcis audit`. Inputs are
+# `(rule_id, relpath, line, snippet)`; first 8 bytes (16 hex chars) form
+# the fingerprint. cli-audit.md Phase B item 10.
+sha2 = "0.10"
 
 [profile.release]
 # Smaller, faster binary. The tradeoffs (longer compile, no incremental in

--- a/packages/arcis-rust/Cargo.toml
+++ b/packages/arcis-rust/Cargo.toml
@@ -51,6 +51,13 @@ dirs = "5.0"
 # `(rule_id, relpath, line, snippet)`; first 8 bytes (16 hex chars) form
 # the fingerprint. cli-audit.md Phase B item 10.
 sha2 = "0.10"
+# `.arcisignore` + `.gitignore` path exclusion for `arcis audit`
+# (cli-audit.md Phase B item 7). BurntSushi's crate, the same one
+# ripgrep uses; gives us native gitignore stacking semantics including
+# `**`, negation (`!important.js`), nested per-directory files, and
+# `.git/info/exclude`. `walkdir` stays in the manifest unused for now
+# per the cross-track ADD-ONLY rule; will be GC'd when all tracks merge.
+ignore = "0.4"
 
 [profile.release]
 # Smaller, faster binary. The tradeoffs (longer compile, no incremental in

--- a/packages/arcis-rust/crates/arcis-cli/src/audit.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/audit.rs
@@ -14,8 +14,8 @@ use std::process::ExitCode;
 use std::time::Instant;
 
 use arcis_engine::audit::{
-    collect_files, detect_language, render_json, render_sarif, rules as compiled_rules, scan_file,
-    Finding, JsonReport, Language, SarifReport, Severity,
+    assign_ids, collect_files, detect_language, render_json, render_sarif, rules as compiled_rules,
+    scan_file, Finding, JsonReport, Language, SarifReport, Severity,
 };
 
 const TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -354,6 +354,12 @@ pub fn run(argv: &[String]) -> ExitCode {
             .then_with(|| a.file.cmp(&b.file))
             .then_with(|| a.line.cmp(&b.line))
     });
+
+    // Deterministic finding ids — `<RULE_ID>-<16hex>` over
+    // `(rule_id, relpath, line, snippet)`. Pinned to the user's input
+    // path so `arcis audit .` and `arcis audit /abs/repo` produce the
+    // same id for the same source line. cli-audit.md item 10.
+    assign_ids(&mut findings, &path);
 
     // Per-severity counts. Sorted by Severity Ord so the JSON
     // `bySeverity` map keys come out in [critical, high, medium, low]

--- a/packages/arcis-rust/crates/arcis-cli/src/audit.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/audit.rs
@@ -14,8 +14,9 @@ use std::process::ExitCode;
 use std::time::Instant;
 
 use arcis_engine::audit::{
-    assign_ids, collect_files, detect_language, render_json, render_sarif, rules as compiled_rules,
-    scan_file_with_suppression, Finding, JsonReport, Language, SarifReport, Severity,
+    assign_ids, collect_files_with_options, detect_language, render_json, render_sarif,
+    rules as compiled_rules, scan_file_with_suppression, Finding, IgnoreOptions, JsonReport,
+    Language, SarifReport, Severity,
 };
 
 const TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -30,6 +31,14 @@ struct Args {
     quiet: bool,
     json_output: bool,
     sarif_output: bool,
+    /// `--no-ignore`: disable BOTH `.arcisignore` AND `.gitignore`
+    /// (and `.git/info/exclude`, and global git ignore). Mirrors
+    /// ripgrep's flag of the same name.
+    no_ignore: bool,
+    /// `--no-gitignore`: disable `.gitignore` only — `.arcisignore`
+    /// stays active. Useful in monorepos with broad gitignore lines
+    /// over vendored dirs you do want to scan. Mirrors ripgrep.
+    no_gitignore: bool,
 }
 
 #[derive(Debug)]
@@ -50,6 +59,8 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
     let mut quiet = false;
     let mut json_output = false;
     let mut sarif_output = false;
+    let mut no_ignore = false;
+    let mut no_gitignore = false;
 
     let mut iter = argv.iter().enumerate();
     while let Some((_, arg)) = iter.next() {
@@ -60,6 +71,8 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
             "--quiet" | "-q" => quiet = true,
             "--json" => json_output = true,
             "--sarif" => sarif_output = true,
+            "--no-ignore" => no_ignore = true,
+            "--no-gitignore" => no_gitignore = true,
             "--language" | "-l" => match iter.next() {
                 Some((_, v)) => match Language::parse(v) {
                     Some(l) => language = Some(l),
@@ -113,6 +126,8 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
         quiet,
         json_output,
         sarif_output,
+        no_ignore,
+        no_gitignore,
     })
 }
 
@@ -173,6 +188,14 @@ fn print_help<W: Write>(out: &mut W) -> io::Result<()> {
     writeln!(
         out,
         "      --sarif          Emit results as SARIF 2.1.0 for GitHub Code Scanning."
+    )?;
+    writeln!(
+        out,
+        "      --no-ignore      Disable both .arcisignore and .gitignore (gitignore-style glob syntax)."
+    )?;
+    writeln!(
+        out,
+        "      --no-gitignore   Disable .gitignore only; keep .arcisignore active."
     )?;
     writeln!(out, "  -h, --help           Show this message and exit.")?;
     Ok(())
@@ -269,7 +292,19 @@ pub fn run(argv: &[String]) -> ExitCode {
     let target_abs = abspath(&path);
     let target_str = target_abs.to_string_lossy().into_owned();
 
-    let files = collect_files(&path, args.language);
+    // cli-audit.md item 7: build ignore options from CLI flags.
+    // `--no-ignore` is a superset of `--no-gitignore` — when set it
+    // disables both files. Asymmetry is intentional: there's no
+    // `--no-arcisignore` because arcisignore-only-off has no use case
+    // (just delete the file).
+    let ignore_opts = IgnoreOptions {
+        use_arcisignore: !args.no_ignore,
+        use_gitignore: !(args.no_ignore || args.no_gitignore),
+    };
+
+    let walk = collect_files_with_options(&path, args.language, &ignore_opts);
+    let files = walk.files;
+    let ignored_count = walk.ignored;
 
     // No scannable files: machine modes still emit a valid empty
     // document so CI parsers don't choke; non-machine prints a hint.
@@ -290,6 +325,7 @@ pub fn run(argv: &[String]) -> ExitCode {
                     duration_ms: 0,
                     severity_filter: args.severity,
                     suppressed: 0,
+                    ignored: ignored_count,
                 })
             } else {
                 render_sarif(&SarifReport {
@@ -389,6 +425,7 @@ pub fn run(argv: &[String]) -> ExitCode {
                 duration_ms,
                 severity_filter: args.severity,
                 suppressed: suppressed_total,
+                ignored: ignored_count,
             })
         } else {
             render_sarif(&SarifReport {
@@ -419,6 +456,7 @@ pub fn run(argv: &[String]) -> ExitCode {
         &by_severity,
         duration_ms,
         suppressed_total,
+        ignored_count,
     );
 
     if findings.is_empty() {
@@ -440,6 +478,7 @@ fn print_human_report<W: Write>(
     by_severity: &BTreeMap<Severity, usize>,
     duration_ms: u64,
     suppressed: usize,
+    ignored: usize,
 ) -> io::Result<()> {
     writeln!(out)?;
     writeln!(out, "  Arcis Audit")?;
@@ -538,6 +577,12 @@ fn print_human_report<W: Write>(
     // wants the unconditional view.
     if suppressed > 0 {
         writeln!(out, "    Suppressed      {suppressed}")?;
+    }
+    // cli-audit.md item 7: surface .arcisignore / .gitignore exclusion
+    // count only when non-zero. Same noise rationale as Suppressed
+    // above — JSON always carries the field for machine consumers.
+    if ignored > 0 {
+        writeln!(out, "    Files ignored   {ignored}")?;
     }
     writeln!(out, "    Time            {duration_ms}ms")?;
     Ok(())
@@ -680,6 +725,7 @@ mod tests {
             &by_sev,
             42,
             7,
+            0,
         )
         .unwrap();
         let out = String::from_utf8(buf).unwrap();
@@ -708,12 +754,131 @@ mod tests {
             &by_sev,
             42,
             0,
+            0,
         )
         .unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(
             !out.contains("Suppressed"),
             "Suppressed line should not appear when count is 0, got:\n{out}"
+        );
+    }
+
+    // ── ignore-file machinery (cli-audit.md item 7) ────────────────────
+
+    #[test]
+    fn parse_args_no_ignore_flag() {
+        match parse_args(&[".".to_string(), "--no-ignore".to_string()]) {
+            ParseOutcome::Args(a) => {
+                assert!(a.no_ignore);
+                assert!(!a.no_gitignore);
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_no_gitignore_flag() {
+        match parse_args(&[".".to_string(), "--no-gitignore".to_string()]) {
+            ParseOutcome::Args(a) => {
+                assert!(!a.no_ignore);
+                assert!(a.no_gitignore);
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_no_ignore_and_no_gitignore_both_set() {
+        // Redundant but legal — `--no-ignore` already implies
+        // `--no-gitignore`. Both flags being set is fine, no error.
+        match parse_args(&[
+            ".".to_string(),
+            "--no-ignore".to_string(),
+            "--no-gitignore".to_string(),
+        ]) {
+            ParseOutcome::Args(a) => {
+                assert!(a.no_ignore);
+                assert!(a.no_gitignore);
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn help_documents_no_ignore_flags() {
+        // cli-audit.md item 7 spec: help text must surface both flags
+        // and explain `.arcisignore` uses gitignore-style syntax so
+        // users don't have to dig through crate docs.
+        let mut buf: Vec<u8> = Vec::new();
+        print_help(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("--no-ignore"), "help must mention --no-ignore");
+        assert!(
+            out.contains("--no-gitignore"),
+            "help must mention --no-gitignore"
+        );
+        assert!(
+            out.contains(".arcisignore"),
+            "help must mention .arcisignore"
+        );
+        assert!(
+            out.to_lowercase().contains("gitignore-style")
+                || out.to_lowercase().contains("gitignore syntax")
+                || out.to_lowercase().contains("gitignore-style glob"),
+            "help must mention that patterns follow gitignore-style syntax, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn human_summary_emits_files_ignored_line_when_count_positive() {
+        let mut buf: Vec<u8> = Vec::new();
+        let by_lang: BTreeMap<String, usize> = [("python".to_string(), 1)].into_iter().collect();
+        let by_sev: BTreeMap<Severity, usize> = BTreeMap::new();
+        print_human_report(
+            &mut buf,
+            Path::new("/tmp"),
+            &[PathBuf::from("/tmp/a.py")],
+            &by_lang,
+            14,
+            None,
+            &[],
+            &by_sev,
+            42,
+            0,
+            5,
+        )
+        .unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains("Files ignored   5"),
+            "expected Files ignored line in summary, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn human_summary_omits_files_ignored_line_when_count_zero() {
+        let mut buf: Vec<u8> = Vec::new();
+        let by_lang: BTreeMap<String, usize> = [("python".to_string(), 1)].into_iter().collect();
+        let by_sev: BTreeMap<Severity, usize> = BTreeMap::new();
+        print_human_report(
+            &mut buf,
+            Path::new("/tmp"),
+            &[PathBuf::from("/tmp/a.py")],
+            &by_lang,
+            14,
+            None,
+            &[],
+            &by_sev,
+            42,
+            0,
+            0,
+        )
+        .unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            !out.contains("Files ignored"),
+            "Files ignored line should not appear when count is 0, got:\n{out}"
         );
     }
 }

--- a/packages/arcis-rust/crates/arcis-cli/src/audit.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/audit.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 
 use arcis_engine::audit::{
     assign_ids, collect_files, detect_language, render_json, render_sarif, rules as compiled_rules,
-    scan_file, Finding, JsonReport, Language, SarifReport, Severity,
+    scan_file_with_suppression, Finding, JsonReport, Language, SarifReport, Severity,
 };
 
 const TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -289,6 +289,7 @@ pub fn run(argv: &[String]) -> ExitCode {
                     by_severity: &by_sev,
                     duration_ms: 0,
                     severity_filter: args.severity,
+                    suppressed: 0,
                 })
             } else {
                 render_sarif(&SarifReport {
@@ -339,7 +340,13 @@ pub fn run(argv: &[String]) -> ExitCode {
 
     // Run scan. Time only the scan phase, like Python.
     let start = Instant::now();
-    let mut findings: Vec<Finding> = files.iter().flat_map(|f| scan_file(f)).collect();
+    let mut findings: Vec<Finding> = Vec::new();
+    let mut suppressed_total: usize = 0;
+    for f in &files {
+        let r = scan_file_with_suppression(f);
+        findings.extend(r.findings);
+        suppressed_total += r.suppressed;
+    }
     let duration_ms = start.elapsed().as_millis() as u64;
 
     // Severity filter — keep findings whose severity rank <= threshold.
@@ -381,6 +388,7 @@ pub fn run(argv: &[String]) -> ExitCode {
                 by_severity: &by_severity,
                 duration_ms,
                 severity_filter: args.severity,
+                suppressed: suppressed_total,
             })
         } else {
             render_sarif(&SarifReport {
@@ -410,6 +418,7 @@ pub fn run(argv: &[String]) -> ExitCode {
         &findings,
         &by_severity,
         duration_ms,
+        suppressed_total,
     );
 
     if findings.is_empty() {
@@ -430,6 +439,7 @@ fn print_human_report<W: Write>(
     findings: &[Finding],
     by_severity: &BTreeMap<Severity, usize>,
     duration_ms: u64,
+    suppressed: usize,
 ) -> io::Result<()> {
     writeln!(out)?;
     writeln!(out, "  Arcis Audit")?;
@@ -521,6 +531,13 @@ fn print_human_report<W: Write>(
         })
         .collect();
         writeln!(out, "    Findings        {} ({})", total, parts.join(", "))?;
+    }
+    // cli-audit.md item 6: surface suppress-comment count only when
+    // non-zero. Zero is the common case and would just be visual noise
+    // in the summary; the count exists in JSON output for tooling that
+    // wants the unconditional view.
+    if suppressed > 0 {
+        writeln!(out, "    Suppressed      {suppressed}")?;
     }
     writeln!(out, "    Time            {duration_ms}ms")?;
     Ok(())
@@ -642,5 +659,61 @@ mod tests {
     fn abspath_handles_dotdot() {
         let p = abspath(Path::new("a/b/../c"));
         assert!(!p.to_string_lossy().contains("..")); // collapsed
+    }
+
+    #[test]
+    fn human_summary_emits_suppressed_line_when_count_positive() {
+        // cli-audit.md item 6: Summary block must include
+        // "Suppressed N" when at least one finding was silenced by a
+        // suppress-comment directive.
+        let mut buf: Vec<u8> = Vec::new();
+        let by_lang: BTreeMap<String, usize> = [("python".to_string(), 1)].into_iter().collect();
+        let by_sev: BTreeMap<Severity, usize> = BTreeMap::new();
+        print_human_report(
+            &mut buf,
+            Path::new("/tmp"),
+            &[PathBuf::from("/tmp/a.py")],
+            &by_lang,
+            14,
+            None,
+            &[],
+            &by_sev,
+            42,
+            7,
+        )
+        .unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains("Suppressed      7"),
+            "expected Suppressed line in summary, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn human_summary_omits_suppressed_line_when_count_zero() {
+        // Zero is the common case; printing "Suppressed 0" every time
+        // is just noise. Tooling can read the JSON output for the
+        // unconditional value.
+        let mut buf: Vec<u8> = Vec::new();
+        let by_lang: BTreeMap<String, usize> = [("python".to_string(), 1)].into_iter().collect();
+        let by_sev: BTreeMap<Severity, usize> = BTreeMap::new();
+        print_human_report(
+            &mut buf,
+            Path::new("/tmp"),
+            &[PathBuf::from("/tmp/a.py")],
+            &by_lang,
+            14,
+            None,
+            &[],
+            &by_sev,
+            42,
+            0,
+        )
+        .unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            !out.contains("Suppressed"),
+            "Suppressed line should not appear when count is 0, got:\n{out}"
+        );
     }
 }

--- a/packages/arcis-rust/crates/arcis-engine/Cargo.toml
+++ b/packages/arcis-rust/crates/arcis-engine/Cargo.toml
@@ -27,6 +27,9 @@ reqwest = { workspace = true }
 urlencoding = "2.1"
 # `~/.arcis/osv-cache.json` — OSV layer (cli-sca.md Phase B).
 dirs = { workspace = true }
+# Deterministic finding IDs for `arcis audit` (cli-audit.md Phase B
+# item 10). Used only by `audit::finding_id`; safe in the hot path.
+sha2 = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/packages/arcis-rust/crates/arcis-engine/Cargo.toml
+++ b/packages/arcis-rust/crates/arcis-engine/Cargo.toml
@@ -30,6 +30,11 @@ dirs = { workspace = true }
 # Deterministic finding IDs for `arcis audit` (cli-audit.md Phase B
 # item 10). Used only by `audit::finding_id`; safe in the hot path.
 sha2 = { workspace = true }
+# `.arcisignore` + `.gitignore` exclusion for `arcis audit` (cli-audit.md
+# Phase B item 7). Used only by `audit::walker`; built on top of walkdir
+# under the hood so we lose nothing performance-wise vs the previous
+# raw walkdir traversal.
+ignore = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/engine.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/engine.rs
@@ -596,6 +596,24 @@ mod tests {
         assert_eq!(r.suppressed, 1);
     }
 
+    // ── ignore-file machinery (cli-audit.md item 7) ────────────────────
+
+    #[test]
+    fn scan_directory_respects_gitignore_via_back_compat_wrapper() {
+        // Regression guard: existing callers of `scan_directory`
+        // (which routes through the back-compat `collect_files`
+        // wrapper) must transparently inherit `.gitignore` semantics
+        // once item 7 lands. A finding inside a gitignored file must
+        // not appear in results.
+        let td = TempDir::new().unwrap();
+        write(&td, "src/main.py", "yaml.load(f)\n");
+        write(&td, "generated/auto.py", "yaml.load(f)\n");
+        write(&td, ".gitignore", "generated/\n");
+        let findings = scan_directory(td.path(), None, None);
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].file.contains("main.py"));
+    }
+
     #[test]
     fn suppress_two_runs_byte_equal_with_directive() {
         // Determinism: directives must not change run-to-run output.

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/engine.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/engine.rs
@@ -8,10 +8,19 @@
 use std::fs;
 use std::path::Path;
 
+use super::finding_id;
 use super::rules::{rules as compiled_rules, Language, Rule, Severity};
 use super::walker::{collect_files, detect_language};
 
-/// One audit finding. Field-for-field with Python's `Finding` dataclass.
+/// One audit finding.
+///
+/// `id` is the deterministic fingerprint computed by
+/// [`finding_id::assign_ids`]; `scan_file` leaves it empty (no relpath
+/// context), `scan_directory` fills it in. The CLI calls
+/// [`finding_id::assign_ids`] explicitly when it scans via
+/// `collect_files` + `scan_file` rather than `scan_directory` so it can
+/// pin the relpath to the user's input arg. Empty `id` indicates "not
+/// yet assigned" — never an error.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Finding {
     pub rule_id: &'static str,
@@ -20,6 +29,9 @@ pub struct Finding {
     pub file: String,
     pub line: usize,
     pub snippet: String,
+    /// `<RULE_ID>-<16hex>` deterministic fingerprint. See
+    /// [`finding_id`] for the derivation.
+    pub id: String,
 }
 
 /// Scan a single file. Returns empty if extension is unknown or read
@@ -84,6 +96,7 @@ pub fn scan_file(path: &Path) -> Vec<Finding> {
                 file: file_str.clone(),
                 line: line_num,
                 snippet,
+                id: String::new(),
             });
         }
     }
@@ -119,6 +132,13 @@ pub fn scan_directory(
             .then_with(|| a.file.cmp(&b.file))
             .then_with(|| a.line.cmp(&b.line))
     });
+
+    // Fill in deterministic ids so two runs of `scan_directory` over
+    // the same target return findings that compare PartialEq. The CLI
+    // can override later with a different `target_root` if the user
+    // passed one (e.g. ran `arcis audit .` and we want relpaths
+    // relative to cwd, not absolutized).
+    finding_id::assign_ids(&mut findings, path);
 
     findings
 }

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/engine.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/engine.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 
 use super::finding_id;
 use super::rules::{rules as compiled_rules, Language, Rule, Severity};
+use super::suppress::{self, Directive};
 use super::walker::{collect_files, detect_language};
 
 /// One audit finding.
@@ -34,17 +35,41 @@ pub struct Finding {
     pub id: String,
 }
 
+/// Result of scanning one or more files: kept findings plus a
+/// per-scan count of findings that fired but were silenced by a
+/// suppress directive (cli-audit.md item 6). The suppressed payload
+/// itself is intentionally NOT retained — a `--show-suppressed` flag
+/// can resurrect it later if there's demand. Only the count surfaces,
+/// shown in the human summary as `Suppressed N`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FileResult {
+    pub findings: Vec<Finding>,
+    pub suppressed: usize,
+}
+
 /// Scan a single file. Returns empty if extension is unknown or read
-/// fails. Mirrors `audit.py:scan_file`.
+/// fails. Backward-compatible thin wrapper over
+/// [`scan_file_with_suppression`] that drops the suppression count.
 ///
 /// Per-line, comment-only lines (lines whose first non-whitespace char
 /// is `#` or `//`) are skipped — matches Python's `stripped.startswith`
 /// check. Lines that match a rule's `pattern` AND its `safe_pattern`
 /// (when set) are exempted, e.g. `yaml.load(f, Loader=SafeLoader)`.
 pub fn scan_file(path: &Path) -> Vec<Finding> {
+    scan_file_with_suppression(path).findings
+}
+
+/// Scan a single file. Same scan logic as [`scan_file`] but also
+/// honours the suppress-comment directives documented in
+/// [`super::suppress`] (cli-audit.md item 6).
+///
+/// Suppressed findings are excluded from the `findings` vec; the count
+/// is surfaced via `FileResult.suppressed` so the CLI can show a
+/// `Suppressed N` line in the human summary.
+pub fn scan_file_with_suppression(path: &Path) -> FileResult {
     let lang = match detect_language(path) {
         Some(l) => l,
-        None => return Vec::new(),
+        None => return FileResult::default(),
     };
 
     let applicable: Vec<&Rule> = compiled_rules()
@@ -52,7 +77,7 @@ pub fn scan_file(path: &Path) -> Vec<Finding> {
         .filter(|r| r.languages.contains(&lang))
         .collect();
     if applicable.is_empty() {
-        return Vec::new();
+        return FileResult::default();
     }
 
     // Match Python's `errors='replace'` semantics. `read_to_string`
@@ -62,14 +87,31 @@ pub fn scan_file(path: &Path) -> Vec<Finding> {
         Ok(c) => c,
         Err(_) => match fs::read(path) {
             Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
-            Err(_) => return Vec::new(),
+            Err(_) => return FileResult::default(),
         },
     };
 
+    let lines: Vec<&str> = content.lines().collect();
+
+    // Per-line directive table. Indexed 0-based; aligned with the
+    // (line_num - 1) used in the rule loop below. Built up-front so
+    // line N can cheaply look at line N-1's directive.
+    let directives: Vec<Option<Directive>> =
+        lines.iter().map(|l| suppress::parse_line(l)).collect();
+
+    // File-level directive: any line carrying a File directive
+    // suppresses every finding in this file. The suppressed count
+    // still records what *would* have fired, so users get a number to
+    // act on if they later remove the directive.
+    let file_level = directives
+        .iter()
+        .any(|d| matches!(d, Some(Directive::File)));
+
     let file_str = path.to_string_lossy().into_owned();
     let mut findings = Vec::new();
+    let mut suppressed = 0usize;
 
-    for (idx, line) in content.lines().enumerate() {
+    for (idx, line) in lines.iter().enumerate() {
         let line_num = idx + 1;
         let stripped = line.trim();
         if stripped.starts_with('#') || stripped.starts_with("//") {
@@ -84,6 +126,30 @@ pub fn scan_file(path: &Path) -> Vec<Finding> {
                     continue;
                 }
             }
+
+            // Suppress check, in priority order:
+            //   1. File-level directive anywhere in the file.
+            //   2. Same-line directive matching this rule_id.
+            //   3. Preceding-line directive matching this rule_id —
+            //      ONLY when line N-1 is a comment-only line. A
+            //      trailing inline directive on line N-1's code does
+            //      NOT spill onto line N (Semgrep semantics; explicit
+            //      footgun-prevention).
+            let same = directives.get(idx).and_then(|d| d.as_ref());
+            let prev_comment_only = idx > 0 && suppress::is_comment_only_line(lines[idx - 1]);
+            let prev = if prev_comment_only {
+                directives.get(idx - 1).and_then(|d| d.as_ref())
+            } else {
+                None
+            };
+            let is_suppressed = file_level
+                || same.is_some_and(|d| suppress::matches(d, rule.id))
+                || prev.is_some_and(|d| suppress::matches(d, rule.id));
+            if is_suppressed {
+                suppressed += 1;
+                continue;
+            }
+
             // Snippet: codepoint-bounded prefix of the trimmed line.
             // Python's `stripped[:120]` is a unicode-codepoint slice;
             // matching that requires `chars().take(120)` rather than a
@@ -101,7 +167,10 @@ pub fn scan_file(path: &Path) -> Vec<Finding> {
         }
     }
 
-    findings
+    FileResult {
+        findings,
+        suppressed,
+    }
 }
 
 /// Scan a directory tree. Mirrors `audit.py:scan_directory`.
@@ -110,13 +179,34 @@ pub fn scan_file(path: &Path) -> Vec<Finding> {
 /// `Some(Severity::High)` removes medium/low findings. Final list is
 /// sorted by `(severity, file, line)` so JSON / SARIF output is
 /// byte-stable across runs.
+///
+/// Backward-compatible wrapper over [`scan_directory_with_suppression`]
+/// that drops the suppression count.
 pub fn scan_directory(
     path: &Path,
     language: Option<Language>,
     severity: Option<Severity>,
 ) -> Vec<Finding> {
+    scan_directory_with_suppression(path, language, severity).findings
+}
+
+/// Same scan as [`scan_directory`] but additionally returns the count
+/// of suppressed findings (via the `FileResult.suppressed` field).
+/// Suppressed findings themselves are excluded from `findings`.
+pub fn scan_directory_with_suppression(
+    path: &Path,
+    language: Option<Language>,
+    severity: Option<Severity>,
+) -> FileResult {
     let files = collect_files(path, language);
-    let mut findings: Vec<Finding> = files.into_iter().flat_map(|f| scan_file(&f)).collect();
+
+    let mut findings = Vec::new();
+    let mut suppressed = 0usize;
+    for f in files {
+        let r = scan_file_with_suppression(&f);
+        findings.extend(r.findings);
+        suppressed += r.suppressed;
+    }
 
     if let Some(threshold) = severity {
         // Severity Ord declares Critical < High < Medium < Low. The
@@ -140,7 +230,10 @@ pub fn scan_directory(
     // relative to cwd, not absolutized).
     finding_id::assign_ids(&mut findings, path);
 
-    findings
+    FileResult {
+        findings,
+        suppressed,
+    }
 }
 
 #[cfg(test)]
@@ -359,5 +452,161 @@ mod tests {
         let td = TempDir::new().unwrap();
         let findings = scan_directory(td.path(), None, None);
         assert!(findings.is_empty());
+    }
+
+    // ── suppress comments (cli-audit.md item 6) ────────────────────────
+
+    #[test]
+    fn suppress_same_line_double_slash_hides_finding() {
+        let td = TempDir::new().unwrap();
+        let f = write(&td, "main.js", "el.innerHTML = x  // arcis-audit: ignore\n");
+        let r = scan_file_with_suppression(&f);
+        assert!(r.findings.is_empty());
+        assert_eq!(r.suppressed, 1);
+    }
+
+    #[test]
+    fn suppress_same_line_hash_hides_finding_python() {
+        let td = TempDir::new().unwrap();
+        let f = write(&td, "main.py", "yaml.load(f)  # arcis-audit: ignore\n");
+        let r = scan_file_with_suppression(&f);
+        assert!(r.findings.is_empty());
+        assert_eq!(r.suppressed, 1);
+    }
+
+    #[test]
+    fn suppress_preceding_comment_only_line_hides_finding() {
+        let td = TempDir::new().unwrap();
+        let f = write(&td, "main.py", "# arcis-audit: ignore\nyaml.load(f)\n");
+        let r = scan_file_with_suppression(&f);
+        assert!(r.findings.is_empty());
+        assert_eq!(r.suppressed, 1);
+    }
+
+    #[test]
+    fn suppress_preceding_inline_directive_does_not_hide_next_line() {
+        // Footgun-prevention: a trailing inline directive on a code
+        // line N-1 (e.g. `eval(x)  // arcis-audit: ignore EVAL-EXEC`)
+        // applies ONLY to its own line. A real, unsuppressed finding
+        // on line N must survive — silent suppression is a
+        // classic SAST footgun and we deliberately avoid it.
+        let td = TempDir::new().unwrap();
+        let f = write(
+            &td,
+            "main.py",
+            "eval(x)  # arcis-audit: ignore EVAL-EXEC\nyaml.load(f)\n",
+        );
+        let r = scan_file_with_suppression(&f);
+        // Line 1 (eval): suppressed by its own same-line directive.
+        // Line 2 (yaml.load): NOT suppressed, even though directive
+        // sits on line 1, because line 1 is not comment-only.
+        assert_eq!(r.findings.len(), 1);
+        assert_eq!(r.findings[0].rule_id, "YAML-UNSAFE");
+        assert_eq!(r.findings[0].line, 2);
+        assert_eq!(r.suppressed, 1);
+    }
+
+    #[test]
+    fn suppress_two_lines_before_does_not_hide_finding() {
+        // Spec: "Two-lines-before does NOT suppress." Only the
+        // immediately preceding (comment-only) line counts.
+        let td = TempDir::new().unwrap();
+        let f = write(&td, "main.py", "# arcis-audit: ignore\n\nyaml.load(f)\n");
+        let r = scan_file_with_suppression(&f);
+        assert_eq!(r.findings.len(), 1);
+        assert_eq!(r.findings[0].rule_id, "YAML-UNSAFE");
+        assert_eq!(r.suppressed, 0);
+    }
+
+    #[test]
+    fn suppress_rule_id_specificity_does_not_cross_rules() {
+        // Spec: `ignore SQL-CONCAT` does NOT hide a YAML-UNSAFE
+        // finding. Rule IDs in a directive name only those rules.
+        let td = TempDir::new().unwrap();
+        let f = write(
+            &td,
+            "main.py",
+            "yaml.load(f)  # arcis-audit: ignore SQL-CONCAT\n",
+        );
+        let r = scan_file_with_suppression(&f);
+        assert_eq!(r.findings.len(), 1);
+        assert_eq!(r.findings[0].rule_id, "YAML-UNSAFE");
+        assert_eq!(r.suppressed, 0);
+    }
+
+    #[test]
+    fn suppress_comma_list_hides_each_listed_rule() {
+        // EVAL-EXEC and HARDCODED-SECRET both fire on this line; a
+        // comma-list directive that names both must hide both.
+        let td = TempDir::new().unwrap();
+        let aws = format!("{}{}", "AKIA", "ABCDEFGHIJKLMNOP");
+        let line =
+            format!("key = {aws}; eval(x)  # arcis-audit: ignore EVAL-EXEC,HARDCODED-SECRET\n");
+        let f = write(&td, "main.py", &line);
+        let r = scan_file_with_suppression(&f);
+        // Both rules suppressed → no surviving findings on this line.
+        assert!(
+            r.findings.is_empty(),
+            "expected both rules suppressed, got {:?}",
+            r.findings
+        );
+        assert_eq!(r.suppressed, 2);
+    }
+
+    #[test]
+    fn suppress_file_level_directive_hides_everything_in_file() {
+        let td = TempDir::new().unwrap();
+        let f = write(
+            &td,
+            "main.py",
+            "# arcis-audit: ignore-file\nyaml.load(f)\npickle.loads(b'x')\neval(y)\n",
+        );
+        let r = scan_file_with_suppression(&f);
+        assert!(r.findings.is_empty());
+        assert!(
+            r.suppressed >= 3,
+            "expected at least 3 suppressed (one per line), got {}",
+            r.suppressed
+        );
+    }
+
+    #[test]
+    fn suppress_file_level_directive_works_when_placed_anywhere() {
+        // The file-level directive is global to the file — placement
+        // (top, middle, bottom) shouldn't matter.
+        let td = TempDir::new().unwrap();
+        let f = write(
+            &td,
+            "main.py",
+            "yaml.load(f)\n# arcis-audit: ignore-file\npickle.loads(b'x')\n",
+        );
+        let r = scan_file_with_suppression(&f);
+        assert!(r.findings.is_empty());
+        assert!(r.suppressed >= 2);
+    }
+
+    #[test]
+    fn suppress_count_propagates_through_scan_directory() {
+        let td = TempDir::new().unwrap();
+        write(&td, "a.py", "yaml.load(f)  # arcis-audit: ignore\n"); // 1 suppressed
+        write(&td, "b.py", "pickle.loads(b'x')\n"); // 1 finding, no suppress
+        let r = scan_directory_with_suppression(td.path(), None, None);
+        assert_eq!(r.findings.len(), 1);
+        assert_eq!(r.findings[0].rule_id, "PICKLE-LOAD");
+        assert_eq!(r.suppressed, 1);
+    }
+
+    #[test]
+    fn suppress_two_runs_byte_equal_with_directive() {
+        // Determinism: directives must not change run-to-run output.
+        let td = TempDir::new().unwrap();
+        write(
+            &td,
+            "a.py",
+            "# arcis-audit: ignore\nyaml.load(f)\npickle.loads(b'x')\n",
+        );
+        let r1 = scan_directory_with_suppression(td.path(), None, None);
+        let r2 = scan_directory_with_suppression(td.path(), None, None);
+        assert_eq!(r1, r2);
     }
 }

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/finding_id.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/finding_id.rs
@@ -1,0 +1,370 @@
+//! Deterministic finding IDs.
+//!
+//! Implements cli-audit.md Phase B item 10. Each finding gets a stable
+//! id `<RULE_ID>-<16hex>` derived from `(rule_id, relpath, line,
+//! snippet)`. Two runs over the same source produce byte-equal output;
+//! a run on Windows and a run on Linux over the same repo produce the
+//! same ids. This is the foundation for baseline diffing (item 9) and
+//! SARIF de-dupe in GitHub Code Scanning.
+//!
+//! ## Hash inputs
+//!
+//! * `rule_id` — verbatim.
+//! * `relpath` — file path with backslashes flipped to `/`, leading
+//!   `./` trimmed. Computed against the audit's target root so a
+//!   `cd repo && arcis audit .` and `arcis audit /abs/repo` produce
+//!   the same id.
+//! * `line` — 1-indexed line number, decimal.
+//! * `snippet` — with trailing whitespace stripped. Editors auto-strip
+//!   trailing spaces on save; preserving them would invalidate every
+//!   baseline id on a `git config core.whitespace` flip. Leading
+//!   whitespace is preserved — indentation carries information.
+//!
+//! Inputs are joined with NUL (`\0`) so a `:` inside a Windows drive
+//! letter, a `-` inside a rule id, or a structural char in a snippet
+//! can't shift hash boundaries via concatenation collisions.
+//!
+//! ## Output shape
+//!
+//! `<RULE_ID>-<16hex>` — 16 lowercase hex chars (64-bit fingerprint).
+//! 64 bits is wide enough that a single repo with ~100k findings hits
+//! a collision with probability < 1e-10 (birthday). Snyk and Semgrep
+//! emit the same width.
+
+use std::path::{Component, Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use super::engine::Finding;
+
+/// Compute the deterministic id for a finding.
+///
+/// Inputs are NUL-joined and SHA-256 hashed; the first 8 bytes (16
+/// hex chars, lowercase) form the fingerprint. The snippet has
+/// trailing whitespace trimmed before hashing per the cli-audit.md
+/// item 10 amendment.
+pub fn compute(rule_id: &str, relpath: &str, line: usize, snippet: &str) -> String {
+    let snippet_trimmed = snippet.trim_end();
+    let line_str = line.to_string();
+    let mut hasher = Sha256::new();
+    hasher.update(rule_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(relpath.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(line_str.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(snippet_trimmed.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(16);
+    for byte in &digest[..8] {
+        use std::fmt::Write;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    format!("{rule_id}-{hex}")
+}
+
+/// Normalize a finding's file path to a stable relpath against
+/// `target_root`. Strips the absolute target_root prefix, flips
+/// backslashes to forward slashes, removes a leading `./`. Falls back
+/// to the input path with separators flipped if the prefix can't be
+/// stripped (e.g. cross-drive on Windows, or a finding outside the
+/// target tree).
+pub fn normalize_relpath(file: &Path, target_root: &Path) -> String {
+    let file_abs = make_absolute(file);
+    let root_abs = make_absolute(target_root);
+
+    // Single-file scan: target_root is the file itself, so the relpath
+    // base is its parent (relpath becomes the bare filename).
+    let base = if root_abs.is_file() {
+        root_abs.parent().map(Path::to_path_buf).unwrap_or(root_abs)
+    } else {
+        root_abs
+    };
+
+    let stripped: PathBuf = file_abs
+        .strip_prefix(&base)
+        .map(Path::to_path_buf)
+        .unwrap_or(file_abs);
+    flip_to_unix_separators(&stripped.to_string_lossy())
+}
+
+/// Fill in `id` on every finding, computing relpaths against
+/// `target_root`. Idempotent — overwrites whatever was there.
+pub fn assign_ids(findings: &mut [Finding], target_root: &Path) {
+    for f in findings.iter_mut() {
+        let relpath = normalize_relpath(Path::new(&f.file), target_root);
+        f.id = compute(f.rule_id, &relpath, f.line, &f.snippet);
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/// Mirror Python's `os.path.abspath` — does NOT follow symlinks
+/// (unlike `Path::canonicalize`, which would also fail on missing
+/// paths during testing). Resolves `..` and `.` lexically.
+fn make_absolute(p: &Path) -> PathBuf {
+    let abs = if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        std::env::current_dir().unwrap_or_default().join(p)
+    };
+    normalize_components(&abs)
+}
+
+fn normalize_components(p: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in p.components() {
+        match comp {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+fn flip_to_unix_separators(s: &str) -> String {
+    let flipped = s.replace('\\', "/");
+    flipped
+        .strip_prefix("./")
+        .map(str::to_string)
+        .unwrap_or(flipped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::engine::Finding;
+    use crate::audit::rules::Severity;
+    use tempfile::TempDir;
+
+    fn sample(file: &str, line: usize, snippet: &str) -> Finding {
+        Finding {
+            rule_id: "YAML-UNSAFE",
+            severity: Severity::High,
+            message: "yaml.load() without SafeLoader",
+            file: file.to_string(),
+            line,
+            snippet: snippet.to_string(),
+            id: String::new(),
+        }
+    }
+
+    // ── compute ────────────────────────────────────────────────────────
+
+    #[test]
+    fn compute_is_deterministic() {
+        let a = compute("YAML-UNSAFE", "src/a.py", 10, "yaml.load(f)");
+        let b = compute("YAML-UNSAFE", "src/a.py", 10, "yaml.load(f)");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn compute_changes_with_rule_id() {
+        let a = compute("YAML-UNSAFE", "src/a.py", 10, "x");
+        let b = compute("PICKLE-LOAD", "src/a.py", 10, "x");
+        assert_ne!(a, b);
+        assert!(a.starts_with("YAML-UNSAFE-"));
+        assert!(b.starts_with("PICKLE-LOAD-"));
+    }
+
+    #[test]
+    fn compute_changes_with_relpath() {
+        let a = compute("X", "src/a.py", 1, "s");
+        let b = compute("X", "src/b.py", 1, "s");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn compute_changes_with_line() {
+        let a = compute("X", "src/a.py", 1, "s");
+        let b = compute("X", "src/a.py", 2, "s");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn compute_changes_with_snippet() {
+        let a = compute("X", "src/a.py", 1, "yaml.load(f)");
+        let b = compute("X", "src/a.py", 1, "yaml.load(g)");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn compute_strips_trailing_whitespace_from_snippet() {
+        // Editors auto-strip trailing whitespace; baseline ids must
+        // survive that. Per cli-audit.md item 10 amendment.
+        let a = compute("X", "src/a.py", 1, "yaml.load(f)");
+        let b = compute("X", "src/a.py", 1, "yaml.load(f)   ");
+        let c = compute("X", "src/a.py", 1, "yaml.load(f)\t");
+        let d = compute("X", "src/a.py", 1, "yaml.load(f)\r\n");
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+        assert_eq!(a, d);
+    }
+
+    #[test]
+    fn compute_does_not_strip_leading_whitespace() {
+        // Indent carries information. A finding inside a function body
+        // shouldn't share an id with a top-level one if their snippets
+        // happen to share a tail.
+        let a = compute("X", "src/a.py", 1, "yaml.load(f)");
+        let b = compute("X", "src/a.py", 1, "  yaml.load(f)");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn id_format_matches_pattern() {
+        let id = compute("YAML-UNSAFE", "src/a.py", 10, "yaml.load(f)");
+        let rest = id.strip_prefix("YAML-UNSAFE-").expect("rule id prefix");
+        assert_eq!(rest.len(), 16, "fingerprint width is 16 hex chars");
+        assert!(
+            rest.chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+            "fingerprint must be lowercase hex: {rest}"
+        );
+    }
+
+    #[test]
+    fn nul_separator_prevents_concatenation_collision() {
+        // Without a separator, ("AB", "C") and ("A", "BC") would hash
+        // identically. NUL byte rules that out.
+        let a = compute("AB", "C", 1, "x");
+        let b = compute("A", "BC", 1, "x");
+        assert_ne!(a, b);
+    }
+
+    // ── flip_to_unix_separators ────────────────────────────────────────
+
+    #[test]
+    fn flip_separators_replaces_backslashes() {
+        assert_eq!(flip_to_unix_separators("a\\b\\c"), "a/b/c");
+    }
+
+    #[test]
+    fn flip_separators_strips_leading_dot_slash() {
+        assert_eq!(flip_to_unix_separators("./a/b"), "a/b");
+        assert_eq!(flip_to_unix_separators(".\\a\\b"), "a/b");
+    }
+
+    #[test]
+    fn flip_separators_passes_clean_path_unchanged() {
+        assert_eq!(flip_to_unix_separators("a/b/c.py"), "a/b/c.py");
+    }
+
+    // ── normalize_relpath ──────────────────────────────────────────────
+
+    #[test]
+    fn normalize_relpath_strips_target_root_dir() {
+        let td = TempDir::new().unwrap();
+        let f = td.path().join("src").join("a.py");
+        std::fs::create_dir_all(f.parent().unwrap()).unwrap();
+        std::fs::write(&f, "").unwrap();
+        let rel = normalize_relpath(&f, td.path());
+        assert_eq!(rel, "src/a.py");
+    }
+
+    #[test]
+    fn normalize_relpath_strips_target_root_file_to_filename() {
+        // Single-file scan: relpath = bare filename.
+        let td = TempDir::new().unwrap();
+        let f = td.path().join("a.py");
+        std::fs::write(&f, "").unwrap();
+        let rel = normalize_relpath(&f, &f);
+        assert_eq!(rel, "a.py");
+    }
+
+    #[test]
+    fn normalize_relpath_no_leading_dot_slash() {
+        let td = TempDir::new().unwrap();
+        let f = td.path().join("a.py");
+        std::fs::write(&f, "").unwrap();
+        let rel = normalize_relpath(&f, td.path());
+        assert!(
+            !rel.starts_with("./"),
+            "relpath must not start with ./: {rel}"
+        );
+        assert!(!rel.starts_with(".\\"));
+    }
+
+    #[test]
+    fn normalize_relpath_outside_target_falls_back_to_input() {
+        // A finding path that doesn't sit under target_root should
+        // still produce a string (no panic, no canonicalize). Used
+        // when a follow-symlink scenario or a cross-drive Windows
+        // case escapes the prefix.
+        let td = TempDir::new().unwrap();
+        let other = TempDir::new().unwrap();
+        let f = other.path().join("a.py");
+        std::fs::write(&f, "").unwrap();
+        let rel = normalize_relpath(&f, td.path());
+        // We don't assert exact contents (cwd-dependent). Only that
+        // the function returned something non-empty without panicking.
+        assert!(!rel.is_empty());
+    }
+
+    // ── assign_ids ─────────────────────────────────────────────────────
+
+    #[test]
+    fn assign_ids_fills_id_field() {
+        let td = TempDir::new().unwrap();
+        let f = td.path().join("src").join("a.py");
+        std::fs::create_dir_all(f.parent().unwrap()).unwrap();
+        std::fs::write(&f, "").unwrap();
+        let mut findings = vec![sample(f.to_string_lossy().as_ref(), 1, "yaml.load(f)")];
+        assert!(findings[0].id.is_empty());
+        assign_ids(&mut findings, td.path());
+        assert!(!findings[0].id.is_empty());
+        assert!(findings[0].id.starts_with("YAML-UNSAFE-"));
+    }
+
+    #[test]
+    fn assign_ids_is_idempotent() {
+        let td = TempDir::new().unwrap();
+        let f = td.path().join("a.py");
+        std::fs::write(&f, "").unwrap();
+        let mut findings = vec![sample(f.to_string_lossy().as_ref(), 1, "x")];
+        assign_ids(&mut findings, td.path());
+        let first = findings[0].id.clone();
+        assign_ids(&mut findings, td.path());
+        assert_eq!(findings[0].id, first);
+    }
+
+    #[test]
+    fn assign_ids_two_targets_same_relpath_same_id() {
+        // Two different repos, same file layout, same line/snippet
+        // should produce the same id. This is what makes baselines
+        // portable across machines and CI runners.
+        let td_a = TempDir::new().unwrap();
+        let td_b = TempDir::new().unwrap();
+        let fa = td_a.path().join("src").join("a.py");
+        let fb = td_b.path().join("src").join("a.py");
+        std::fs::create_dir_all(fa.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(fb.parent().unwrap()).unwrap();
+        std::fs::write(&fa, "").unwrap();
+        std::fs::write(&fb, "").unwrap();
+
+        let mut a = vec![sample(fa.to_string_lossy().as_ref(), 7, "yaml.load(f)")];
+        let mut b = vec![sample(fb.to_string_lossy().as_ref(), 7, "yaml.load(f)")];
+        assign_ids(&mut a, td_a.path());
+        assign_ids(&mut b, td_b.path());
+        assert_eq!(a[0].id, b[0].id);
+    }
+
+    #[test]
+    fn assign_ids_different_relpath_different_id() {
+        let td = TempDir::new().unwrap();
+        let f1 = td.path().join("src").join("a.py");
+        let f2 = td.path().join("src").join("b.py");
+        std::fs::create_dir_all(f1.parent().unwrap()).unwrap();
+        std::fs::write(&f1, "").unwrap();
+        std::fs::write(&f2, "").unwrap();
+        let mut findings = vec![
+            sample(f1.to_string_lossy().as_ref(), 1, "x"),
+            sample(f2.to_string_lossy().as_ref(), 1, "x"),
+        ];
+        assign_ids(&mut findings, td.path());
+        assert_ne!(findings[0].id, findings[1].id);
+    }
+}

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/mod.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/mod.rs
@@ -16,11 +16,13 @@
 //! next to the clap glue.
 
 pub mod engine;
+pub mod finding_id;
 pub mod render;
 pub mod rules;
 pub mod walker;
 
 pub use engine::{scan_directory, scan_file, Finding};
+pub use finding_id::{assign_ids, compute as compute_finding_id, normalize_relpath};
 pub use render::{render_json, render_sarif, JsonReport, SarifReport};
 pub use rules::{rules, Language, Rule, Severity};
 pub use walker::{collect_files, detect_language, SKIP_DIRS};

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/mod.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/mod.rs
@@ -19,9 +19,13 @@ pub mod engine;
 pub mod finding_id;
 pub mod render;
 pub mod rules;
+pub mod suppress;
 pub mod walker;
 
-pub use engine::{scan_directory, scan_file, Finding};
+pub use engine::{
+    scan_directory, scan_directory_with_suppression, scan_file, scan_file_with_suppression,
+    FileResult, Finding,
+};
 pub use finding_id::{assign_ids, compute as compute_finding_id, normalize_relpath};
 pub use render::{render_json, render_sarif, JsonReport, SarifReport};
 pub use rules::{rules, Language, Rule, Severity};

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/mod.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/mod.rs
@@ -29,4 +29,7 @@ pub use engine::{
 pub use finding_id::{assign_ids, compute as compute_finding_id, normalize_relpath};
 pub use render::{render_json, render_sarif, JsonReport, SarifReport};
 pub use rules::{rules, Language, Rule, Severity};
-pub use walker::{collect_files, detect_language, SKIP_DIRS};
+pub use walker::{
+    collect_files, collect_files_with_options, detect_language, IgnoreOptions, WalkResult,
+    SKIP_DIRS,
+};

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/render.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/render.rs
@@ -58,6 +58,12 @@ pub struct JsonReport<'a> {
     /// are NOT included in the `findings` array — only the count
     /// surfaces, by design.
     pub suppressed: usize,
+    /// Files excluded by an `.arcisignore` / `.gitignore` /
+    /// `.git/info/exclude` rule (cli-audit.md item 7). Surfaces as
+    /// `summary.ignored` in the JSON output. Always emitted (zero is
+    /// informative — confirms the field exists even on a clean run).
+    /// Ignored files do NOT appear in `filesScanned` or `byLanguage`.
+    pub ignored: usize,
 }
 
 /// Render the audit result as a JSON document. Schema:
@@ -117,6 +123,10 @@ pub fn render_json(report: &JsonReport<'_>) -> String {
     // even on a clean run). Suppressed findings themselves are NOT
     // listed; only the count.
     summary.insert("suppressed".into(), Value::from(report.suppressed));
+    // cli-audit.md item 7: count of files excluded by `.arcisignore` /
+    // `.gitignore` / `.git/info/exclude`. Always emitted (same noise
+    // tradeoff as `suppressed`); the human report hides the line at 0.
+    summary.insert("ignored".into(), Value::from(report.ignored));
     doc.insert("summary".into(), Value::Object(summary));
 
     let mut findings_arr = Vec::with_capacity(report.findings.len());
@@ -397,6 +407,7 @@ mod tests {
             duration_ms: 500,
             severity_filter: None,
             suppressed: 0,
+            ignored: 0,
         };
         let out = render_json(&report);
         let doc = parse(&out);
@@ -429,6 +440,7 @@ mod tests {
             duration_ms: 0,
             severity_filter: Some(Severity::High),
             suppressed: 0,
+            ignored: 0,
         };
         let doc = parse(&render_json(&report));
         assert_eq!(doc["severityFilter"], Json::from("high"));
@@ -450,6 +462,7 @@ mod tests {
             duration_ms: 100,
             severity_filter: None,
             suppressed: 0,
+            ignored: 0,
         };
         let out = render_json(&report);
         let doc = parse(&out);
@@ -484,6 +497,7 @@ mod tests {
             duration_ms: 0,
             severity_filter: None,
             suppressed: 0,
+            ignored: 0,
         });
         // String-position sniff: ruleId opens the finding object, id
         // follows immediately, severity comes after.
@@ -515,6 +529,7 @@ mod tests {
             duration_ms: 0,
             severity_filter: None,
             suppressed: 0,
+            ignored: 0,
         });
         let positions: Vec<usize> = [
             "\"tool\"",
@@ -551,6 +566,7 @@ mod tests {
             duration_ms: 0,
             severity_filter: None,
             suppressed: 0,
+            ignored: 0,
         });
         assert!(
             out.contains("\\u2014"),
@@ -580,11 +596,62 @@ mod tests {
             duration_ms: 0,
             severity_filter: None,
             suppressed: 12,
+            ignored: 0,
         });
         let doc = parse(&out);
         assert_eq!(doc["summary"]["suppressed"], Json::from(12u64));
         assert_eq!(doc["summary"]["totalFindings"], Json::from(0u64));
         assert_eq!(doc["findings"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn json_ignored_count_emitted_in_summary() {
+        // cli-audit.md item 7: when the walker excluded N files via
+        // `.arcisignore` / `.gitignore`, `summary.ignored` reports the
+        // count. Ignored files do NOT appear in `filesScanned` (the
+        // walker drops them before scanning).
+        let by_lang = BTreeMap::new();
+        let by_sev = BTreeMap::new();
+        let out = render_json(&JsonReport {
+            tool_version: "1.0",
+            target: "/tmp",
+            findings: &[],
+            files_scanned: 7,
+            by_language: &by_lang,
+            rules_applied: 0,
+            by_severity: &by_sev,
+            duration_ms: 0,
+            severity_filter: None,
+            suppressed: 0,
+            ignored: 4,
+        });
+        let doc = parse(&out);
+        assert_eq!(doc["summary"]["ignored"], Json::from(4u64));
+        assert_eq!(doc["summary"]["filesScanned"], Json::from(7u64));
+    }
+
+    #[test]
+    fn json_ignored_key_always_present_even_at_zero() {
+        // Same noise tradeoff as `suppressed`: zero is informative —
+        // confirms the field exists on a clean run, so consumers don't
+        // have to handle "missing" vs "zero".
+        let by_lang = BTreeMap::new();
+        let by_sev = BTreeMap::new();
+        let out = render_json(&JsonReport {
+            tool_version: "1.0",
+            target: "/tmp",
+            findings: &[],
+            files_scanned: 0,
+            by_language: &by_lang,
+            rules_applied: 0,
+            by_severity: &by_sev,
+            duration_ms: 0,
+            severity_filter: None,
+            suppressed: 0,
+            ignored: 0,
+        });
+        let doc = parse(&out);
+        assert_eq!(doc["summary"]["ignored"], Json::from(0u64));
     }
 
     #[test]
@@ -602,6 +669,7 @@ mod tests {
             duration_ms: 0,
             severity_filter: None,
             suppressed: 0,
+            ignored: 0,
         });
         // Python `json.dumps(..., indent=2)` uses 2-space indent. Our
         // serde_json::to_string_pretty default is also 2 spaces. Pin

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/render.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/render.rs
@@ -52,6 +52,12 @@ pub struct JsonReport<'a> {
     pub by_severity: &'a BTreeMap<Severity, usize>,
     pub duration_ms: u64,
     pub severity_filter: Option<Severity>,
+    /// Findings that fired but were silenced by a suppress-comment
+    /// directive (cli-audit.md item 6). Surfaces as
+    /// `summary.suppressed` in the JSON output. Suppressed findings
+    /// are NOT included in the `findings` array — only the count
+    /// surfaces, by design.
+    pub suppressed: usize,
 }
 
 /// Render the audit result as a JSON document. Schema:
@@ -106,6 +112,11 @@ pub fn render_json(report: &JsonReport<'_>) -> String {
     summary.insert("bySeverity".into(), Value::Object(by_sev));
 
     summary.insert("totalFindings".into(), Value::from(report.findings.len()));
+    // cli-audit.md item 6: count of suppress-comment-silenced findings.
+    // Always emitted (zero is informative — confirms the field exists
+    // even on a clean run). Suppressed findings themselves are NOT
+    // listed; only the count.
+    summary.insert("suppressed".into(), Value::from(report.suppressed));
     doc.insert("summary".into(), Value::Object(summary));
 
     let mut findings_arr = Vec::with_capacity(report.findings.len());
@@ -385,6 +396,7 @@ mod tests {
             by_severity: &by_sev,
             duration_ms: 500,
             severity_filter: None,
+            suppressed: 0,
         };
         let out = render_json(&report);
         let doc = parse(&out);
@@ -395,6 +407,9 @@ mod tests {
         assert_eq!(doc["summary"]["filesScanned"], Json::from(3u64));
         assert_eq!(doc["summary"]["rulesApplied"], Json::from(14u64));
         assert_eq!(doc["summary"]["totalFindings"], Json::from(0u64));
+        // cli-audit.md item 6: suppressed key always present, defaults
+        // to 0 even on a clean run.
+        assert_eq!(doc["summary"]["suppressed"], Json::from(0u64));
         assert!(doc["findings"].is_array());
         assert_eq!(doc["findings"].as_array().unwrap().len(), 0);
     }
@@ -413,6 +428,7 @@ mod tests {
             by_severity: &by_sev,
             duration_ms: 0,
             severity_filter: Some(Severity::High),
+            suppressed: 0,
         };
         let doc = parse(&render_json(&report));
         assert_eq!(doc["severityFilter"], Json::from("high"));
@@ -433,6 +449,7 @@ mod tests {
             by_severity: &by_sev,
             duration_ms: 100,
             severity_filter: None,
+            suppressed: 0,
         };
         let out = render_json(&report);
         let doc = parse(&out);
@@ -466,6 +483,7 @@ mod tests {
             by_severity: &by_sev,
             duration_ms: 0,
             severity_filter: None,
+            suppressed: 0,
         });
         // String-position sniff: ruleId opens the finding object, id
         // follows immediately, severity comes after.
@@ -496,6 +514,7 @@ mod tests {
             by_severity: &by_sev,
             duration_ms: 0,
             severity_filter: None,
+            suppressed: 0,
         });
         let positions: Vec<usize> = [
             "\"tool\"",
@@ -531,6 +550,7 @@ mod tests {
             by_severity: &by_sev,
             duration_ms: 0,
             severity_filter: None,
+            suppressed: 0,
         });
         assert!(
             out.contains("\\u2014"),
@@ -540,6 +560,31 @@ mod tests {
             !out.contains('\u{2014}'),
             "em dash should not appear literally — Python's default escapes it"
         );
+    }
+
+    #[test]
+    fn json_suppressed_count_emitted_in_summary() {
+        // cli-audit.md item 6: when the scan suppressed N findings,
+        // `summary.suppressed` reports the count. Suppressed findings
+        // do NOT appear in the `findings` array.
+        let by_lang = BTreeMap::new();
+        let by_sev = BTreeMap::new();
+        let out = render_json(&JsonReport {
+            tool_version: "1.0",
+            target: "/tmp",
+            findings: &[],
+            files_scanned: 1,
+            by_language: &by_lang,
+            rules_applied: 0,
+            by_severity: &by_sev,
+            duration_ms: 0,
+            severity_filter: None,
+            suppressed: 12,
+        });
+        let doc = parse(&out);
+        assert_eq!(doc["summary"]["suppressed"], Json::from(12u64));
+        assert_eq!(doc["summary"]["totalFindings"], Json::from(0u64));
+        assert_eq!(doc["findings"].as_array().unwrap().len(), 0);
     }
 
     #[test]
@@ -556,6 +601,7 @@ mod tests {
             by_severity: &by_sev,
             duration_ms: 0,
             severity_filter: None,
+            suppressed: 0,
         });
         // Python `json.dumps(..., indent=2)` uses 2-space indent. Our
         // serde_json::to_string_pretty default is also 2 spaces. Pin

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/render.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/render.rs
@@ -112,6 +112,11 @@ pub fn render_json(report: &JsonReport<'_>) -> String {
     for f in report.findings {
         let mut item = Map::new();
         item.insert("ruleId".into(), Value::from(f.rule_id));
+        // `id` is the deterministic `<RULE_ID>-<16hex>` fingerprint.
+        // Sits second so consumers can scan a finding's identity in the
+        // first two keys without paging through the message/file/line
+        // body. cli-audit.md item 10.
+        item.insert("id".into(), Value::from(f.id.as_str()));
         item.insert("severity".into(), Value::from(f.severity.as_str()));
         item.insert("message".into(), Value::from(f.message));
         item.insert("file".into(), Value::from(f.file.as_str()));
@@ -232,6 +237,18 @@ pub fn render_sarif(report: &SarifReport<'_>) -> String {
             "locations".into(),
             Value::Array(vec![Value::Object(location)]),
         );
+        // SARIF 2.1.0 §3.27.16: `partialFingerprints` is a tool-defined
+        // map that GitHub Code Scanning hashes for cross-run de-dupe.
+        // Versioned key (`arcis/v1`) gives us a clean rotation lane if
+        // we ever change the hash function — bumping to `arcis/v2`
+        // signals to GitHub that the fingerprint domain shifted.
+        // Empty `id` (scan_file path that bypassed assign_ids) is
+        // skipped so we don't emit empty-string fingerprints.
+        if !f.id.is_empty() {
+            let mut pf = Map::new();
+            pf.insert("arcis/v1".into(), Value::from(f.id.as_str()));
+            result.insert("partialFingerprints".into(), Value::Object(pf));
+        }
         results.push(Value::Object(result));
     }
 
@@ -334,6 +351,9 @@ mod tests {
     use serde_json::Value as Json;
 
     fn finding(rule_id: &'static str, sev: Severity, file: &str, line: usize) -> Finding {
+        // Test fixture id mirrors the live `<RULE_ID>-<16hex>` shape
+        // without invoking the hasher — render tests should exercise
+        // the renderer, not the hasher.
         Finding {
             rule_id,
             severity: sev,
@@ -341,6 +361,7 @@ mod tests {
             file: file.to_string(),
             line,
             snippet: "yaml.load(f)".to_string(),
+            id: format!("{rule_id}-deadbeefcafef00d"),
         }
     }
 
@@ -421,10 +442,41 @@ mod tests {
         assert_eq!(arr.len(), 1);
         let item = &arr[0];
         assert_eq!(item["ruleId"], Json::from("YAML-UNSAFE"));
+        assert_eq!(item["id"], Json::from("YAML-UNSAFE-deadbeefcafef00d"));
         assert_eq!(item["severity"], Json::from("high"));
         assert_eq!(item["file"], Json::from("/tmp/a.py"));
         assert_eq!(item["line"], Json::from(42u64));
         assert_eq!(item["snippet"], Json::from("yaml.load(f)"));
+    }
+
+    #[test]
+    fn json_finding_id_appears_second_after_rule_id() {
+        // cli-audit.md item 10: `id` sits between `ruleId` and the
+        // body fields so consumers see the identity pair up front.
+        let f = finding("YAML-UNSAFE", Severity::High, "/tmp/a.py", 42);
+        let by_lang: BTreeMap<String, usize> = BTreeMap::new();
+        let by_sev: BTreeMap<Severity, usize> = BTreeMap::new();
+        let out = render_json(&JsonReport {
+            tool_version: "1.0",
+            target: "/tmp",
+            findings: std::slice::from_ref(&f),
+            files_scanned: 1,
+            by_language: &by_lang,
+            rules_applied: 0,
+            by_severity: &by_sev,
+            duration_ms: 0,
+            severity_filter: None,
+        });
+        // String-position sniff: ruleId opens the finding object, id
+        // follows immediately, severity comes after.
+        let rule_pos = out.find("\"ruleId\"").expect("ruleId key in output");
+        let id_pos = out.find("\"id\"").expect("id key in output");
+        let sev_pos = out.find("\"severity\"").expect("severity key in output");
+        assert!(
+            rule_pos < id_pos && id_pos < sev_pos,
+            "expected ruleId < id < severity in output, got positions \
+             rule={rule_pos} id={id_pos} sev={sev_pos}"
+        );
     }
 
     #[test]
@@ -645,6 +697,48 @@ mod tests {
             .as_str()
             .unwrap();
         assert_eq!(target_uri, target_uri2);
+    }
+
+    #[test]
+    fn sarif_partial_fingerprints_emitted_under_arcis_v1_key() {
+        // GitHub Code Scanning de-dupes results across runs by hashing
+        // the partialFingerprints map. cli-audit.md item 10 — versioned
+        // key gives us a clean rotation lane.
+        let f = finding("YAML-UNSAFE", Severity::High, "/x.py", 1);
+        let doc = parse(&render_sarif(&SarifReport {
+            tool_version: "1.0",
+            target_abspath: "/tmp",
+            findings: std::slice::from_ref(&f),
+        }));
+        let pf = &doc["runs"][0]["results"][0]["partialFingerprints"];
+        assert!(pf.is_object(), "partialFingerprints must be an object");
+        assert_eq!(
+            pf["arcis/v1"],
+            Json::from("YAML-UNSAFE-deadbeefcafef00d"),
+            "fingerprint sits under tool-versioned key"
+        );
+    }
+
+    #[test]
+    fn sarif_partial_fingerprints_omitted_when_id_empty() {
+        // Finding produced by `scan_file` (no relpath context) carries
+        // an empty id. The SARIF renderer must skip emitting an empty
+        // partialFingerprints entry rather than ship a useless `""` —
+        // a downstream tool with strict schema validation would reject
+        // it as a degenerate fingerprint.
+        let mut f = finding("YAML-UNSAFE", Severity::High, "/x.py", 1);
+        f.id = String::new();
+        let doc = parse(&render_sarif(&SarifReport {
+            tool_version: "1.0",
+            target_abspath: "/tmp",
+            findings: std::slice::from_ref(&f),
+        }));
+        assert!(
+            doc["runs"][0]["results"][0]
+                .get("partialFingerprints")
+                .is_none(),
+            "partialFingerprints must be absent for empty id"
+        );
     }
 
     #[test]

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/suppress.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/suppress.rs
@@ -1,0 +1,292 @@
+//! Suppress-comment directive parser. cli-audit.md item 6.
+//!
+//! Recognised forms:
+//!
+//! ```text
+//! // arcis-audit: ignore                  any rule, this line
+//! // arcis-audit: ignore RULE-ID          one specific rule
+//! // arcis-audit: ignore A,B,C            comma list
+//! // arcis-audit: ignore-file             whole file, any rule
+//! ```
+//!
+//! Both `//` (JS / TS) and `#` (Python) markers are recognised; nothing
+//! else. Block-comment forms (`/* ... */`, `<!-- ... -->`) are NOT
+//! recognised — adds parser complexity for zero current demand and
+//! invites multi-line directive ambiguity. Document-and-defer.
+//!
+//! ## Suppression scope
+//!
+//! Standard SAST semantics (matches Semgrep, NOT permissive-Bandit):
+//!
+//! 1. **Same-line directive** — applies to its own line. Trailing
+//!    comment-directive on a code line is the most common form:
+//!    `result = eval(x)  // arcis-audit: ignore EVAL-EXEC`.
+//! 2. **Preceding-line directive** — applies to the next line ONLY when
+//!    the directive sits on a comment-only line (first non-whitespace
+//!    char is `//` or `#`). A trailing inline directive on a code line
+//!    suppresses ONLY its own line; it never bleeds into the next.
+//! 3. **File-level directive** — `arcis-audit: ignore-file` anywhere in
+//!    the file suppresses every finding in that file.
+//!
+//! Why the comment-only-line restriction (not "any preceding line"):
+//! a directive like `eval(x) // arcis-audit: ignore` says "this eval is
+//! OK." Letting it also silently suppress a finding on the next line is
+//! the classic SAST footgun — security tooling must be predictable, not
+//! convenient. If someone wants to suppress two adjacent lines, they
+//! write two directives.
+//!
+//! ## Out-of-scope (today)
+//!
+//! - `--show-suppressed` flag — wait for a real ask.
+//! - Per-file `noqa`-style end-of-line directive without rule scoping
+//!   beyond what's documented here.
+//! - Block-comment hosts.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+/// One parsed suppression directive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Directive {
+    /// `arcis-audit: ignore` (any rule) or `arcis-audit: ignore A,B,C`
+    /// (specific rules). `None` rules → matches every rule_id.
+    Line { rules: Option<Vec<String>> },
+    /// `arcis-audit: ignore-file` — whole file, any rule.
+    File,
+}
+
+static LINE_RE: OnceLock<Regex> = OnceLock::new();
+static FILE_RE: OnceLock<Regex> = OnceLock::new();
+
+fn line_re() -> &'static Regex {
+    LINE_RE.get_or_init(|| {
+        // `(?://|#)` — comment marker (JS-family or Python).
+        // `\s*arcis-audit:\s*ignore` — directive token.
+        // `(?:\s+(.+?))?` — optional whitespace-separated rule list.
+        // `\s*$` — anchored to end of line; with `\s*` after the rule
+        //          capture, this correctly fails to match `ignore-file`
+        //          (no whitespace before `-file`).
+        Regex::new(r"(?://|#)\s*arcis-audit:\s*ignore(?:\s+(.+?))?\s*$").unwrap()
+    })
+}
+
+fn file_re() -> &'static Regex {
+    FILE_RE.get_or_init(|| Regex::new(r"(?://|#)\s*arcis-audit:\s*ignore-file\b").unwrap())
+}
+
+/// Parse one source line into a directive, or `None` if it carries
+/// none. The file-level form takes precedence over the line form when
+/// both could in theory match.
+pub fn parse_line(line: &str) -> Option<Directive> {
+    if file_re().is_match(line) {
+        return Some(Directive::File);
+    }
+    let cap = line_re().captures(line)?;
+    let rules = cap.get(1).map(|m| {
+        m.as_str()
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+    });
+    // An empty captured group (e.g. directive with trailing whitespace
+    // but no rule) collapses back to "any rule" semantics.
+    let rules = match rules {
+        Some(v) if v.is_empty() => None,
+        v => v,
+    };
+    Some(Directive::Line { rules })
+}
+
+/// True if `line`'s first non-whitespace char begins a comment marker
+/// (`//` or `#`). Used to gate preceding-line directive scope per the
+/// module-level scope rules.
+pub fn is_comment_only_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("//") || trimmed.starts_with('#')
+}
+
+/// True if `directive` covers `rule_id`.
+pub fn matches(directive: &Directive, rule_id: &str) -> bool {
+    match directive {
+        Directive::File => true,
+        Directive::Line { rules: None } => true,
+        Directive::Line { rules: Some(ids) } => ids.iter().any(|r| r == rule_id),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line(rules: Option<Vec<&str>>) -> Directive {
+        Directive::Line {
+            rules: rules.map(|v| v.into_iter().map(String::from).collect()),
+        }
+    }
+
+    // ── parse_line: line-level forms ─────────────────────────────────────
+
+    #[test]
+    fn parses_bare_double_slash_directive_as_any_rule() {
+        assert_eq!(parse_line("// arcis-audit: ignore"), Some(line(None)));
+    }
+
+    #[test]
+    fn parses_bare_hash_directive_as_any_rule_for_python() {
+        assert_eq!(parse_line("# arcis-audit: ignore"), Some(line(None)));
+    }
+
+    #[test]
+    fn parses_single_rule_list() {
+        assert_eq!(
+            parse_line("// arcis-audit: ignore EVAL-EXEC"),
+            Some(line(Some(vec!["EVAL-EXEC"])))
+        );
+    }
+
+    #[test]
+    fn parses_comma_rule_list_with_whitespace_between() {
+        assert_eq!(
+            parse_line("# arcis-audit: ignore EVAL-EXEC, YAML-UNSAFE , PICKLE-LOAD"),
+            Some(line(Some(vec!["EVAL-EXEC", "YAML-UNSAFE", "PICKLE-LOAD"])))
+        );
+    }
+
+    #[test]
+    fn parses_trailing_comment_directive_after_code() {
+        // The most common form: trailing comment on a code line.
+        assert_eq!(
+            parse_line("    result = eval(x)  // arcis-audit: ignore EVAL-EXEC"),
+            Some(line(Some(vec!["EVAL-EXEC"])))
+        );
+    }
+
+    #[test]
+    fn parses_trailing_hash_directive_after_python_code() {
+        assert_eq!(
+            parse_line("    result = eval(x)  # arcis-audit: ignore EVAL-EXEC"),
+            Some(line(Some(vec!["EVAL-EXEC"])))
+        );
+    }
+
+    // ── parse_line: file-level form ──────────────────────────────────────
+
+    #[test]
+    fn parses_double_slash_file_directive() {
+        assert_eq!(
+            parse_line("// arcis-audit: ignore-file"),
+            Some(Directive::File)
+        );
+    }
+
+    #[test]
+    fn parses_hash_file_directive() {
+        assert_eq!(
+            parse_line("# arcis-audit: ignore-file"),
+            Some(Directive::File)
+        );
+    }
+
+    #[test]
+    fn file_directive_takes_priority_over_line_directive_form() {
+        // `ignore-file` must NOT be parsed as `ignore` with rule `-file`.
+        match parse_line("// arcis-audit: ignore-file").unwrap() {
+            Directive::File => {}
+            other => panic!("expected File directive, got {other:?}"),
+        }
+    }
+
+    // ── parse_line: rejection cases ──────────────────────────────────────
+
+    #[test]
+    fn rejects_non_directive_comment() {
+        assert_eq!(parse_line("// regular comment"), None);
+        assert_eq!(parse_line("# also regular"), None);
+    }
+
+    #[test]
+    fn rejects_typo_in_directive_token() {
+        // The token must be exactly `arcis-audit:`. `arcis:`, `arcisaudit:`,
+        // `arcis-audit ` (no colon) all bounce.
+        assert_eq!(parse_line("// arcis: ignore"), None);
+        assert_eq!(parse_line("// arcisaudit: ignore"), None);
+        assert_eq!(parse_line("// arcis-audit ignore"), None);
+    }
+
+    #[test]
+    fn rejects_string_literal_with_directive_text_no_comment_marker() {
+        // No `//` or `#` anywhere → not a directive even if the body
+        // contains the magic words. Prevents string-literal false matches.
+        assert_eq!(parse_line(r#"const s = "arcis-audit: ignore EVAL""#), None);
+    }
+
+    #[test]
+    fn rejects_plain_code_line() {
+        assert_eq!(parse_line("result = eval(user_input)"), None);
+        assert_eq!(parse_line(""), None);
+    }
+
+    // ── is_comment_only_line ─────────────────────────────────────────────
+
+    #[test]
+    fn is_comment_only_line_recognises_double_slash() {
+        assert!(is_comment_only_line("// hi"));
+        assert!(is_comment_only_line("    // hi"));
+        assert!(is_comment_only_line("\t// hi"));
+    }
+
+    #[test]
+    fn is_comment_only_line_recognises_hash() {
+        assert!(is_comment_only_line("# hi"));
+        assert!(is_comment_only_line("    # hi"));
+    }
+
+    #[test]
+    fn is_comment_only_line_rejects_inline_comment() {
+        // `eval(x) // ...` is NOT a comment-only line.
+        assert!(!is_comment_only_line("eval(x) // arcis-audit: ignore"));
+        assert!(!is_comment_only_line("eval(x) # arcis-audit: ignore"));
+    }
+
+    #[test]
+    fn is_comment_only_line_rejects_non_comment_lines() {
+        assert!(!is_comment_only_line("eval(x)"));
+        assert!(!is_comment_only_line(""));
+        assert!(!is_comment_only_line("   "));
+    }
+
+    // ── matches ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn matches_file_directive_covers_anything() {
+        assert!(matches(&Directive::File, "EVAL-EXEC"));
+        assert!(matches(&Directive::File, "ANYTHING"));
+    }
+
+    #[test]
+    fn matches_line_directive_with_no_rules_is_wildcard() {
+        assert!(matches(&line(None), "EVAL-EXEC"));
+        assert!(matches(&line(None), "YAML-UNSAFE"));
+    }
+
+    #[test]
+    fn matches_line_directive_only_for_listed_rule() {
+        let d = line(Some(vec!["EVAL-EXEC", "YAML-UNSAFE"]));
+        assert!(matches(&d, "EVAL-EXEC"));
+        assert!(matches(&d, "YAML-UNSAFE"));
+        assert!(!matches(&d, "PICKLE-LOAD"));
+        assert!(!matches(&d, "XSS-RAW"));
+    }
+
+    #[test]
+    fn matches_is_case_sensitive_on_rule_id() {
+        // Rule IDs in this codebase are uppercase (EVAL-EXEC, etc.).
+        // Lowercase / mixed case in a directive is treated as a typo,
+        // not a fuzzy match — silent suppression is worse than a missed
+        // suppression hint.
+        let d = line(Some(vec!["eval-exec"]));
+        assert!(!matches(&d, "EVAL-EXEC"));
+    }
+}

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/walker.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/walker.rs
@@ -1,22 +1,33 @@
 //! File walker for the audit module.
 //!
-//! Direct port of `_collect_files` from
-//! `packages/arcis-python/arcis/cli/audit.py`. Walks the target tree,
-//! prunes `SKIP_DIRS`, returns paths whose extensions map to a known
-//! [`Language`] via [`Language::from_extension`].
+//! Walks the target tree, prunes [`SKIP_DIRS`], honours `.arcisignore`,
+//! `.gitignore`, and `.git/info/exclude`, and returns paths whose
+//! extensions map to a known [`Language`] via
+//! [`Language::from_extension`].
 //!
-//! Uses `walkdir`, not the `ignore` crate. Python `os.walk` does NOT
-//! honor `.gitignore`, and we need byte-equal parity in the final
-//! finding list — using `ignore` would diverge whenever a target tree
-//! has gitignored source files. Gitignore support belongs behind a
-//! flag (post-parity).
+//! Uses BurntSushi's `ignore` crate (same engine as ripgrep) for native
+//! gitignore stacking: per-directory files apply to their subtree,
+//! `**`, negation (`!important.js`), and trailing-comment syntax all
+//! work without a hand-rolled matcher. The walk was previously
+//! `walkdir`-based for byte-equal parity with Python's `os.walk` (which
+//! does NOT honor gitignore); that constraint went away when the Python
+//! audit was cut in commit `a9353af`.
 //!
-//! Symlinks are not followed — matches the post-fix Python behavior
+//! Symlinks are not followed — matches the post-fix Python behaviour
 //! from commit `e778439`.
+//!
+//! ## Hardcoded fallback ([`SKIP_DIRS`])
+//!
+//! 13 directory names are pruned regardless of ignore-file presence
+//! (e.g. `node_modules`, `.git`, `__pycache__`, `dist`). This is the
+//! belt-and-braces safety net for: (a) projects with no `.gitignore`,
+//! (b) users who pass `--no-ignore` to bypass ignore files, (c)
+//! always-junk dirs that nobody ever wants to scan deliberately. It
+//! applies to BOTH the main walk and the `--no-ignore` count walk.
 
 use std::path::{Path, PathBuf};
 
-use walkdir::WalkDir;
+use ignore::WalkBuilder;
 
 use super::rules::Language;
 
@@ -52,53 +63,194 @@ pub fn detect_language(path: &Path) -> Option<Language> {
         .and_then(Language::from_extension)
 }
 
-/// Collect scannable source files under `path`.
+/// Options controlling which ignore-file machinery is honoured during
+/// the walk. Patterns in `.arcisignore` and `.gitignore` follow standard
+/// gitignore syntax via the `ignore` crate — `**` glob, `!important.js`
+/// negation, per-directory scoping, `#` comments, and trailing-slash
+/// directory-only matchers all work without further configuration.
+///
+/// Default is **both on**, matching ripgrep / Semgrep convention. Users
+/// expect gitignored generated files / build artifacts / vendored deps
+/// to skip without extra flags.
+///
+/// CLI flag mapping:
+/// * `--no-ignore` disables both → `IgnoreOptions { use_arcisignore: false, use_gitignore: false }`
+/// * `--no-gitignore` disables gitignore only → `IgnoreOptions { use_arcisignore: true, use_gitignore: false }`
+///
+/// There is intentionally no `--no-arcisignore` flag: gitignore-only-off
+/// is a real monorepo case (vendored dirs with broad `.gitignore` lines
+/// you do want scanned), arcisignore-only-off has no use case (just
+/// delete the file).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IgnoreOptions {
+    /// Honor `.arcisignore` files at any directory level.
+    pub use_arcisignore: bool,
+    /// Honor `.gitignore`, `.git/info/exclude`, and the user's global
+    /// gitignore.
+    pub use_gitignore: bool,
+}
+
+impl Default for IgnoreOptions {
+    fn default() -> Self {
+        Self {
+            use_arcisignore: true,
+            use_gitignore: true,
+        }
+    }
+}
+
+/// Output of [`collect_files_with_options`]: the kept files plus a
+/// count of files that *would* have been collected but were excluded
+/// by an ignore rule. Mirrors the [`super::engine::FileResult`]
+/// suppressed-count pattern used by item 6.
+///
+/// `ignored` counts only files whose extension maps to a known
+/// [`Language`] (and matches any active language filter) — directories
+/// pruned by an ignore rule contribute one entry per ignored
+/// language-matching file inside them, NOT one per directory. The
+/// number is stable across runs.
+///
+/// `ignored == 0` whenever both `use_arcisignore` and `use_gitignore`
+/// are false, since the count is computed as
+/// `total_after_skip_dirs - kept_after_ignore_rules`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WalkResult {
+    pub files: Vec<PathBuf>,
+    pub ignored: usize,
+}
+
+/// Collect scannable source files under `path` (back-compat wrapper).
+///
+/// Equivalent to [`collect_files_with_options`] with default
+/// [`IgnoreOptions`] (both `.arcisignore` and `.gitignore` honoured),
+/// returning only the kept files. Existing engine + test callers that
+/// don't care about the ignored count keep working unchanged.
+pub fn collect_files(path: &Path, language: Option<Language>) -> Vec<PathBuf> {
+    collect_files_with_options(path, language, &IgnoreOptions::default()).files
+}
+
+/// Collect scannable source files under `path` with explicit ignore
+/// configuration.
 ///
 /// * If `path` is a single file, returns `[path]` if its extension
 ///   maps to a known [`Language`] and matches the optional `language`
-///   filter; otherwise empty.
-/// * If `path` is a directory, walks recursively, prunes any directory
-///   whose name appears in [`SKIP_DIRS`], yields files with a known
-///   extension (and matching the optional language filter).
-/// * Walk order is unspecified — matches Python's `os.walk`. Final
-///   finding output is sorted by `(severity, file, line)` downstream
-///   so the unsorted walk order doesn't affect byte-equality of the
-///   JSON / SARIF doc.
+///   filter; otherwise empty. Ignore files are NOT consulted in this
+///   fast path — the user explicitly named the file.
+/// * If `path` is a directory, walks recursively via
+///   [`ignore::WalkBuilder`]:
+///   - prunes any directory whose name appears in [`SKIP_DIRS`]
+///     (always, regardless of `opts`),
+///   - honours `.arcisignore` per `opts.use_arcisignore`,
+///   - honours `.gitignore` + `.git/info/exclude` + global gitignore
+///     per `opts.use_gitignore`,
+///   - yields files with a known extension matching the optional
+///     `language` filter.
+/// * Walk order is unspecified. Final finding output is sorted by
+///   `(severity, file, line)` downstream so the unsorted walk order
+///   doesn't affect byte-equality of the JSON / SARIF doc.
 /// * If `path` doesn't exist, returns empty (the CLI checks existence
 ///   up-front and emits a friendlier error; a defensive empty here
 ///   keeps the engine API total).
-pub fn collect_files(path: &Path, language: Option<Language>) -> Vec<PathBuf> {
+///
+/// The `ignored` count in the returned [`WalkResult`] is computed via
+/// a second walk with all ignore-file machinery disabled; the diff is
+/// the contribution of the ignore-file rules. Both walks share
+/// [`SKIP_DIRS`] + extension filter so "files always pruned" don't
+/// inflate the ignored count. See [`WalkResult`] for semantics.
+pub fn collect_files_with_options(
+    path: &Path,
+    language: Option<Language>,
+    opts: &IgnoreOptions,
+) -> WalkResult {
     if path.is_file() {
-        return match detect_language(path) {
+        let files = match detect_language(path) {
             Some(lang) if language.is_none() || language == Some(lang) => {
                 vec![path.to_path_buf()]
             }
             _ => Vec::new(),
         };
+        return WalkResult { files, ignored: 0 };
     }
     if !path.is_dir() {
-        return Vec::new();
+        return WalkResult::default();
     }
 
-    let mut files = Vec::new();
+    let files = walk_with_ignore(path, language, opts);
 
-    let walker = WalkDir::new(path).follow_links(false).into_iter();
-    let walker = walker.filter_entry(|e| {
+    // Compute `ignored` via a second walk with all ignore machinery
+    // disabled. The diff is the contribution of `.arcisignore` +
+    // `.gitignore` + `.git/info/exclude`. Acceptable two-walk overhead:
+    // the second pass is OS-cached and audit's hot path is per-line
+    // pattern matching, not directory traversal. Revisit if/when item
+    // 11 (parallel scanning) lands — at that point a single-walk
+    // visitor that records both kept + skipped becomes worth the
+    // complexity.
+    let ignored = if opts.use_arcisignore || opts.use_gitignore {
+        let raw = IgnoreOptions {
+            use_arcisignore: false,
+            use_gitignore: false,
+        };
+        let total = walk_with_ignore(path, language, &raw).len();
+        total.saturating_sub(files.len())
+    } else {
+        0
+    };
+
+    WalkResult { files, ignored }
+}
+
+/// Internal walker: one pass with the given [`IgnoreOptions`]. Returns
+/// kept files only; counting is layered on top in
+/// [`collect_files_with_options`].
+fn walk_with_ignore(path: &Path, language: Option<Language>, opts: &IgnoreOptions) -> Vec<PathBuf> {
+    let mut builder = WalkBuilder::new(path);
+    builder
+        .follow_links(false)
+        // Don't auto-skip dotfiles. SKIP_DIRS already prunes the
+        // always-junk hidden dirs (`.git`, `.venv`, `.tox`,
+        // `.pytest_cache`, `.mypy_cache`, `.env`); leaving the
+        // ignore-crate `hidden` filter on would silently start skipping
+        // every `.foo.py` in a project, a behavior change from the
+        // previous walkdir-based traversal.
+        .hidden(false)
+        // `.gitignore` machinery — three knobs go together. Disabling
+        // honors `--no-gitignore` AND `--no-ignore`.
+        .git_ignore(opts.use_gitignore)
+        .git_global(opts.use_gitignore)
+        .git_exclude(opts.use_gitignore)
+        // Walk up from `path` to find ancestor `.gitignore` / global
+        // git config. Off when gitignore is off so the second
+        // count-walk in `collect_files_with_options` doesn't pick up
+        // an ancestor `.gitignore` outside the user's target tree.
+        .parents(opts.use_gitignore)
+        // `require_git(false)` so `.gitignore` is honoured even when
+        // the target dir isn't a real git working tree (no `.git/`
+        // marker). This is the documented escape hatch for the
+        // tempdir-based test pattern AND for users running audit on
+        // exported tarballs / vendored snapshots.
+        .require_git(false)
+        // `.ignore` (rg-style) AND any custom-ignore filename are
+        // gated together by this flag. Disabling honors `--no-ignore`.
+        .ignore(opts.use_arcisignore);
+    if opts.use_arcisignore {
+        builder.add_custom_ignore_filename(".arcisignore");
+    }
+    builder.filter_entry(|e| {
         // Always keep the root: SKIP_DIRS prunes CHILDREN only. If a
-        // user runs `arcis audit node_modules/`, walk it. Mirrors the
-        // Python `dirs[:] = [d for d in dirs if d not in SKIP_DIRS]`
-        // line (which only filters children of the current root).
+        // user runs `arcis audit node_modules/`, walk it.
         if e.depth() == 0 {
             return true;
         }
-        if e.file_type().is_dir() {
+        if e.file_type().is_some_and(|t| t.is_dir()) {
             return !is_skipped_dir_name(&e.file_name().to_string_lossy());
         }
         true
     });
 
-    for entry in walker.filter_map(|res| res.ok()) {
-        if !entry.file_type().is_file() {
+    let mut files = Vec::new();
+    for result in builder.build() {
+        let Ok(entry) = result else { continue };
+        if !entry.file_type().is_some_and(|t| t.is_file()) {
             continue;
         }
         let p = entry.path();
@@ -296,5 +448,199 @@ mod tests {
         write(td.path(), "a/b/c/d/e/skip.txt", "");
         let r = collect_files(td.path(), None);
         assert_eq!(names(&r), vec!["deep.py"]);
+    }
+
+    // ── ignore-file machinery (cli-audit.md item 7) ───────────────────
+
+    /// Canary: WITHOUT a `.git/` marker, `.gitignore` must still be
+    /// honored. We rely on `WalkBuilder::require_git(false)` to make
+    /// this work in tempdir tests AND in tarball-style targets that
+    /// are not git working trees.
+    #[test]
+    fn gitignore_respected_by_default() {
+        let td = TempDir::new().unwrap();
+        write(td.path(), "src/keep.py", "");
+        write(td.path(), "src/skip.py", "");
+        write(td.path(), ".gitignore", "skip.py\n");
+        let r = collect_files_with_options(td.path(), None, &IgnoreOptions::default());
+        assert_eq!(names(&r.files), vec!["keep.py"]);
+        assert_eq!(r.ignored, 1, "skip.py should be counted as ignored");
+    }
+
+    #[test]
+    fn arcisignore_at_root_excludes_glob_pattern() {
+        let td = TempDir::new().unwrap();
+        write(td.path(), "src/main.ts", "");
+        write(td.path(), "src/foo.generated.ts", "");
+        write(td.path(), "src/bar.generated.ts", "");
+        write(td.path(), ".arcisignore", "*.generated.ts\n");
+        let r = collect_files_with_options(td.path(), None, &IgnoreOptions::default());
+        assert_eq!(names(&r.files), vec!["main.ts"]);
+        assert_eq!(r.ignored, 2);
+    }
+
+    #[test]
+    fn arcisignore_in_subdir_scopes_to_subdir() {
+        // `.arcisignore` semantics mirror `.gitignore`: a file at
+        // `pkg/.arcisignore` only applies under `pkg/`. A pattern like
+        // `*.gen.ts` in that file must NOT exclude top-level
+        // `other.gen.ts`.
+        let td = TempDir::new().unwrap();
+        write(td.path(), "pkg/keep.ts", "");
+        write(td.path(), "pkg/foo.gen.ts", ""); // excluded by pkg/.arcisignore
+        write(td.path(), "pkg/.arcisignore", "*.gen.ts\n");
+        write(td.path(), "other.gen.ts", ""); // NOT excluded — directive scope is pkg/
+        let r = collect_files_with_options(td.path(), None, &IgnoreOptions::default());
+        let mut names = names(&r.files);
+        names.sort();
+        assert_eq!(names, vec!["keep.ts", "other.gen.ts"]);
+        assert_eq!(r.ignored, 1);
+    }
+
+    #[test]
+    fn arcisignore_negation_unexcludes() {
+        let td = TempDir::new().unwrap();
+        write(td.path(), "src/a.js", "");
+        write(td.path(), "src/b.js", "");
+        write(td.path(), "src/important.js", "");
+        write(td.path(), ".arcisignore", "*.js\n!important.js\n");
+        let r = collect_files_with_options(td.path(), None, &IgnoreOptions::default());
+        // Only `important.js` survives — the negation un-ignores it
+        // even after `*.js` would have excluded it.
+        assert_eq!(names(&r.files), vec!["important.js"]);
+        assert_eq!(r.ignored, 2);
+    }
+
+    #[test]
+    fn arcisignore_double_star_glob_excludes_nested() {
+        // Use `generated/` not `build/`: `build` is in SKIP_DIRS, so a
+        // hardcoded prune would steal credit from the `.arcisignore`
+        // rule and the test wouldn't actually exercise the `**` glob
+        // path. `generated/` is not in SKIP_DIRS, so without the
+        // arcisignore rule both nested `auto.py` files would be
+        // collected.
+        let td = TempDir::new().unwrap();
+        write(td.path(), "src/main.py", "");
+        write(td.path(), "src/generated/a.py", "");
+        write(td.path(), "lib/generated/nested/b.py", "");
+        write(td.path(), ".arcisignore", "**/generated/**\n");
+        let r = collect_files_with_options(td.path(), None, &IgnoreOptions::default());
+        assert_eq!(names(&r.files), vec!["main.py"]);
+        assert_eq!(r.ignored, 2);
+    }
+
+    #[test]
+    fn no_ignore_disables_both_files() {
+        let td = TempDir::new().unwrap();
+        write(td.path(), "a.py", "");
+        write(td.path(), "b.py", "");
+        write(td.path(), "c.py", "");
+        write(td.path(), ".gitignore", "a.py\n");
+        write(td.path(), ".arcisignore", "b.py\n");
+        let opts = IgnoreOptions {
+            use_arcisignore: false,
+            use_gitignore: false,
+        };
+        let r = collect_files_with_options(td.path(), None, &opts);
+        let mut names = names(&r.files);
+        names.sort();
+        assert_eq!(names, vec!["a.py", "b.py", "c.py"]);
+        assert_eq!(
+            r.ignored, 0,
+            "ignored count must be 0 when both ignore knobs are off"
+        );
+    }
+
+    #[test]
+    fn no_gitignore_keeps_arcisignore() {
+        let td = TempDir::new().unwrap();
+        write(td.path(), "a.py", "");
+        write(td.path(), "b.py", "");
+        write(td.path(), "c.py", "");
+        write(td.path(), ".gitignore", "a.py\n"); // disabled
+        write(td.path(), ".arcisignore", "b.py\n"); // still active
+        let opts = IgnoreOptions {
+            use_arcisignore: true,
+            use_gitignore: false,
+        };
+        let r = collect_files_with_options(td.path(), None, &opts);
+        let mut names = names(&r.files);
+        names.sort();
+        assert_eq!(names, vec!["a.py", "c.py"]);
+        assert_eq!(r.ignored, 1, "only b.py from .arcisignore counts");
+    }
+
+    #[test]
+    fn skip_dirs_still_skip_with_no_ignore_files() {
+        // Belt-and-braces: `target/`, `node_modules/`, etc. must still
+        // prune even when the user runs `--no-ignore` on a fresh
+        // checkout with no `.gitignore`. Otherwise `arcis audit
+        // --no-ignore .` on a Node repo would walk a 100k-file
+        // node_modules tree.
+        let td = TempDir::new().unwrap();
+        write(td.path(), "src/a.py", "");
+        write(td.path(), "node_modules/b.py", "");
+        write(td.path(), ".git/c.py", "");
+        let opts = IgnoreOptions {
+            use_arcisignore: false,
+            use_gitignore: false,
+        };
+        let r = collect_files_with_options(td.path(), None, &opts);
+        assert_eq!(names(&r.files), vec!["a.py"]);
+        assert_eq!(r.ignored, 0);
+    }
+
+    #[test]
+    fn walkresult_ignored_count_matches_diff() {
+        // Pin the `ignored = total - kept` invariant explicitly so a
+        // future refactor can't silently break the count semantics.
+        let td = TempDir::new().unwrap();
+        for i in 0..5 {
+            write(td.path(), &format!("keep_{i}.py"), "");
+        }
+        for i in 0..3 {
+            write(td.path(), &format!("skip_{i}.py"), "");
+        }
+        write(td.path(), ".gitignore", "skip_*.py\n");
+        let r = collect_files_with_options(td.path(), None, &IgnoreOptions::default());
+        let raw = collect_files_with_options(
+            td.path(),
+            None,
+            &IgnoreOptions {
+                use_arcisignore: false,
+                use_gitignore: false,
+            },
+        );
+        assert_eq!(r.files.len(), 5);
+        assert_eq!(raw.files.len(), 8);
+        assert_eq!(r.ignored, raw.files.len() - r.files.len());
+    }
+
+    #[test]
+    fn single_file_path_unaffected_by_ignore_options() {
+        // The single-file fast path doesn't consult ignore files —
+        // the user explicitly named the file. Assert that a file
+        // matching its parent's `.gitignore` still scans when passed
+        // directly. Regression guard: if someone naively threads
+        // ignore-file logic into the fast path, this test catches it.
+        let td = TempDir::new().unwrap();
+        let target = write(td.path(), "skip.py", "");
+        write(td.path(), ".gitignore", "skip.py\n");
+        let r = collect_files_with_options(&target, None, &IgnoreOptions::default());
+        assert_eq!(r.files, vec![target]);
+        assert_eq!(r.ignored, 0);
+    }
+
+    #[test]
+    fn back_compat_collect_files_default_honours_gitignore() {
+        // The existing `collect_files` wrapper uses default
+        // IgnoreOptions, so any caller that doesn't migrate gets
+        // gitignore semantics for free. Pin that contract.
+        let td = TempDir::new().unwrap();
+        write(td.path(), "keep.py", "");
+        write(td.path(), "skip.py", "");
+        write(td.path(), ".gitignore", "skip.py\n");
+        let files = collect_files(td.path(), None);
+        assert_eq!(names(&files), vec!["keep.py"]);
     }
 }


### PR DESCRIPTION
## Summary

Three cli-audit.md Phase B ergonomics items shipped on track/rust-audit-ergo, plus a Cargo.lock refresh.

- **Item 10** — Deterministic SHA-256 finding IDs across runs. New `audit::finding_id` module fingerprints `(rule_id, relpath, line, snippet.trim_end())` with NUL separator + cross-platform-stable relpath. JSON emits `id` as second key after `ruleId`; SARIF emits `partialFingerprints["arcis/v1"]`. 17 finding_id tests + 3 render tests.
- **Item 6** — Suppress comments. Recognises `// arcis-audit: ignore[-file] [RULE-IDs]` and Python `#` form. Semgrep-strict semantics: preceding-line scope is comment-only-line gated to prevent silent-suppression footguns. New `summary.suppressed` JSON field + human "Suppressed N" line. 36 new tests.
- **Item 7** — `.arcisignore` + `.gitignore` exclusion via the `ignore` crate (ripgrep's engine). Native gitignore stacking, `**`, `!`negation, per-directory scoping. New CLI flags `--no-ignore` (kills both) and `--no-gitignore` (kills gitignore only). New `summary.ignored` JSON field + human "Files ignored N" line. 20 new tests.
- **Cargo.lock refresh** — pulls in `ignore` + transitives (bstr, crossbeam-*, globset). Deferred until PR #103 merged to avoid lock churn.

## Test surface

~73 new Rust tests. Workspace test count: 320 passing in Docker rust:1.88 with item 7 active. fmt + clippy clean on the new code. Same 3 platforms as PR #103: ubuntu / macos / windows.

## Next on this track

Item 8 (CLI integration test pin for `--severity`), then item 9 (baseline mode, now unblocked by item 10) or item 11 (bounded concurrency, independent).