### PR TITLE
scan(phaseb): --bearer + --cookie + --login + curl reproducer + --categories comma syntax (cli-scan.md items 5, 7, 8)

### DIFF
--- a/packages/arcis-rust/crates/arcis-cli/src/scan.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/scan.rs
@@ -13,8 +13,8 @@ use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
 use arcis_engine::scan::{
-    attack_categories, discover_routes, format_curl, payloads::slug, scan_route, AuthConfig,
-    DiscoveredRoute, RouteResult, ScanOptions, DEFAULT_FIELDS,
+    attack_categories, discover_routes, execute_login, format_curl, payloads::slug, scan_route,
+    AuthConfig, DiscoveredRoute, LoginConfig, RouteResult, ScanOptions, DEFAULT_FIELDS,
 };
 
 const RESET: &str = "\x1b[0m";
@@ -40,6 +40,9 @@ struct Args {
     json_output: bool,
     bearer: Option<String>,
     cookie: Option<String>,
+    login_url: Option<String>,
+    login_form: Vec<(String, String)>,
+    login_json: bool,
 }
 
 #[derive(Debug)]
@@ -66,6 +69,9 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
         json_output: false,
         bearer: None,
         cookie: None,
+        login_url: None,
+        login_form: Vec::new(),
+        login_json: false,
     };
 
     let mut i = 0;
@@ -168,12 +174,41 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
                     Err(e) => return ParseOutcome::Err(e),
                 }
             }
-            // note(commit #4 --login): when --login lands, add a mutex
-            // check here:
-            //   if args.login.is_some() && args.bearer.is_some() { exit 2 }
-            //   if args.login.is_some() && args.cookie.is_some() { exit 2 }
-            // --login generates its own auth artifact, so combining it
-            // with manual flags is ambiguous. Reject early.
+            "--login" => {
+                i += 1;
+                let Some(v) = argv.get(i) else {
+                    return ParseOutcome::Err("arcis scan: --login needs a value".into());
+                };
+                match validate_login_url(v) {
+                    Ok(u) => args.login_url = Some(u),
+                    Err(e) => return ParseOutcome::Err(e),
+                }
+            }
+            arg if arg.starts_with("--login=") => {
+                let v = &arg["--login=".len()..];
+                match validate_login_url(v) {
+                    Ok(u) => args.login_url = Some(u),
+                    Err(e) => return ParseOutcome::Err(e),
+                }
+            }
+            "--login-form" => {
+                i += 1;
+                let Some(v) = argv.get(i) else {
+                    return ParseOutcome::Err("arcis scan: --login-form needs a value".into());
+                };
+                match parse_login_form_pair(v) {
+                    Ok(pair) => args.login_form.push(pair),
+                    Err(e) => return ParseOutcome::Err(e),
+                }
+            }
+            arg if arg.starts_with("--login-form=") => {
+                let v = &arg["--login-form=".len()..];
+                match parse_login_form_pair(v) {
+                    Ok(pair) => args.login_form.push(pair),
+                    Err(e) => return ParseOutcome::Err(e),
+                }
+            }
+            "--login-json" => args.login_json = true,
             other if other.starts_with("--") || (other.starts_with('-') && other.len() > 1) => {
                 return ParseOutcome::Err(format!("arcis scan: unknown flag: {other}"));
             }
@@ -187,6 +222,23 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
             }
         }
         i += 1;
+    }
+
+    // Cross-flag validation. Run after the per-arg parse loop so the
+    // user sees the most relevant error first (mutex / orphan-flag
+    // checks fire only when the individual flags parsed cleanly).
+    if args.login_url.is_some() && (args.bearer.is_some() || args.cookie.is_some()) {
+        return ParseOutcome::Err(
+            "arcis scan: --login is mutually exclusive with --bearer / --cookie. \
+             Use --login OR manual flags, not both."
+                .into(),
+        );
+    }
+    if args.login_url.is_none() && !args.login_form.is_empty() {
+        return ParseOutcome::Err("arcis scan: --login-form requires --login".into());
+    }
+    if args.login_url.is_none() && args.login_json {
+        return ParseOutcome::Err("arcis scan: --login-json requires --login".into());
     }
 
     ParseOutcome::Args(Box::new(args))
@@ -206,6 +258,32 @@ fn validate_cookie_value(value: &str) -> Result<String, String> {
     } else {
         Ok(value.to_string())
     }
+}
+
+fn validate_login_url(value: &str) -> Result<String, String> {
+    if value.trim().is_empty() {
+        return Err("arcis scan: --login cannot be empty or whitespace-only".into());
+    }
+    if !(value.starts_with("http://") || value.starts_with("https://")) {
+        return Err(format!(
+            "arcis scan: invalid --login URL scheme: {value}\n  Only http:// and https:// are supported."
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn parse_login_form_pair(value: &str) -> Result<(String, String), String> {
+    let Some((key, val)) = value.split_once('=') else {
+        return Err(format!(
+            "arcis scan: --login-form expects key=value, got: {value}"
+        ));
+    };
+    if key.is_empty() {
+        return Err(format!(
+            "arcis scan: --login-form expects key=value with non-empty key, got: {value}"
+        ));
+    }
+    Ok((key.to_string(), val.to_string()))
 }
 
 fn ansi(no_color: bool, code: &str) -> &str {
@@ -354,6 +432,34 @@ fn print_help(out: &mut dyn Write) -> io::Result<()> {
     writeln!(
         out,
         "                               Cookie value never appears in --json output."
+    )?;
+    writeln!(
+        out,
+        "      --login <url>            POST credentials to <url> and capture an auth artifact."
+    )?;
+    writeln!(
+        out,
+        "                               Capture priority: Set-Cookie -> access_token -> token -> jwt."
+    )?;
+    writeln!(
+        out,
+        "                               Mutex with --bearer / --cookie."
+    )?;
+    writeln!(
+        out,
+        "      --login-form key=value   Field for the login request body. Repeatable."
+    )?;
+    writeln!(
+        out,
+        "                               Default encoding: form-urlencoded."
+    )?;
+    writeln!(
+        out,
+        "      --login-json             Send --login-form fields as JSON instead."
+    )?;
+    writeln!(
+        out,
+        "                               Form keys + values never appear in --json output."
     )?;
     writeln!(
         out,
@@ -641,12 +747,41 @@ pub fn run(argv: &[String]) -> ExitCode {
 
     let timeout = Duration::from_secs(args.timeout);
 
-    // Build the auth config once. Parser already rejected empty/
-    // whitespace-only inputs; the engine validator below is belt-and-
-    // braces for any future direct API caller that bypasses the parser.
-    // `--bearer` and `--cookie` compose: distinct header names, no
-    // collision logic needed.
-    let auth_config: Option<AuthConfig> = if args.bearer.is_some() || args.cookie.is_some() {
+    // Build the runtime first — login (--login) needs to await
+    // execute_login before we can build the AuthConfig.
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            let _ = writeln!(err, "arcis scan: tokio runtime init failed: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    // Build the auth config. Three exclusive paths (the `--login`
+    // mutex check at parse time guarantees at most one of these
+    // branches fires):
+    //   1. `--login` set: execute the login flow on the runtime,
+    //      capture the artifact into a populated AuthConfig.
+    //   2. `--bearer` and/or `--cookie` set: compose manually.
+    //   3. Neither: no auth.
+    let auth_config: Option<AuthConfig> = if let Some(url) = args.login_url.as_deref() {
+        let lcfg = LoginConfig {
+            url: url.to_string(),
+            form: args.login_form.clone(),
+            json: args.login_json,
+        };
+        match runtime.block_on(execute_login(&lcfg, timeout)) {
+            Ok(cfg) => Some(cfg),
+            Err(e) => {
+                let _ = writeln!(err, "arcis scan: {e}");
+                return ExitCode::from(2);
+            }
+        }
+    } else if args.bearer.is_some() || args.cookie.is_some() {
         let mut cfg = AuthConfig::default();
         if let Some(token) = args.bearer.as_deref() {
             match AuthConfig::with_bearer(token) {
@@ -669,18 +804,6 @@ pub fn run(argv: &[String]) -> ExitCode {
         Some(cfg)
     } else {
         None
-    };
-
-    let runtime = match tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(4)
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(e) => {
-            let _ = writeln!(err, "arcis scan: tokio runtime init failed: {e}");
-            return ExitCode::from(2);
-        }
     };
 
     let start = Instant::now();
@@ -1123,6 +1246,218 @@ mod tests {
         let a = args(&["--bearer", "tok", "--cookie", "session=abc"]);
         assert_eq!(a.bearer.as_deref(), Some("tok"));
         assert_eq!(a.cookie.as_deref(), Some("session=abc"));
+    }
+
+    // --login flag tests
+
+    #[test]
+    fn parses_login_url_space_separated() {
+        let a = args(&["--login", "http://localhost:5000/auth/login"]);
+        assert_eq!(
+            a.login_url.as_deref(),
+            Some("http://localhost:5000/auth/login")
+        );
+    }
+
+    #[test]
+    fn parses_login_url_equals_inline() {
+        let a = args(&["--login=https://example.com/login"]);
+        assert_eq!(a.login_url.as_deref(), Some("https://example.com/login"));
+    }
+
+    #[test]
+    fn login_url_invalid_scheme_rejected() {
+        let argv: Vec<String> = ["--login", "ftp://example.com/login"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => {
+                assert!(e.contains("invalid --login URL scheme"), "got: {e}")
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn login_empty_value_rejected() {
+        let argv: Vec<String> = ["--login", ""].iter().map(|s| s.to_string()).collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => {
+                assert!(e.contains("--login cannot be empty"), "got: {e}")
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_login_form_repeatable() {
+        let a = args(&[
+            "--login",
+            "http://x/auth",
+            "--login-form",
+            "user=admin",
+            "--login-form",
+            "pass=hunter2",
+        ]);
+        assert_eq!(
+            a.login_form,
+            vec![
+                ("user".into(), "admin".into()),
+                ("pass".into(), "hunter2".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_login_form_value_with_inner_equals_kept_verbatim() {
+        // Only the FIRST `=` splits key from value — useful when the
+        // value itself contains `=` (base64, JWT-ish, etc.).
+        let a = args(&["--login", "http://x/auth", "--login-form", "raw=k=v=more"]);
+        assert_eq!(a.login_form, vec![("raw".into(), "k=v=more".into())]);
+    }
+
+    #[test]
+    fn login_form_rejects_no_equals() {
+        let argv: Vec<String> = ["--login", "http://x/auth", "--login-form", "bareword"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => {
+                assert!(
+                    e.contains("--login-form expects key=value, got: bareword"),
+                    "got: {e}"
+                )
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn login_form_rejects_empty_key() {
+        let argv: Vec<String> = ["--login", "http://x/auth", "--login-form", "=val"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => {
+                assert!(e.contains("non-empty key"), "got: {e}")
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_login_json_flag() {
+        let a = args(&["--login", "http://x/auth", "--login-json"]);
+        assert!(a.login_json);
+    }
+
+    #[test]
+    fn login_form_without_login_url_rejected() {
+        let argv: Vec<String> = ["--login-form", "user=admin"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => {
+                assert!(e.contains("--login-form requires --login"), "got: {e}")
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn login_json_without_login_url_rejected() {
+        let argv: Vec<String> = ["--login-json"].iter().map(|s| s.to_string()).collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => {
+                assert!(e.contains("--login-json requires --login"), "got: {e}")
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    /// The mutex error message is part of the documented contract.
+    /// Pin its exact wording so future refactors don't drift.
+    const MUTEX_MESSAGE: &str = "--login is mutually exclusive with --bearer / --cookie. \
+         Use --login OR manual flags, not both.";
+
+    #[test]
+    fn login_mutex_with_bearer_rejected_with_exact_message() {
+        let argv: Vec<String> = ["--login", "http://x/auth", "--bearer", "tok"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => assert!(e.contains(MUTEX_MESSAGE), "got: {e}"),
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn login_mutex_with_cookie_rejected_with_exact_message() {
+        let argv: Vec<String> = ["--login", "http://x/auth", "--cookie", "session=abc"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => assert!(e.contains(MUTEX_MESSAGE), "got: {e}"),
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn login_mutex_with_both_bearer_and_cookie_still_one_message() {
+        let argv: Vec<String> = [
+            "--login",
+            "http://x/auth",
+            "--bearer",
+            "tok",
+            "--cookie",
+            "s=a",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => assert!(e.contains(MUTEX_MESSAGE), "got: {e}"),
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn help_text_documents_login_capture_priority() {
+        // The capture priority (Set-Cookie -> access_token -> token ->
+        // jwt) is part of the documented user contract — pin it so
+        // future help-text refactors don't drop it. Users with weird
+        // login responses need a clear failure mode.
+        let mut buf: Vec<u8> = Vec::new();
+        print_help(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("--login <url>"), "missing flag entry: {s}");
+        assert!(
+            s.contains("--login-form key=value"),
+            "missing form flag: {s}"
+        );
+        assert!(s.contains("--login-json"), "missing json flag: {s}");
+        // Capture priority — all four tokens in the documented order.
+        let priority_pos = s.find("Set-Cookie -> access_token -> token -> jwt");
+        assert!(
+            priority_pos.is_some(),
+            "missing capture-priority order line: {s}"
+        );
+        // Mutex hint.
+        assert!(
+            s.contains("Mutex with --bearer / --cookie"),
+            "missing mutex hint: {s}"
+        );
+        // Form-redaction hint.
+        assert!(
+            s.contains("Form keys + values never appear in --json"),
+            "missing form redaction note: {s}"
+        );
     }
 
     #[test]

--- a/packages/arcis-rust/crates/arcis-cli/src/scan.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/scan.rs
@@ -106,11 +106,19 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
                 args.timeout = n;
             }
             "--categories" | "-c" => {
-                // nargs+: consume args until the next flag.
+                // Accept either nargs+ (space-separated, `--categories xss
+                // sql path`) or comma-separated (`--categories xss,sql,path`)
+                // or a mix of both. Each consumed token is split on `,`,
+                // trimmed, and empty pieces (from a stray comma) are dropped.
                 let mut cats: Vec<String> = Vec::new();
                 while i + 1 < argv.len() && !argv[i + 1].starts_with('-') {
                     i += 1;
-                    cats.push(argv[i].clone());
+                    for piece in argv[i].split(',') {
+                        let p = piece.trim();
+                        if !p.is_empty() {
+                            cats.push(p.to_string());
+                        }
+                    }
                 }
                 if cats.is_empty() {
                     return ParseOutcome::Err(
@@ -224,11 +232,11 @@ fn print_help(out: &mut dyn Write) -> io::Result<()> {
     )?;
     writeln!(
         out,
-        "  -c, --categories CAT [CAT..] Attack categories (default: all)."
+        "  -c, --categories CAT[,CAT..] Attack categories. Comma- or space-separated."
     )?;
     writeln!(
         out,
-        "                               Choices: {}",
+        "                               (default: all). Choices: {}",
         names.join(", ")
     )?;
     writeln!(
@@ -629,6 +637,27 @@ mod tests {
         let a = args(&["-c", "xss", "sql", "--yes"]);
         assert_eq!(a.categories.as_deref().unwrap(), &["xss", "sql"]);
         assert!(a.yes);
+    }
+
+    #[test]
+    fn parses_categories_comma_separated() {
+        let a = args(&["-c", "xss,sql,path"]);
+        assert_eq!(a.categories.as_deref().unwrap(), &["xss", "sql", "path"]);
+    }
+
+    #[test]
+    fn parses_categories_mixed_comma_and_space() {
+        let a = args(&["--categories", "xss,sql", "path", "nosql, cmd"]);
+        assert_eq!(
+            a.categories.as_deref().unwrap(),
+            &["xss", "sql", "path", "nosql", "cmd"]
+        );
+    }
+
+    #[test]
+    fn categories_drops_empty_comma_pieces() {
+        let a = args(&["-c", "xss,,sql,"]);
+        assert_eq!(a.categories.as_deref().unwrap(), &["xss", "sql"]);
     }
 
     #[test]

--- a/packages/arcis-rust/crates/arcis-cli/src/scan.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/scan.rs
@@ -13,8 +13,8 @@ use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
 use arcis_engine::scan::{
-    attack_categories, discover_routes, format_curl, payloads::slug, scan_route, DiscoveredRoute,
-    RouteResult, ScanOptions, DEFAULT_FIELDS,
+    attack_categories, discover_routes, format_curl, payloads::slug, scan_route, AuthConfig,
+    DiscoveredRoute, RouteResult, ScanOptions, DEFAULT_FIELDS,
 };
 
 const RESET: &str = "\x1b[0m";
@@ -38,6 +38,7 @@ struct Args {
     no_discovery: bool,
     no_control_plane: bool,
     json_output: bool,
+    bearer: Option<String>,
 }
 
 #[derive(Debug)]
@@ -62,6 +63,7 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
         no_discovery: false,
         no_control_plane: false,
         json_output: false,
+        bearer: None,
     };
 
     let mut i = 0;
@@ -130,6 +132,29 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
             "-l" => {
                 args.list = true;
             }
+            "--bearer" => {
+                i += 1;
+                let Some(v) = argv.get(i) else {
+                    return ParseOutcome::Err("arcis scan: --bearer needs a value".into());
+                };
+                match validate_bearer_value(v) {
+                    Ok(t) => args.bearer = Some(t),
+                    Err(e) => return ParseOutcome::Err(e),
+                }
+            }
+            arg if arg.starts_with("--bearer=") => {
+                let v = &arg["--bearer=".len()..];
+                match validate_bearer_value(v) {
+                    Ok(t) => args.bearer = Some(t),
+                    Err(e) => return ParseOutcome::Err(e),
+                }
+            }
+            // note(commit #4 --login): when --login lands, add a mutex
+            // check here:
+            //   if args.login.is_some() && args.bearer.is_some() { exit 2 }
+            //   if args.login.is_some() && !args.cookies.is_empty() { exit 2 }
+            // --login generates its own auth artifact, so combining it
+            // with manual flags is ambiguous. Reject early.
             other if other.starts_with("--") || (other.starts_with('-') && other.len() > 1) => {
                 return ParseOutcome::Err(format!("arcis scan: unknown flag: {other}"));
             }
@@ -146,6 +171,14 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
     }
 
     ParseOutcome::Args(Box::new(args))
+}
+
+fn validate_bearer_value(value: &str) -> Result<String, String> {
+    if value.trim().is_empty() {
+        Err("arcis scan: --bearer cannot be empty or whitespace-only".into())
+    } else {
+        Ok(value.to_string())
+    }
 }
 
 fn ansi(no_color: bool, code: &str) -> &str {
@@ -277,6 +310,14 @@ fn print_help(out: &mut dyn Write) -> io::Result<()> {
     )?;
     writeln!(
         out,
+        "      --bearer <token>         Send Authorization: Bearer <token> on every request."
+    )?;
+    writeln!(
+        out,
+        "                               Token value never appears in --json output."
+    )?;
+    writeln!(
+        out,
         "  -h, --help                   Show this help and exit."
     )?;
     writeln!(out)?;
@@ -399,6 +440,7 @@ fn print_human_report(
 fn print_json_report(
     out: &mut dyn Write,
     target_url: &str,
+    auth: Option<&AuthConfig>,
     results: &[RouteResult],
     summary: &ScanSummary,
 ) -> io::Result<()> {
@@ -447,6 +489,16 @@ fn print_json_report(
     let mut doc = Map::new();
     doc.insert("tool".into(), Value::String("arcis-scan".into()));
     doc.insert("target".into(), Value::String(target_url.into()));
+    // Auth metadata, redacted. Slot is between `target` and
+    // `durationMs` (run setup, before run results). Omitted entirely
+    // for unauthenticated runs so prior JSON output stays byte-equal.
+    // The redaction rule lives on `AuthConfig::redact_for_json`; see
+    // that doc-comment for the contract future flags must follow.
+    if let Some(auth) = auth {
+        if let Some(meta) = auth.redact_for_json() {
+            doc.insert("auth".into(), meta);
+        }
+    }
     doc.insert(
         "durationMs".into(),
         json!((summary.duration_secs * 1000.0).round() as u64),
@@ -550,6 +602,21 @@ pub fn run(argv: &[String]) -> ExitCode {
 
     let timeout = Duration::from_secs(args.timeout);
 
+    // Build the auth config once. Parser already rejected empty/
+    // whitespace-only tokens, so the engine validator should not fire
+    // here — but keep the belt-and-braces error path for the case where
+    // a future direct caller bypasses the parser.
+    let auth_config: Option<AuthConfig> = match args.bearer.as_deref() {
+        Some(token) => match AuthConfig::with_bearer(token) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                let _ = writeln!(err, "arcis scan: {e}");
+                return ExitCode::from(2);
+            }
+        },
+        None => None,
+    };
+
     let runtime = match tokio::runtime::Builder::new_multi_thread()
         .worker_threads(4)
         .enable_all()
@@ -572,6 +639,7 @@ pub fn run(argv: &[String]) -> ExitCode {
                 timeout,
                 categories: categories.as_deref(),
                 thorough: args.thorough,
+                auth: auth_config.as_ref(),
             };
             out.push(scan_route(&target_url, method, path, &opts).await);
         }
@@ -582,7 +650,13 @@ pub fn run(argv: &[String]) -> ExitCode {
     let summary = summarize(&results, elapsed);
 
     if args.json_output {
-        let _ = print_json_report(&mut out, &target_url, &results, &summary);
+        let _ = print_json_report(
+            &mut out,
+            &target_url,
+            auth_config.as_ref(),
+            &results,
+            &summary,
+        );
     } else if !args.quiet {
         let _ = print_human_report(&mut out, &target_url, &results, &summary, args.no_color);
     }
@@ -753,6 +827,114 @@ mod tests {
         assert_eq!(r, vec![("POST".into(), "http://example.com/x".into())]);
     }
 
+    /// Deliberately unique sentinel for the JSON-redaction tests below.
+    /// Pinned so a substring match against the emitted JSON cannot
+    /// false-positive on a hash digest, route URL, or vector label.
+    const TEST_BEARER_TOKEN: &str = "arcis-test-bearer-DEADBEEF-9f3a2c";
+
+    #[test]
+    fn parses_bearer_space_separated() {
+        let a = args(&["--bearer", "foo"]);
+        assert_eq!(a.bearer.as_deref(), Some("foo"));
+    }
+
+    #[test]
+    fn parses_bearer_equals_inline() {
+        let a = args(&["--bearer=foo"]);
+        assert_eq!(a.bearer.as_deref(), Some("foo"));
+    }
+
+    #[test]
+    fn bearer_empty_value_rejected() {
+        let argv: Vec<String> = ["--bearer", ""].iter().map(|s| s.to_string()).collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => {
+                assert!(e.contains("--bearer cannot be empty"), "got: {e}")
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bearer_whitespace_only_rejected() {
+        let argv: Vec<String> = ["--bearer", "   "].iter().map(|s| s.to_string()).collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => {
+                assert!(e.contains("--bearer cannot be empty"), "got: {e}")
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bearer_inline_equals_empty_rejected() {
+        let argv: Vec<String> = ["--bearer="].iter().map(|s| s.to_string()).collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => {
+                assert!(e.contains("--bearer cannot be empty"), "got: {e}")
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_report_includes_auth_method_bearer_and_redacts_token() {
+        let auth = AuthConfig::with_bearer(TEST_BEARER_TOKEN).unwrap();
+        let summary = ScanSummary::default();
+        let mut buf: Vec<u8> = Vec::new();
+        print_json_report(
+            &mut buf,
+            "http://localhost:5000",
+            Some(&auth),
+            &[],
+            &summary,
+        )
+        .unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["auth"]["method"], "bearer");
+        // Sentinel: the literal token string must NEVER appear anywhere
+        // in the emitted JSON. This pins the redaction contract — users
+        // pipe `--json` output to logs and CI artifacts; secrets must
+        // not leak there.
+        assert!(
+            !s.contains(TEST_BEARER_TOKEN),
+            "token leaked to JSON output: {s}"
+        );
+    }
+
+    #[test]
+    fn json_report_omits_auth_when_unauthenticated() {
+        let summary = ScanSummary::default();
+        let mut buf: Vec<u8> = Vec::new();
+        print_json_report(&mut buf, "http://localhost:5000", None, &[], &summary).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        // No-auth runs must not emit the key at all so prior
+        // unauthenticated JSON output stays byte-equal.
+        assert!(v.get("auth").is_none(), "got: {s}");
+        assert!(!s.contains("\"auth\""), "got: {s}");
+    }
+
+    #[test]
+    fn help_text_documents_bearer_redaction() {
+        // The "never appears in --json" line is load-bearing for users
+        // running scans in CI — it tells them piping --json to logs is
+        // safe. Pin it so future help-text refactors don't drop it.
+        let mut buf: Vec<u8> = Vec::new();
+        print_help(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("--bearer <token>"), "missing flag entry: {s}");
+        assert!(
+            s.contains("Authorization: Bearer"),
+            "missing header description: {s}"
+        );
+        assert!(
+            s.contains("never appears in --json"),
+            "missing redaction note: {s}"
+        );
+    }
+
     #[test]
     fn catalog_output_no_color_byte_shape() {
         let mut buf: Vec<u8> = Vec::new();
@@ -849,7 +1031,7 @@ mod tests {
         let rr = fixture_route();
         let summary = summarize(std::slice::from_ref(&rr), Duration::from_millis(50));
         let mut buf: Vec<u8> = Vec::new();
-        print_json_report(&mut buf, "http://localhost:5000", &[rr], &summary).unwrap();
+        print_json_report(&mut buf, "http://localhost:5000", None, &[rr], &summary).unwrap();
         let s = String::from_utf8(buf).unwrap();
         let v: serde_json::Value = serde_json::from_str(&s).unwrap();
         let route0 = &v["routes"][0];

--- a/packages/arcis-rust/crates/arcis-cli/src/scan.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/scan.rs
@@ -13,8 +13,8 @@ use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
 use arcis_engine::scan::{
-    attack_categories, discover_routes, payloads::slug, scan_route, DiscoveredRoute, RouteResult,
-    ScanOptions, DEFAULT_FIELDS,
+    attack_categories, discover_routes, format_curl, payloads::slug, scan_route, DiscoveredRoute,
+    RouteResult, ScanOptions, DEFAULT_FIELDS,
 };
 
 const RESET: &str = "\x1b[0m";
@@ -372,6 +372,14 @@ fn print_human_report(
                 "    {dim}{mark}{reset} [{}] {} {dim}{}{reset}",
                 v.category, v.label, v.note
             )?;
+            // Emit a copyable curl reproducer for each vulnerable finding
+            // so the user can reproduce the probe + verify their fix
+            // without re-running the full scan. Blocked findings are
+            // intentionally skipped to keep the report scannable.
+            if !v.blocked {
+                let curl = format_curl(target_url, &rr.method, &rr.path, &rr.field, &v.payload);
+                writeln!(out, "       {dim}{curl}{reset}")?;
+            }
         }
     }
     writeln!(out)?;
@@ -410,6 +418,15 @@ fn print_json_report(
                     m.insert("status".into(), json!(v.status));
                     m.insert("blocked".into(), Value::Bool(v.blocked));
                     m.insert("note".into(), Value::String(v.note.clone()));
+                    // Include the curl reproducer for every vector (blocked
+                    // and vulnerable) so machine consumers can render or
+                    // filter as they please.
+                    m.insert(
+                        "curl".into(),
+                        Value::String(format_curl(
+                            target_url, &rr.method, &rr.path, &rr.field, &v.payload,
+                        )),
+                    );
                     Value::Object(m)
                 })
                 .collect();
@@ -421,6 +438,7 @@ fn print_json_report(
                 "error".into(),
                 rr.error.clone().map(Value::String).unwrap_or(Value::Null),
             );
+            m.insert("field".into(), Value::String(rr.field.clone()));
             m.insert("vectors".into(), Value::Array(vectors));
             Value::Object(m)
         })
@@ -774,5 +792,80 @@ mod tests {
         assert!(s.contains(RESET));
         assert!(s.contains(DIM));
         assert!(s.contains(CYAN));
+    }
+
+    fn fixture_route() -> RouteResult {
+        use arcis_engine::scan::VectorResult;
+        RouteResult {
+            method: "POST".into(),
+            path: "/api/login".into(),
+            reachable: true,
+            error: None,
+            field: "username".into(),
+            vectors: vec![
+                VectorResult {
+                    category: "XSS".into(),
+                    label: "script tag".into(),
+                    payload: "<script>alert(1)</script>".into(),
+                    status: 200,
+                    blocked: false,
+                    note: "reflected in response (200)".into(),
+                },
+                VectorResult {
+                    category: "SQL Injection".into(),
+                    label: "OR bypass".into(),
+                    payload: "' OR '1'='1' --".into(),
+                    status: 400,
+                    blocked: true,
+                    note: "rejected (400)".into(),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn human_report_includes_curl_for_vulnerable_only() {
+        let rr = fixture_route();
+        let summary = summarize(std::slice::from_ref(&rr), Duration::from_millis(50));
+        let mut buf: Vec<u8> = Vec::new();
+        print_human_report(&mut buf, "http://localhost:5000", &[rr], &summary, true).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        // Vulnerable XSS finding should be followed by a curl line.
+        assert!(
+            s.contains("curl -fsSL -X POST 'http://localhost:5000/api/login'"),
+            "expected curl reproducer for vulnerable finding, got:\n{s}"
+        );
+        // Blocked SQL finding should NOT have a curl line for it.
+        // We check that the OR-bypass payload does not appear inside any
+        // curl command — it would only show up if format_curl ran.
+        assert!(
+            !s.contains("' OR '1"),
+            "blocked findings should not emit a curl line, got:\n{s}"
+        );
+    }
+
+    #[test]
+    fn json_report_includes_curl_per_vector_and_field_per_route() {
+        let rr = fixture_route();
+        let summary = summarize(std::slice::from_ref(&rr), Duration::from_millis(50));
+        let mut buf: Vec<u8> = Vec::new();
+        print_json_report(&mut buf, "http://localhost:5000", &[rr], &summary).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        let route0 = &v["routes"][0];
+        assert_eq!(route0["field"], "username");
+        let vectors = route0["vectors"].as_array().unwrap();
+        // Both blocked and vulnerable vectors carry a curl reproducer in JSON.
+        assert_eq!(vectors.len(), 2);
+        for vec in vectors {
+            let curl = vec["curl"].as_str().unwrap();
+            assert!(curl.starts_with("curl -fsSL"), "curl prefix: {curl}");
+        }
+        // Vulnerable XSS payload appears URL-encoded INSIDE the JSON body
+        // of its own POST curl command (since method=POST). Confirm the
+        // method + path land correctly.
+        let xss_curl = vectors[0]["curl"].as_str().unwrap();
+        assert!(xss_curl.contains("-X POST"), "got: {xss_curl}");
+        assert!(xss_curl.contains("/api/login"), "got: {xss_curl}");
     }
 }

--- a/packages/arcis-rust/crates/arcis-cli/src/scan.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/scan.rs
@@ -993,6 +993,7 @@ mod tests {
         let auth = AuthConfig {
             bearer: Some(TEST_BEARER_TOKEN.into()),
             cookie: Some(TEST_COOKIE_VALUE.into()),
+            ..Default::default()
         };
         let summary = ScanSummary::default();
         let mut buf: Vec<u8> = Vec::new();

--- a/packages/arcis-rust/crates/arcis-cli/src/scan.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/scan.rs
@@ -39,6 +39,7 @@ struct Args {
     no_control_plane: bool,
     json_output: bool,
     bearer: Option<String>,
+    cookie: Option<String>,
 }
 
 #[derive(Debug)]
@@ -64,6 +65,7 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
         no_control_plane: false,
         json_output: false,
         bearer: None,
+        cookie: None,
     };
 
     let mut i = 0;
@@ -149,10 +151,27 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
                     Err(e) => return ParseOutcome::Err(e),
                 }
             }
+            "--cookie" => {
+                i += 1;
+                let Some(v) = argv.get(i) else {
+                    return ParseOutcome::Err("arcis scan: --cookie needs a value".into());
+                };
+                match validate_cookie_value(v) {
+                    Ok(t) => args.cookie = Some(t),
+                    Err(e) => return ParseOutcome::Err(e),
+                }
+            }
+            arg if arg.starts_with("--cookie=") => {
+                let v = &arg["--cookie=".len()..];
+                match validate_cookie_value(v) {
+                    Ok(t) => args.cookie = Some(t),
+                    Err(e) => return ParseOutcome::Err(e),
+                }
+            }
             // note(commit #4 --login): when --login lands, add a mutex
             // check here:
             //   if args.login.is_some() && args.bearer.is_some() { exit 2 }
-            //   if args.login.is_some() && !args.cookies.is_empty() { exit 2 }
+            //   if args.login.is_some() && args.cookie.is_some() { exit 2 }
             // --login generates its own auth artifact, so combining it
             // with manual flags is ambiguous. Reject early.
             other if other.starts_with("--") || (other.starts_with('-') && other.len() > 1) => {
@@ -176,6 +195,14 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
 fn validate_bearer_value(value: &str) -> Result<String, String> {
     if value.trim().is_empty() {
         Err("arcis scan: --bearer cannot be empty or whitespace-only".into())
+    } else {
+        Ok(value.to_string())
+    }
+}
+
+fn validate_cookie_value(value: &str) -> Result<String, String> {
+    if value.trim().is_empty() {
+        Err("arcis scan: --cookie cannot be empty or whitespace-only".into())
     } else {
         Ok(value.to_string())
     }
@@ -315,6 +342,18 @@ fn print_help(out: &mut dyn Write) -> io::Result<()> {
     writeln!(
         out,
         "                               Token value never appears in --json output."
+    )?;
+    writeln!(
+        out,
+        "      --cookie <value>         Send Cookie: <value> on every request. Pasted verbatim;"
+    )?;
+    writeln!(
+        out,
+        "                               join multi-cookie with `; `. Composes with --bearer."
+    )?;
+    writeln!(
+        out,
+        "                               Cookie value never appears in --json output."
     )?;
     writeln!(
         out,
@@ -603,18 +642,33 @@ pub fn run(argv: &[String]) -> ExitCode {
     let timeout = Duration::from_secs(args.timeout);
 
     // Build the auth config once. Parser already rejected empty/
-    // whitespace-only tokens, so the engine validator should not fire
-    // here — but keep the belt-and-braces error path for the case where
-    // a future direct caller bypasses the parser.
-    let auth_config: Option<AuthConfig> = match args.bearer.as_deref() {
-        Some(token) => match AuthConfig::with_bearer(token) {
-            Ok(c) => Some(c),
-            Err(e) => {
-                let _ = writeln!(err, "arcis scan: {e}");
-                return ExitCode::from(2);
+    // whitespace-only inputs; the engine validator below is belt-and-
+    // braces for any future direct API caller that bypasses the parser.
+    // `--bearer` and `--cookie` compose: distinct header names, no
+    // collision logic needed.
+    let auth_config: Option<AuthConfig> = if args.bearer.is_some() || args.cookie.is_some() {
+        let mut cfg = AuthConfig::default();
+        if let Some(token) = args.bearer.as_deref() {
+            match AuthConfig::with_bearer(token) {
+                Ok(c) => cfg.bearer = c.bearer,
+                Err(e) => {
+                    let _ = writeln!(err, "arcis scan: {e}");
+                    return ExitCode::from(2);
+                }
             }
-        },
-        None => None,
+        }
+        if let Some(value) = args.cookie.as_deref() {
+            match AuthConfig::with_cookie(value) {
+                Ok(c) => cfg.cookie = c.cookie,
+                Err(e) => {
+                    let _ = writeln!(err, "arcis scan: {e}");
+                    return ExitCode::from(2);
+                }
+            }
+        }
+        Some(cfg)
+    } else {
+        None
     };
 
     let runtime = match tokio::runtime::Builder::new_multi_thread()
@@ -827,10 +881,11 @@ mod tests {
         assert_eq!(r, vec![("POST".into(), "http://example.com/x".into())]);
     }
 
-    /// Deliberately unique sentinel for the JSON-redaction tests below.
+    /// Deliberately unique sentinels for the JSON-redaction tests below.
     /// Pinned so a substring match against the emitted JSON cannot
     /// false-positive on a hash digest, route URL, or vector label.
     const TEST_BEARER_TOKEN: &str = "arcis-test-bearer-DEADBEEF-9f3a2c";
+    const TEST_COOKIE_VALUE: &str = "session=arcis-test-cookie-CAFEBABE-7e1f4d; csrf=feedface";
 
     #[test]
     fn parses_bearer_space_separated() {
@@ -878,7 +933,7 @@ mod tests {
     }
 
     #[test]
-    fn json_report_includes_auth_method_bearer_and_redacts_token() {
+    fn json_report_includes_auth_methods_array_for_bearer_and_redacts_token() {
         let auth = AuthConfig::with_bearer(TEST_BEARER_TOKEN).unwrap();
         let summary = ScanSummary::default();
         let mut buf: Vec<u8> = Vec::new();
@@ -892,7 +947,9 @@ mod tests {
         .unwrap();
         let s = String::from_utf8(buf).unwrap();
         let v: serde_json::Value = serde_json::from_str(&s).unwrap();
-        assert_eq!(v["auth"]["method"], "bearer");
+        // Schema: `methods` is always an array (even for one entry).
+        assert_eq!(v["auth"]["methods"][0], "bearer");
+        assert_eq!(v["auth"]["methods"].as_array().unwrap().len(), 1);
         // Sentinel: the literal token string must NEVER appear anywhere
         // in the emitted JSON. This pins the redaction contract — users
         // pipe `--json` output to logs and CI artifacts; secrets must
@@ -900,6 +957,66 @@ mod tests {
         assert!(
             !s.contains(TEST_BEARER_TOKEN),
             "token leaked to JSON output: {s}"
+        );
+    }
+
+    #[test]
+    fn json_report_includes_auth_methods_array_for_cookie_and_redacts_value() {
+        let auth = AuthConfig::with_cookie(TEST_COOKIE_VALUE).unwrap();
+        let summary = ScanSummary::default();
+        let mut buf: Vec<u8> = Vec::new();
+        print_json_report(
+            &mut buf,
+            "http://localhost:5000",
+            Some(&auth),
+            &[],
+            &summary,
+        )
+        .unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["auth"]["methods"][0], "cookie");
+        assert_eq!(v["auth"]["methods"].as_array().unwrap().len(), 1);
+        // Cookie value sentinel must NOT appear anywhere in JSON. The
+        // verbatim no-parse policy means we never extract names either.
+        assert!(!s.contains(TEST_COOKIE_VALUE), "cookie value leaked: {s}");
+        assert!(
+            !s.contains("session="),
+            "cookie name should not leak under no-parse policy: {s}"
+        );
+    }
+
+    #[test]
+    fn json_report_with_bearer_and_cookie_lists_both_methods_and_redacts_both() {
+        // Composite path: alphabetical order pinned, both sentinels
+        // checked absent.
+        let auth = AuthConfig {
+            bearer: Some(TEST_BEARER_TOKEN.into()),
+            cookie: Some(TEST_COOKIE_VALUE.into()),
+        };
+        let summary = ScanSummary::default();
+        let mut buf: Vec<u8> = Vec::new();
+        print_json_report(
+            &mut buf,
+            "http://localhost:5000",
+            Some(&auth),
+            &[],
+            &summary,
+        )
+        .unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        let methods = v["auth"]["methods"].as_array().unwrap();
+        assert_eq!(methods.len(), 2);
+        assert_eq!(methods[0], "bearer");
+        assert_eq!(methods[1], "cookie");
+        assert!(
+            !s.contains(TEST_BEARER_TOKEN),
+            "bearer leaked in composite: {s}"
+        );
+        assert!(
+            !s.contains(TEST_COOKIE_VALUE),
+            "cookie leaked in composite: {s}"
         );
     }
 
@@ -930,9 +1047,81 @@ mod tests {
             "missing header description: {s}"
         );
         assert!(
-            s.contains("never appears in --json"),
-            "missing redaction note: {s}"
+            s.contains("Token value never appears in --json"),
+            "missing bearer redaction note: {s}"
         );
+    }
+
+    #[test]
+    fn help_text_documents_cookie_redaction() {
+        // Parallel to the bearer pin: the redaction promise is also
+        // load-bearing for --cookie. Future help-text refactors must
+        // not drop either line.
+        let mut buf: Vec<u8> = Vec::new();
+        print_help(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("--cookie <value>"), "missing flag entry: {s}");
+        assert!(
+            s.contains("Send Cookie:"),
+            "missing header description: {s}"
+        );
+        assert!(
+            s.contains("Cookie value never appears in --json"),
+            "missing cookie redaction note: {s}"
+        );
+    }
+
+    #[test]
+    fn parses_cookie_space_separated() {
+        let a = args(&["--cookie", "session=abc; csrf=xyz"]);
+        assert_eq!(a.cookie.as_deref(), Some("session=abc; csrf=xyz"));
+    }
+
+    #[test]
+    fn parses_cookie_equals_inline() {
+        let a = args(&["--cookie=session=abc"]);
+        // Verbatim including the inner `=` — no further parsing.
+        assert_eq!(a.cookie.as_deref(), Some("session=abc"));
+    }
+
+    #[test]
+    fn cookie_empty_value_rejected() {
+        let argv: Vec<String> = ["--cookie", ""].iter().map(|s| s.to_string()).collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => {
+                assert!(e.contains("--cookie cannot be empty"), "got: {e}")
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cookie_whitespace_only_rejected() {
+        let argv: Vec<String> = ["--cookie", "   "].iter().map(|s| s.to_string()).collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => {
+                assert!(e.contains("--cookie cannot be empty"), "got: {e}")
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cookie_inline_equals_empty_rejected() {
+        let argv: Vec<String> = ["--cookie="].iter().map(|s| s.to_string()).collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => {
+                assert!(e.contains("--cookie cannot be empty"), "got: {e}")
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_bearer_and_cookie_compose() {
+        let a = args(&["--bearer", "tok", "--cookie", "session=abc"]);
+        assert_eq!(a.bearer.as_deref(), Some("tok"));
+        assert_eq!(a.cookie.as_deref(), Some("session=abc"));
     }
 
     #[test]

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/auth.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/auth.rs
@@ -1,39 +1,48 @@
 //! Authentication for `arcis scan` probe requests.
 //!
 //! Backs the Phase B item-5 flags: `--bearer`, `--cookie`, `--login`.
-//! For the current commit only the `bearer` arm exists; `cookies` and
-//! `login` slot into this same struct in follow-up commits.
+//! `--bearer` and `--cookie` ship today; `--login` slots into the same
+//! `AuthConfig` struct in a follow-up commit.
 //!
 //! # Redaction contract (load-bearing)
 //!
 //! Token values, cookie values, and login passwords MUST NEVER appear
 //! in machine output (`--json`) or in human log lines / stderr trace
-//! messages. Auth metadata is restricted to method identifiers and (for
-//! cookies) names. The single rendering entry point is
-//! [`AuthConfig::redact_for_json`]; future flags MUST extend that
-//! method rather than bypass it. The same rule applies to any future
-//! human-output line that wants to surface auth status — add a paired
-//! `redact_for_log` helper rather than formatting the field directly.
+//! messages. Auth metadata is restricted to method identifiers only —
+//! we deliberately don't parse cookie name/value pairs (verbatim
+//! string policy) so cookie names also never surface. The single
+//! rendering entry point is [`AuthConfig::redact_for_json`]; future
+//! flags MUST extend that method rather than bypass it. The same rule
+//! applies to any future human-output line that wants to surface auth
+//! status — add a paired `redact_for_log` helper rather than
+//! formatting the field directly.
 //!
-//! A test in this module asserts that a unique sentinel token literal
-//! does not appear anywhere in the serialized JSON.
+//! Tests in this module assert that unique sentinel token / cookie
+//! literals do not appear anywhere in the serialized JSON.
 
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, COOKIE};
 use serde_json::{Map, Value};
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum AuthError {
     #[error("--bearer cannot be empty or whitespace-only")]
     EmptyBearer,
+    #[error("--cookie cannot be empty or whitespace-only")]
+    EmptyCookie,
 }
 
 /// Auth state attached to a scan run. Carried through
 /// [`super::probe::ScanOptions::auth`]; `None` means unauthenticated
 /// scan (the common path) and skips header-map allocation entirely.
+///
+/// `cookie` is a verbatim header value: the user pastes from browser
+/// dev tools, joins multi-cookie with `; ` themselves. We do not parse
+/// `name=value` pairs, dedupe, or validate beyond non-empty — keeps
+/// the surface tiny and lets the user control formatting end-to-end.
 #[derive(Debug, Clone, Default)]
 pub struct AuthConfig {
     pub bearer: Option<String>,
-    // commit #3 will add: pub cookies: Vec<(String, String)>
+    pub cookie: Option<String>,
     // commit #4 will add: pub login: Option<LoginArtifact>
 }
 
@@ -48,12 +57,29 @@ impl AuthConfig {
         }
         Ok(Self {
             bearer: Some(token.to_string()),
+            ..Default::default()
+        })
+    }
+
+    /// Construct an `AuthConfig` carrying `Cookie: <value>` verbatim.
+    /// `value` is the entire header body as the user wants it on the
+    /// wire — we do not parse, validate `name=value` shape, or dedupe.
+    /// Empty / whitespace-only is rejected at construction time.
+    pub fn with_cookie(value: &str) -> Result<Self, AuthError> {
+        if value.trim().is_empty() {
+            return Err(AuthError::EmptyCookie);
+        }
+        Ok(Self {
+            cookie: Some(value.to_string()),
+            ..Default::default()
         })
     }
 
     /// Build the `HeaderMap` seeded into
     /// `Client::builder().default_headers`. Probe and every vector
     /// inherits these headers automatically — single injection site.
+    /// `Authorization` and `Cookie` are distinct header names, so
+    /// composition is automatic when both are set.
     pub fn to_header_map(&self) -> HeaderMap {
         let mut headers = HeaderMap::new();
         if let Some(token) = &self.bearer {
@@ -64,31 +90,47 @@ impl AuthConfig {
                 headers.insert(AUTHORIZATION, v);
             }
         }
+        if let Some(value) = &self.cookie {
+            if let Ok(v) = HeaderValue::from_str(value) {
+                headers.insert(COOKIE, v);
+            }
+        }
         headers
     }
 
-    /// Render auth metadata for `--json` run headers. NEVER emits the
-    /// token value, cookie value, or login password — only the method
-    /// (and, for cookies, the cookie name). Returns `None` when no auth
-    /// is configured so the renderer can omit the key entirely
-    /// (preserves byte-parity with prior unauthenticated JSON).
+    /// Render auth metadata for `--json` run headers.
     ///
-    /// Future flags MUST extend this method rather than bypass it.
-    /// The redaction is enforced by a unit test that fails if a unique
-    /// sentinel token literal appears in the serialized output.
+    /// **Schema:** `{"methods": [<name>, ...]}` where each entry is one
+    /// of `"bearer"`, `"cookie"`, `"login"`. Always an array (even for
+    /// a single method) so downstream parsers don't switch on type.
+    /// Order is stable and alphabetical (`bearer` < `cookie` < `login`).
+    ///
+    /// **Redaction contract:** NEVER emits the token value, cookie
+    /// value, or login password — only method names. Future flags MUST
+    /// extend this method rather than bypass it. The redaction is
+    /// enforced by tests that fail if a unique sentinel token / cookie
+    /// literal appears in the serialized output.
+    ///
+    /// Returns `None` when no auth is configured so the renderer can
+    /// omit the key entirely (preserves byte-parity with prior
+    /// unauthenticated JSON).
     pub fn redact_for_json(&self) -> Option<Value> {
-        let mut m = Map::new();
+        // Insert in alphabetical order — keeps the output deterministic
+        // without an explicit sort. When `login` lands in commit #4,
+        // append after `cookie` to maintain ordering.
+        let mut methods: Vec<Value> = Vec::new();
         if self.bearer.is_some() {
-            m.insert("method".into(), Value::String("bearer".into()));
+            methods.push(Value::String("bearer".into()));
         }
-        // commit #3 will add: { "method": "cookie", "names": [...] }
-        //                  or composite when bearer + cookie are both set.
-        // commit #4 will add: { "method": "login", "via": "cookie"|"bearer" }
-        if m.is_empty() {
-            None
-        } else {
-            Some(Value::Object(m))
+        if self.cookie.is_some() {
+            methods.push(Value::String("cookie".into()));
         }
+        if methods.is_empty() {
+            return None;
+        }
+        let mut m = Map::new();
+        m.insert("methods".into(), Value::Array(methods));
+        Some(Value::Object(m))
     }
 }
 
@@ -96,10 +138,12 @@ impl AuthConfig {
 mod tests {
     use super::*;
 
-    /// Deliberately unique sentinel so a substring match against the
+    /// Deliberately unique sentinels so a substring match against the
     /// emitted JSON cannot false-positive on a hash digest, route URL,
-    /// or vector label.
+    /// or vector label. One per auth surface so each redaction path is
+    /// exercised independently.
     const TEST_BEARER_TOKEN: &str = "arcis-test-bearer-DEADBEEF-9f3a2c";
+    const TEST_COOKIE_VALUE: &str = "session=arcis-test-cookie-CAFEBABE-7e1f4d; csrf=feedface";
 
     #[test]
     fn with_bearer_rejects_empty() {
@@ -125,6 +169,37 @@ mod tests {
     fn with_bearer_accepts_token() {
         let cfg = AuthConfig::with_bearer("foo").unwrap();
         assert_eq!(cfg.bearer.as_deref(), Some("foo"));
+        assert!(cfg.cookie.is_none());
+    }
+
+    #[test]
+    fn with_cookie_rejects_empty() {
+        assert!(matches!(
+            AuthConfig::with_cookie(""),
+            Err(AuthError::EmptyCookie)
+        ));
+    }
+
+    #[test]
+    fn with_cookie_rejects_whitespace_only() {
+        assert!(matches!(
+            AuthConfig::with_cookie("   "),
+            Err(AuthError::EmptyCookie)
+        ));
+        assert!(matches!(
+            AuthConfig::with_cookie("\t\n"),
+            Err(AuthError::EmptyCookie)
+        ));
+    }
+
+    #[test]
+    fn with_cookie_accepts_verbatim_value() {
+        // Multi-cookie semicolon form goes in unparsed — the user's
+        // problem to format, the engine's job to deliver verbatim.
+        let raw = "session=abc; csrf=xyz; flavor=chocolate";
+        let cfg = AuthConfig::with_cookie(raw).unwrap();
+        assert_eq!(cfg.cookie.as_deref(), Some(raw));
+        assert!(cfg.bearer.is_none());
     }
 
     #[test]
@@ -135,6 +210,37 @@ mod tests {
             headers.get("authorization").map(|v| v.to_str().unwrap()),
             Some("Bearer foo")
         );
+        assert!(headers.get("cookie").is_none());
+    }
+
+    #[test]
+    fn to_header_map_emits_cookie_header_verbatim() {
+        let cfg = AuthConfig::with_cookie("session=abc; csrf=xyz").unwrap();
+        let headers = cfg.to_header_map();
+        assert_eq!(
+            headers.get("cookie").map(|v| v.to_str().unwrap()),
+            Some("session=abc; csrf=xyz")
+        );
+        assert!(headers.get("authorization").is_none());
+    }
+
+    #[test]
+    fn to_header_map_composes_bearer_and_cookie() {
+        // Both fields set => both headers emitted. `Authorization` and
+        // `Cookie` are distinct header names; no collision logic needed.
+        let cfg = AuthConfig {
+            bearer: Some("token-foo".into()),
+            cookie: Some("session=abc".into()),
+        };
+        let headers = cfg.to_header_map();
+        assert_eq!(
+            headers.get("authorization").map(|v| v.to_str().unwrap()),
+            Some("Bearer token-foo")
+        );
+        assert_eq!(
+            headers.get("cookie").map(|v| v.to_str().unwrap()),
+            Some("session=abc")
+        );
     }
 
     #[test]
@@ -144,14 +250,11 @@ mod tests {
     }
 
     #[test]
-    fn redact_for_json_bearer_only_emits_method_and_redacts_token() {
+    fn redact_for_json_bearer_only_emits_methods_array_and_redacts_token() {
         let cfg = AuthConfig::with_bearer(TEST_BEARER_TOKEN).unwrap();
         let v = cfg.redact_for_json().unwrap();
         let s = serde_json::to_string(&v).unwrap();
-        assert_eq!(s, r#"{"method":"bearer"}"#);
-        // Sentinel: the token literal must not appear in the serialized
-        // output. Pinned by a unique substring so a false-positive
-        // against an unrelated string in the run header is impossible.
+        assert_eq!(s, r#"{"methods":["bearer"]}"#);
         assert!(
             !s.contains(TEST_BEARER_TOKEN),
             "redact_for_json leaked the bearer token: {s}"
@@ -159,8 +262,71 @@ mod tests {
     }
 
     #[test]
+    fn redact_for_json_cookie_only_emits_methods_array_and_redacts_value() {
+        let cfg = AuthConfig::with_cookie(TEST_COOKIE_VALUE).unwrap();
+        let v = cfg.redact_for_json().unwrap();
+        let s = serde_json::to_string(&v).unwrap();
+        assert_eq!(s, r#"{"methods":["cookie"]}"#);
+        // Cookie value sentinel — must NOT appear anywhere in JSON.
+        assert!(
+            !s.contains(TEST_COOKIE_VALUE),
+            "redact_for_json leaked the cookie value: {s}"
+        );
+        // Even the cookie name (`session=`) must not leak — we don't
+        // parse, so we cannot extract a name; nothing about the cookie
+        // structure surfaces.
+        assert!(
+            !s.contains("session"),
+            "cookie name leaked despite no-parse policy: {s}"
+        );
+    }
+
+    #[test]
+    fn redact_for_json_composite_lists_both_methods_alphabetical_and_redacts_both() {
+        let cfg = AuthConfig {
+            bearer: Some(TEST_BEARER_TOKEN.into()),
+            cookie: Some(TEST_COOKIE_VALUE.into()),
+        };
+        let v = cfg.redact_for_json().unwrap();
+        let s = serde_json::to_string(&v).unwrap();
+        // Alphabetical, deterministic order (bearer < cookie). Pinned
+        // exactly so any future drift in order surfaces here.
+        assert_eq!(s, r#"{"methods":["bearer","cookie"]}"#);
+        // Both sentinels must be absent.
+        assert!(
+            !s.contains(TEST_BEARER_TOKEN),
+            "bearer leaked in composite: {s}"
+        );
+        assert!(
+            !s.contains(TEST_COOKIE_VALUE),
+            "cookie leaked in composite: {s}"
+        );
+    }
+
+    #[test]
     fn redact_for_json_returns_none_when_unconfigured() {
         let cfg = AuthConfig::default();
         assert!(cfg.redact_for_json().is_none());
+    }
+
+    #[test]
+    fn auth_error_messages_share_a_consistent_template() {
+        // Pin the error-message contract: every variant should be
+        // "<flag> cannot be empty or whitespace-only". When `--login`
+        // lands in commit #4, its `EmptyLogin` (or similar) variant
+        // must satisfy the same template — keeps user-facing error
+        // strings predictable across the auth surface.
+        let bearer_msg = AuthError::EmptyBearer.to_string();
+        let cookie_msg = AuthError::EmptyCookie.to_string();
+        let suffix = " cannot be empty or whitespace-only";
+        assert!(bearer_msg.ends_with(suffix), "bearer message: {bearer_msg}");
+        assert!(cookie_msg.ends_with(suffix), "cookie message: {cookie_msg}");
+        assert!(bearer_msg.starts_with("--bearer"), "got: {bearer_msg}");
+        assert!(cookie_msg.starts_with("--cookie"), "got: {cookie_msg}");
+        // Same suffix length: messages differ ONLY in the flag name.
+        let bearer_prefix = bearer_msg.strip_suffix(suffix).unwrap();
+        let cookie_prefix = cookie_msg.strip_suffix(suffix).unwrap();
+        assert_eq!(bearer_prefix, "--bearer");
+        assert_eq!(cookie_prefix, "--cookie");
     }
 }

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/auth.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/auth.rs
@@ -23,12 +23,16 @@
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, COOKIE};
 use serde_json::{Map, Value};
 
+use super::login::LoginConfig;
+
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum AuthError {
     #[error("--bearer cannot be empty or whitespace-only")]
     EmptyBearer,
     #[error("--cookie cannot be empty or whitespace-only")]
     EmptyCookie,
+    #[error("--login cannot be empty or whitespace-only")]
+    EmptyLogin,
 }
 
 /// Auth state attached to a scan run. Carried through
@@ -39,11 +43,18 @@ pub enum AuthError {
 /// dev tools, joins multi-cookie with `; ` themselves. We do not parse
 /// `name=value` pairs, dedupe, or validate beyond non-empty — keeps
 /// the surface tiny and lets the user control formatting end-to-end.
+///
+/// `login` is populated when the run was authed via `--login`. After
+/// [`super::login::execute_login`] runs, the captured artifact lands in
+/// `bearer` OR `cookie`, AND `login` stays populated as a "this run
+/// authed via login" marker — so [`AuthConfig::redact_for_json`] can
+/// report `methods=["login"]` instead of leaking which artifact type
+/// was captured.
 #[derive(Debug, Clone, Default)]
 pub struct AuthConfig {
     pub bearer: Option<String>,
     pub cookie: Option<String>,
-    // commit #4 will add: pub login: Option<LoginArtifact>
+    pub login: Option<LoginConfig>,
 }
 
 impl AuthConfig {
@@ -100,30 +111,41 @@ impl AuthConfig {
 
     /// Render auth metadata for `--json` run headers.
     ///
-    /// **Schema:** `{"methods": [<name>, ...]}` where each entry is one
-    /// of `"bearer"`, `"cookie"`, `"login"`. Always an array (even for
-    /// a single method) so downstream parsers don't switch on type.
-    /// Order is stable and alphabetical (`bearer` < `cookie` < `login`).
+    /// **Locked schema.** This method produces exactly ONE of:
     ///
-    /// **Redaction contract:** NEVER emits the token value, cookie
-    /// value, or login password — only method names. Future flags MUST
-    /// extend this method rather than bypass it. The redaction is
-    /// enforced by tests that fail if a unique sentinel token / cookie
-    /// literal appears in the serialized output.
+    /// - `{"methods": ["login"]}`               — when login is set
+    /// - `{"methods": ["bearer"]}`              — bearer only
+    /// - `{"methods": ["cookie"]}`              — cookie only
+    /// - `{"methods": ["bearer", "cookie"]}`    — both manual flags
+    /// - `None`                                 — no auth configured
     ///
-    /// Returns `None` when no auth is configured so the renderer can
-    /// omit the key entirely (preserves byte-parity with prior
-    /// unauthenticated JSON).
+    /// No additional keys. No `loginUrl`, no `origin`, no provenance
+    /// fields. When `login` is set, `methods` reports `["login"]` and
+    /// the captured-artifact channel (bearer or cookie) is NOT
+    /// reflected in the output — login overrides for reporting purposes.
+    ///
+    /// Future auth flags MUST extend the `methods` array AND add a
+    /// bullet to the enumeration above — never add sibling keys.
+    /// Adding a key requires a deliberate schema bump.
+    ///
+    /// **Redaction contract:** NEVER emits token values, cookie values,
+    /// or login form values. Tests assert that unique sentinel literals
+    /// for each kind do not appear in the serialized output.
     pub fn redact_for_json(&self) -> Option<Value> {
-        // Insert in alphabetical order — keeps the output deterministic
-        // without an explicit sort. When `login` lands in commit #4,
-        // append after `cookie` to maintain ordering.
         let mut methods: Vec<Value> = Vec::new();
-        if self.bearer.is_some() {
-            methods.push(Value::String("bearer".into()));
-        }
-        if self.cookie.is_some() {
-            methods.push(Value::String("cookie".into()));
+        if self.login.is_some() {
+            // Login overrides — defensive even if bearer/cookie are
+            // also populated by execute_login's captured artifact, the
+            // user-visible method is "login". Don't leak provenance.
+            methods.push(Value::String("login".into()));
+        } else {
+            // Manual flags: alphabetical order, deterministic.
+            if self.bearer.is_some() {
+                methods.push(Value::String("bearer".into()));
+            }
+            if self.cookie.is_some() {
+                methods.push(Value::String("cookie".into()));
+            }
         }
         if methods.is_empty() {
             return None;
@@ -231,6 +253,7 @@ mod tests {
         let cfg = AuthConfig {
             bearer: Some("token-foo".into()),
             cookie: Some("session=abc".into()),
+            ..Default::default()
         };
         let headers = cfg.to_header_map();
         assert_eq!(
@@ -286,6 +309,7 @@ mod tests {
         let cfg = AuthConfig {
             bearer: Some(TEST_BEARER_TOKEN.into()),
             cookie: Some(TEST_COOKIE_VALUE.into()),
+            ..Default::default()
         };
         let v = cfg.redact_for_json().unwrap();
         let s = serde_json::to_string(&v).unwrap();
@@ -311,22 +335,105 @@ mod tests {
 
     #[test]
     fn auth_error_messages_share_a_consistent_template() {
-        // Pin the error-message contract: every variant should be
-        // "<flag> cannot be empty or whitespace-only". When `--login`
-        // lands in commit #4, its `EmptyLogin` (or similar) variant
+        // Pin the error-message contract: every variant must be
+        // "<flag> cannot be empty or whitespace-only". Future flags
         // must satisfy the same template — keeps user-facing error
         // strings predictable across the auth surface.
         let bearer_msg = AuthError::EmptyBearer.to_string();
         let cookie_msg = AuthError::EmptyCookie.to_string();
+        let login_msg = AuthError::EmptyLogin.to_string();
         let suffix = " cannot be empty or whitespace-only";
-        assert!(bearer_msg.ends_with(suffix), "bearer message: {bearer_msg}");
-        assert!(cookie_msg.ends_with(suffix), "cookie message: {cookie_msg}");
-        assert!(bearer_msg.starts_with("--bearer"), "got: {bearer_msg}");
-        assert!(cookie_msg.starts_with("--cookie"), "got: {cookie_msg}");
-        // Same suffix length: messages differ ONLY in the flag name.
-        let bearer_prefix = bearer_msg.strip_suffix(suffix).unwrap();
-        let cookie_prefix = cookie_msg.strip_suffix(suffix).unwrap();
-        assert_eq!(bearer_prefix, "--bearer");
-        assert_eq!(cookie_prefix, "--cookie");
+        for (label, msg) in [
+            ("bearer", &bearer_msg),
+            ("cookie", &cookie_msg),
+            ("login", &login_msg),
+        ] {
+            assert!(msg.ends_with(suffix), "{label} message: {msg}");
+        }
+        assert_eq!(bearer_msg.strip_suffix(suffix).unwrap(), "--bearer");
+        assert_eq!(cookie_msg.strip_suffix(suffix).unwrap(), "--cookie");
+        assert_eq!(login_msg.strip_suffix(suffix).unwrap(), "--login");
+    }
+
+    /// Sentinel for form-value redaction. Used by the login-redaction
+    /// tests below to prove form values (and keys, by side-effect of
+    /// the no-emit policy) never reach `redact_for_json`'s output.
+    const TEST_LOGIN_PASSWORD: &str = "arcis-test-pass-FACEFEED-3b8d2e";
+
+    fn login_with_sentinel_password() -> LoginConfig {
+        LoginConfig {
+            url: "http://localhost:5000/auth/login".into(),
+            form: vec![
+                ("user".into(), "admin".into()),
+                ("password".into(), TEST_LOGIN_PASSWORD.into()),
+            ],
+            json: false,
+        }
+    }
+
+    #[test]
+    fn redact_for_json_login_only_emits_methods_array_with_login() {
+        let cfg = AuthConfig {
+            login: Some(login_with_sentinel_password()),
+            ..Default::default()
+        };
+        let v = cfg.redact_for_json().unwrap();
+        let s = serde_json::to_string(&v).unwrap();
+        assert_eq!(s, r#"{"methods":["login"]}"#);
+    }
+
+    #[test]
+    fn redact_for_json_login_overrides_bearer_and_cookie() {
+        // Defensive: even if execute_login populated bearer or cookie
+        // with the captured artifact, the user-visible auth method is
+        // still "login". The captured-artifact provenance does not
+        // surface in JSON output.
+        let cfg = AuthConfig {
+            bearer: Some(TEST_BEARER_TOKEN.into()),
+            cookie: Some(TEST_COOKIE_VALUE.into()),
+            login: Some(login_with_sentinel_password()),
+        };
+        let v = cfg.redact_for_json().unwrap();
+        let s = serde_json::to_string(&v).unwrap();
+        assert_eq!(s, r#"{"methods":["login"]}"#);
+        assert!(
+            !s.contains(TEST_BEARER_TOKEN),
+            "bearer leaked under login override: {s}"
+        );
+        assert!(
+            !s.contains(TEST_COOKIE_VALUE),
+            "cookie leaked under login override: {s}"
+        );
+        assert!(
+            !s.contains(TEST_LOGIN_PASSWORD),
+            "form password leaked: {s}"
+        );
+    }
+
+    #[test]
+    fn redact_for_json_login_does_not_leak_form_values_or_keys_or_url() {
+        // Per locked schema, redact_for_json never serializes the
+        // login form OR the URL. Pin all three: form values must not
+        // appear (redaction), form keys must not appear (no-leak —
+        // "password" as a field name reveals the auth shape), and the
+        // URL must not appear (locked-schema guarantee). If a future
+        // schema bump adds the URL, update this assertion AND the
+        // redact_for_json doc-comment in lockstep.
+        let cfg = AuthConfig {
+            login: Some(login_with_sentinel_password()),
+            ..Default::default()
+        };
+        let v = cfg.redact_for_json().unwrap();
+        let s = serde_json::to_string(&v).unwrap();
+        assert!(
+            !s.contains(TEST_LOGIN_PASSWORD),
+            "form password value leaked: {s}"
+        );
+        assert!(!s.contains("password"), "form key 'password' leaked: {s}");
+        assert!(!s.contains("admin"), "form value 'admin' leaked: {s}");
+        assert!(
+            !s.contains("localhost:5000"),
+            "login URL leaked under locked schema: {s}"
+        );
     }
 }

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/auth.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/auth.rs
@@ -1,0 +1,166 @@
+//! Authentication for `arcis scan` probe requests.
+//!
+//! Backs the Phase B item-5 flags: `--bearer`, `--cookie`, `--login`.
+//! For the current commit only the `bearer` arm exists; `cookies` and
+//! `login` slot into this same struct in follow-up commits.
+//!
+//! # Redaction contract (load-bearing)
+//!
+//! Token values, cookie values, and login passwords MUST NEVER appear
+//! in machine output (`--json`) or in human log lines / stderr trace
+//! messages. Auth metadata is restricted to method identifiers and (for
+//! cookies) names. The single rendering entry point is
+//! [`AuthConfig::redact_for_json`]; future flags MUST extend that
+//! method rather than bypass it. The same rule applies to any future
+//! human-output line that wants to surface auth status — add a paired
+//! `redact_for_log` helper rather than formatting the field directly.
+//!
+//! A test in this module asserts that a unique sentinel token literal
+//! does not appear anywhere in the serialized JSON.
+
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use serde_json::{Map, Value};
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum AuthError {
+    #[error("--bearer cannot be empty or whitespace-only")]
+    EmptyBearer,
+}
+
+/// Auth state attached to a scan run. Carried through
+/// [`super::probe::ScanOptions::auth`]; `None` means unauthenticated
+/// scan (the common path) and skips header-map allocation entirely.
+#[derive(Debug, Clone, Default)]
+pub struct AuthConfig {
+    pub bearer: Option<String>,
+    // commit #3 will add: pub cookies: Vec<(String, String)>
+    // commit #4 will add: pub login: Option<LoginArtifact>
+}
+
+impl AuthConfig {
+    /// Construct an `AuthConfig` carrying `Authorization: Bearer <token>`.
+    /// Empty / whitespace-only `token` is rejected at construction time
+    /// so every callsite — CLI parser and any direct API user — gets
+    /// the same enforcement.
+    pub fn with_bearer(token: &str) -> Result<Self, AuthError> {
+        if token.trim().is_empty() {
+            return Err(AuthError::EmptyBearer);
+        }
+        Ok(Self {
+            bearer: Some(token.to_string()),
+        })
+    }
+
+    /// Build the `HeaderMap` seeded into
+    /// `Client::builder().default_headers`. Probe and every vector
+    /// inherits these headers automatically — single injection site.
+    pub fn to_header_map(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        if let Some(token) = &self.bearer {
+            // Caller validated non-empty; only way a non-ASCII control
+            // byte slips through is direct API misuse, in which case
+            // we silently skip rather than panic the scan.
+            if let Ok(v) = HeaderValue::from_str(&format!("Bearer {token}")) {
+                headers.insert(AUTHORIZATION, v);
+            }
+        }
+        headers
+    }
+
+    /// Render auth metadata for `--json` run headers. NEVER emits the
+    /// token value, cookie value, or login password — only the method
+    /// (and, for cookies, the cookie name). Returns `None` when no auth
+    /// is configured so the renderer can omit the key entirely
+    /// (preserves byte-parity with prior unauthenticated JSON).
+    ///
+    /// Future flags MUST extend this method rather than bypass it.
+    /// The redaction is enforced by a unit test that fails if a unique
+    /// sentinel token literal appears in the serialized output.
+    pub fn redact_for_json(&self) -> Option<Value> {
+        let mut m = Map::new();
+        if self.bearer.is_some() {
+            m.insert("method".into(), Value::String("bearer".into()));
+        }
+        // commit #3 will add: { "method": "cookie", "names": [...] }
+        //                  or composite when bearer + cookie are both set.
+        // commit #4 will add: { "method": "login", "via": "cookie"|"bearer" }
+        if m.is_empty() {
+            None
+        } else {
+            Some(Value::Object(m))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deliberately unique sentinel so a substring match against the
+    /// emitted JSON cannot false-positive on a hash digest, route URL,
+    /// or vector label.
+    const TEST_BEARER_TOKEN: &str = "arcis-test-bearer-DEADBEEF-9f3a2c";
+
+    #[test]
+    fn with_bearer_rejects_empty() {
+        assert!(matches!(
+            AuthConfig::with_bearer(""),
+            Err(AuthError::EmptyBearer)
+        ));
+    }
+
+    #[test]
+    fn with_bearer_rejects_whitespace_only() {
+        assert!(matches!(
+            AuthConfig::with_bearer("   "),
+            Err(AuthError::EmptyBearer)
+        ));
+        assert!(matches!(
+            AuthConfig::with_bearer("\t\n"),
+            Err(AuthError::EmptyBearer)
+        ));
+    }
+
+    #[test]
+    fn with_bearer_accepts_token() {
+        let cfg = AuthConfig::with_bearer("foo").unwrap();
+        assert_eq!(cfg.bearer.as_deref(), Some("foo"));
+    }
+
+    #[test]
+    fn to_header_map_emits_bearer_authorization() {
+        let cfg = AuthConfig::with_bearer("foo").unwrap();
+        let headers = cfg.to_header_map();
+        assert_eq!(
+            headers.get("authorization").map(|v| v.to_str().unwrap()),
+            Some("Bearer foo")
+        );
+    }
+
+    #[test]
+    fn to_header_map_empty_when_no_auth_set() {
+        let cfg = AuthConfig::default();
+        assert!(cfg.to_header_map().is_empty());
+    }
+
+    #[test]
+    fn redact_for_json_bearer_only_emits_method_and_redacts_token() {
+        let cfg = AuthConfig::with_bearer(TEST_BEARER_TOKEN).unwrap();
+        let v = cfg.redact_for_json().unwrap();
+        let s = serde_json::to_string(&v).unwrap();
+        assert_eq!(s, r#"{"method":"bearer"}"#);
+        // Sentinel: the token literal must not appear in the serialized
+        // output. Pinned by a unique substring so a false-positive
+        // against an unrelated string in the run header is impossible.
+        assert!(
+            !s.contains(TEST_BEARER_TOKEN),
+            "redact_for_json leaked the bearer token: {s}"
+        );
+    }
+
+    #[test]
+    fn redact_for_json_returns_none_when_unconfigured() {
+        let cfg = AuthConfig::default();
+        assert!(cfg.redact_for_json().is_none());
+    }
+}

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/login.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/login.rs
@@ -1,0 +1,434 @@
+//! Login flow for `arcis scan --login`.
+//!
+//! Backs commit #4 of Phase B item 5. Single-shot async function:
+//! POSTs credentials to the configured URL, captures an auth artifact
+//! from the response, returns a fully-populated [`AuthConfig`] that
+//! the rest of the scan run uses (probe + every vector inherits the
+//! captured headers via `Client::builder().default_headers`).
+//!
+//! ## Capture priority (deterministic, first hit wins)
+//!
+//! 1. Any `Set-Cookie` header(s) on the response → strip per-cookie
+//!    attributes (`Path`, `HttpOnly`, etc.), join the bare `name=value`
+//!    pairs with `; `, populate [`AuthConfig::cookie`].
+//! 2. Else parse the response body as JSON; look up `access_token`,
+//!    then `token`, then `jwt`. The first that is a string populates
+//!    [`AuthConfig::bearer`]. JWT shape is NOT validated — the value
+//!    is treated as opaque.
+//! 3. Else [`LoginError::NoCapturable`].
+//!
+//! ## Redirect handling
+//!
+//! The login client is built with `redirect::Policy::none()` so we
+//! observe the FIRST response directly. This is deliberately different
+//! from the scan client (which follows redirects). Login flows often
+//! return `302 + Set-Cookie` and immediately hand off to the new
+//! session — if we followed the redirect, the Set-Cookie from the 302
+//! would be invisible to us by the time we read `resp.headers()`.
+//! Treating 2xx AND 3xx as artifact-capturable lets us capture the
+//! cookie from the redirect-set-cookie pattern.
+//!
+//! ## TLS
+//!
+//! Same `Client::builder()` base as the scan client — strict TLS via
+//! rustls (workspace `Cargo.toml` `rustls-tls` feature). No `--insecure`
+//! flag exists for either path; both paths are strict in lockstep.
+//!
+//! ## Timeout
+//!
+//! Caller passes the same `Duration` used for scan probes (the CLI's
+//! `--timeout` flag). No separate `--login-timeout` — if login takes
+//! longer than scan, the user already has the knob.
+
+use std::time::Duration;
+
+use reqwest::{header::SET_COOKIE, redirect, Client};
+use serde_json::Value;
+
+use super::auth::AuthConfig;
+
+/// Caller-supplied login spec. `form` is an ordered list of key/value
+/// pairs; the request body encoding switches on `json` (false =
+/// `application/x-www-form-urlencoded`, true = `application/json`).
+#[derive(Debug, Clone)]
+pub struct LoginConfig {
+    pub url: String,
+    pub form: Vec<(String, String)>,
+    pub json: bool,
+}
+
+/// Errors from the login flow. All map to CLI exit code 2 with a
+/// human-readable message at the call site.
+#[derive(Debug, thiserror::Error)]
+pub enum LoginError {
+    #[error("login URL unreachable: {0}")]
+    Unreachable(reqwest::Error),
+    #[error("login failed: POST {url} returned {status}")]
+    BadStatus { url: String, status: u16 },
+    #[error(
+        "login response had no Set-Cookie header or recognized token field (access_token, token, jwt)"
+    )]
+    NoCapturable,
+}
+
+/// Execute the configured login flow. Returns an [`AuthConfig`] whose
+/// `login` field is populated (so [`AuthConfig::redact_for_json`]
+/// reports `methods=["login"]`) AND whose `bearer` or `cookie` field
+/// carries the captured artifact (so
+/// [`AuthConfig::to_header_map`] emits the right header on every
+/// subsequent scan request).
+pub async fn execute_login(cfg: &LoginConfig, timeout: Duration) -> Result<AuthConfig, LoginError> {
+    let client = Client::builder()
+        .timeout(timeout)
+        .redirect(redirect::Policy::none())
+        .build()
+        .map_err(LoginError::Unreachable)?;
+
+    let mut request = client.post(&cfg.url);
+    if cfg.json {
+        // Build a JSON object preserving registration order via
+        // serde_json::Map (with `preserve_order` workspace feature).
+        let mut body = serde_json::Map::new();
+        for (k, v) in &cfg.form {
+            body.insert(k.clone(), Value::String(v.clone()));
+        }
+        request = request
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(Value::Object(body).to_string());
+    } else {
+        // form-urlencoded — reqwest's `.form()` does the encoding.
+        request = request.form(&cfg.form);
+    }
+
+    let response = request.send().await.map_err(LoginError::Unreachable)?;
+    let status = response.status();
+
+    // 2xx + 3xx are both "login proceeded; look for an artifact".
+    // 4xx + 5xx are credential / server failures — no point
+    // continuing.
+    if status.is_client_error() || status.is_server_error() {
+        return Err(LoginError::BadStatus {
+            url: cfg.url.clone(),
+            status: status.as_u16(),
+        });
+    }
+
+    // Capture priority 1: Set-Cookie header(s).
+    if let Some(cookie_header) = extract_set_cookies(response.headers()) {
+        return Ok(AuthConfig {
+            cookie: Some(cookie_header),
+            login: Some(cfg.clone()),
+            ..Default::default()
+        });
+    }
+
+    // Capture priority 2: JSON body with recognized token field.
+    let body_bytes = response.bytes().await.unwrap_or_default();
+    if let Some(token) = extract_token_from_json(&body_bytes) {
+        return Ok(AuthConfig {
+            bearer: Some(token),
+            login: Some(cfg.clone()),
+            ..Default::default()
+        });
+    }
+
+    Err(LoginError::NoCapturable)
+}
+
+/// Pull the `name=value` part of every `Set-Cookie` header on the
+/// response and join them with `; `. Returns `None` if no `Set-Cookie`
+/// header is present. The result is a verbatim `Cookie` request header
+/// value suitable for [`AuthConfig::cookie`].
+fn extract_set_cookies(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    let parts: Vec<String> = headers
+        .get_all(SET_COOKIE)
+        .iter()
+        .filter_map(|hv| hv.to_str().ok())
+        .map(|raw| {
+            // Per RFC 6265 a Set-Cookie value is `name=value` followed
+            // by `;`-separated attributes. Take only the first piece.
+            let head = raw.split(';').next().unwrap_or("").trim();
+            head.to_string()
+        })
+        .filter(|p| !p.is_empty())
+        .collect();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("; "))
+    }
+}
+
+/// Try to extract an opaque token string from a JSON response body.
+/// Looks up `access_token`, then `token`, then `jwt` (priority order,
+/// first hit that is a non-empty string wins). No JWT shape validation
+/// — the token is treated as an opaque bearer string.
+fn extract_token_from_json(body: &[u8]) -> Option<String> {
+    let v: Value = serde_json::from_slice(body).ok()?;
+    for key in ["access_token", "token", "jwt"] {
+        if let Some(s) = v.get(key).and_then(Value::as_str) {
+            if !s.is_empty() {
+                return Some(s.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan::test_server::{MockResponse, MockServer};
+
+    fn login_cfg(url: String, form: Vec<(&str, &str)>, json: bool) -> LoginConfig {
+        LoginConfig {
+            url,
+            form: form
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+            json,
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_login_captures_set_cookie_into_auth_cookie() {
+        let server = MockServer::start().await;
+        server.on("POST", "/auth/login", |_req| {
+            MockResponse::ok("").set_cookie("session=abc123; Path=/; HttpOnly")
+        });
+        let cfg = login_cfg(
+            format!("{}/auth/login", server.url()),
+            vec![("user", "admin"), ("pass", "hunter2")],
+            false,
+        );
+        let result = execute_login(&cfg, Duration::from_secs(2)).await.unwrap();
+        // Per-cookie attributes stripped — only `name=value`.
+        assert_eq!(result.cookie.as_deref(), Some("session=abc123"));
+        assert!(result.bearer.is_none());
+        assert!(result.login.is_some());
+    }
+
+    #[tokio::test]
+    async fn execute_login_joins_multiple_set_cookies_with_semicolons() {
+        let server = MockServer::start().await;
+        server.on("POST", "/auth/login", |_req| {
+            MockResponse::ok("")
+                .set_cookie("session=abc; Path=/; HttpOnly")
+                .set_cookie("csrf=xyz; SameSite=Strict")
+        });
+        let cfg = login_cfg(
+            format!("{}/auth/login", server.url()),
+            vec![("u", "x")],
+            false,
+        );
+        let result = execute_login(&cfg, Duration::from_secs(2)).await.unwrap();
+        assert_eq!(result.cookie.as_deref(), Some("session=abc; csrf=xyz"));
+    }
+
+    #[tokio::test]
+    async fn execute_login_captures_set_cookie_from_302_redirect_response() {
+        // Common pattern: form-style login returns 302 + Set-Cookie,
+        // expects the client to follow Location. Our login client uses
+        // `redirect::Policy::none()` precisely so the Set-Cookie from
+        // the 302 is observable. Without that policy, reqwest would
+        // follow the redirect and we'd see only the final response's
+        // (likely empty) Set-Cookie header set.
+        let server = MockServer::start().await;
+        server.on("POST", "/auth/login", |_req| {
+            MockResponse::ok("")
+                .status(302)
+                .with_header("Location", "/dashboard")
+                .set_cookie("session=redirect-flow-cookie; Path=/")
+        });
+        let cfg = login_cfg(
+            format!("{}/auth/login", server.url()),
+            vec![("u", "x")],
+            false,
+        );
+        let result = execute_login(&cfg, Duration::from_secs(2)).await.unwrap();
+        assert_eq!(
+            result.cookie.as_deref(),
+            Some("session=redirect-flow-cookie")
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_login_captures_access_token_into_auth_bearer() {
+        let server = MockServer::start().await;
+        server.on("POST", "/auth/login", |_req| {
+            MockResponse::json(r#"{"access_token":"jwt.payload.sig","other":"ignored"}"#)
+        });
+        let cfg = login_cfg(
+            format!("{}/auth/login", server.url()),
+            vec![("u", "x")],
+            false,
+        );
+        let result = execute_login(&cfg, Duration::from_secs(2)).await.unwrap();
+        assert_eq!(result.bearer.as_deref(), Some("jwt.payload.sig"));
+        assert!(result.cookie.is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_login_token_field_priority_access_token_then_token_then_jwt() {
+        // access_token wins.
+        let server = MockServer::start().await;
+        server.on("POST", "/auth/multi", |_req| {
+            MockResponse::json(r#"{"access_token":"A","token":"B","jwt":"C"}"#)
+        });
+        let cfg = login_cfg(
+            format!("{}/auth/multi", server.url()),
+            vec![("u", "x")],
+            false,
+        );
+        let result = execute_login(&cfg, Duration::from_secs(2)).await.unwrap();
+        assert_eq!(result.bearer.as_deref(), Some("A"));
+
+        // token beats jwt when access_token is absent.
+        let server2 = MockServer::start().await;
+        server2.on("POST", "/auth/two", |_req| {
+            MockResponse::json(r#"{"token":"B","jwt":"C"}"#)
+        });
+        let cfg2 = login_cfg(
+            format!("{}/auth/two", server2.url()),
+            vec![("u", "x")],
+            false,
+        );
+        let r2 = execute_login(&cfg2, Duration::from_secs(2)).await.unwrap();
+        assert_eq!(r2.bearer.as_deref(), Some("B"));
+
+        // jwt is the last fallback.
+        let server3 = MockServer::start().await;
+        server3.on("POST", "/auth/jwt", |_req| {
+            MockResponse::json(r#"{"jwt":"C"}"#)
+        });
+        let cfg3 = login_cfg(
+            format!("{}/auth/jwt", server3.url()),
+            vec![("u", "x")],
+            false,
+        );
+        let r3 = execute_login(&cfg3, Duration::from_secs(2)).await.unwrap();
+        assert_eq!(r3.bearer.as_deref(), Some("C"));
+    }
+
+    #[tokio::test]
+    async fn execute_login_set_cookie_wins_over_json_body() {
+        // Both present — Set-Cookie has priority. The response body
+        // token would NOT be captured; we never even read the body.
+        let server = MockServer::start().await;
+        server.on("POST", "/auth/both", |_req| {
+            MockResponse::json(r#"{"access_token":"would-be-bearer"}"#)
+                .set_cookie("session=wins; Path=/")
+        });
+        let cfg = login_cfg(
+            format!("{}/auth/both", server.url()),
+            vec![("u", "x")],
+            false,
+        );
+        let result = execute_login(&cfg, Duration::from_secs(2)).await.unwrap();
+        assert_eq!(result.cookie.as_deref(), Some("session=wins"));
+        assert!(result.bearer.is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_login_sends_form_urlencoded_body_by_default() {
+        use std::sync::{Arc, Mutex};
+        let captured: Arc<Mutex<Option<(String, String)>>> = Arc::new(Mutex::new(None));
+        let cap = captured.clone();
+        let server = MockServer::start().await;
+        server.on("POST", "/auth/echo", move |req| {
+            let ct = req.headers.get("content-type").cloned().unwrap_or_default();
+            *cap.lock().unwrap() = Some((ct, req.body.clone()));
+            MockResponse::ok("").set_cookie("session=ok")
+        });
+        let cfg = login_cfg(
+            format!("{}/auth/echo", server.url()),
+            vec![("user", "admin"), ("pass", "hunter2")],
+            false,
+        );
+        let _ = execute_login(&cfg, Duration::from_secs(2)).await.unwrap();
+
+        let snapshot = captured.lock().unwrap().clone().unwrap();
+        let (ct, body) = snapshot;
+        assert!(
+            ct.starts_with("application/x-www-form-urlencoded"),
+            "content-type: {ct}"
+        );
+        assert_eq!(body, "user=admin&pass=hunter2");
+    }
+
+    #[tokio::test]
+    async fn execute_login_sends_json_body_when_json_flag_set() {
+        use std::sync::{Arc, Mutex};
+        let captured: Arc<Mutex<Option<(String, String)>>> = Arc::new(Mutex::new(None));
+        let cap = captured.clone();
+        let server = MockServer::start().await;
+        server.on("POST", "/auth/echo", move |req| {
+            let ct = req.headers.get("content-type").cloned().unwrap_or_default();
+            *cap.lock().unwrap() = Some((ct, req.body.clone()));
+            MockResponse::ok("").set_cookie("session=ok")
+        });
+        let cfg = login_cfg(
+            format!("{}/auth/echo", server.url()),
+            vec![("user", "admin"), ("pass", "hunter2")],
+            true,
+        );
+        let _ = execute_login(&cfg, Duration::from_secs(2)).await.unwrap();
+
+        let snapshot = captured.lock().unwrap().clone().unwrap();
+        let (ct, body) = snapshot;
+        assert!(ct.starts_with("application/json"), "content-type: {ct}");
+        // Field order preserved via serde_json's `preserve_order`
+        // workspace feature.
+        assert_eq!(body, r#"{"user":"admin","pass":"hunter2"}"#);
+    }
+
+    #[tokio::test]
+    async fn execute_login_status_4xx_returns_bad_status() {
+        let server = MockServer::start().await;
+        server.on("POST", "/auth/badcreds", |_req| {
+            MockResponse::ok("").status(401)
+        });
+        let url = format!("{}/auth/badcreds", server.url());
+        let cfg = login_cfg(url.clone(), vec![("u", "x")], false);
+        let err = execute_login(&cfg, Duration::from_secs(2))
+            .await
+            .unwrap_err();
+        match err {
+            LoginError::BadStatus {
+                url: u,
+                status: 401,
+            } => assert_eq!(u, url),
+            other => panic!("expected BadStatus 401, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_login_no_artifact_returns_no_capturable() {
+        let server = MockServer::start().await;
+        server.on("POST", "/auth/blank", |_req| MockResponse::ok(""));
+        let cfg = login_cfg(
+            format!("{}/auth/blank", server.url()),
+            vec![("u", "x")],
+            false,
+        );
+        let err = execute_login(&cfg, Duration::from_secs(2))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, LoginError::NoCapturable), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn execute_login_unreachable_returns_unreachable_error() {
+        // Bind a port then drop it — the URL resolves but nothing
+        // listens, so the connection attempt fails fast.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let cfg = login_cfg(format!("http://{addr}/auth/login"), vec![("u", "x")], false);
+        let err = execute_login(&cfg, Duration::from_millis(500))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, LoginError::Unreachable(_)), "got: {err:?}");
+    }
+}

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/mod.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/mod.rs
@@ -16,6 +16,7 @@
 //! Output formatting (human / `--json`) lives in `arcis-cli` next to the
 //! clap glue.
 
+pub mod auth;
 pub mod classifier;
 pub mod discover;
 pub mod payloads;
@@ -27,6 +28,7 @@ pub mod repro;
 #[cfg(test)]
 pub(crate) mod test_server;
 
+pub use auth::{AuthConfig, AuthError};
 pub use classifier::{classify, Classification};
 pub use discover::{
     detect_project_kind, detect_target, discover_routes, env_target, probe_control_plane,

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/mod.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/mod.rs
@@ -22,6 +22,11 @@ pub mod payloads;
 pub mod probe;
 pub mod repro;
 
+// Test-only mock HTTP server. `pub(crate)` so any scan submodule's
+// `#[cfg(test)] mod tests` can reach it (today `probe`, soon `auth`).
+#[cfg(test)]
+pub(crate) mod test_server;
+
 pub use classifier::{classify, Classification};
 pub use discover::{
     detect_project_kind, detect_target, discover_routes, env_target, probe_control_plane,

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/mod.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/mod.rs
@@ -20,6 +20,7 @@ pub mod classifier;
 pub mod discover;
 pub mod payloads;
 pub mod probe;
+pub mod repro;
 
 pub use classifier::{classify, Classification};
 pub use discover::{
@@ -31,3 +32,4 @@ pub use payloads::{
     attack_categories, AttackCategory, AttackVector, BLOCKED_STATUS_CODES, DEFAULT_FIELDS,
 };
 pub use probe::{scan_route, send_one, RouteResult, ScanOptions, VectorResult};
+pub use repro::format_curl;

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/mod.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/mod.rs
@@ -19,6 +19,7 @@
 pub mod auth;
 pub mod classifier;
 pub mod discover;
+pub mod login;
 pub mod payloads;
 pub mod probe;
 pub mod repro;
@@ -35,6 +36,7 @@ pub use discover::{
     probe_dev_ports, read_env_files, sniff_framework, DiscoveredRoute, TargetCandidate,
     CONTROL_PLANE_URL, DEV_PORTS, ENV_TARGET_KEYS,
 };
+pub use login::{execute_login, LoginConfig, LoginError};
 pub use payloads::{
     attack_categories, AttackCategory, AttackVector, BLOCKED_STATUS_CODES, DEFAULT_FIELDS,
 };

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/probe.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/probe.rs
@@ -41,12 +41,18 @@ pub struct VectorResult {
 }
 
 /// Result of scanning one route (probe + all active vectors).
+///
+/// `field` is the JSON body / query key the probe step settled on; empty
+/// string when the route never reached the vector dispatch stage. Carried
+/// here so renderers (human + JSON) can build a faithful `curl`
+/// reproducer per vector — see `scan::repro::format_curl`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RouteResult {
     pub method: String,
     pub path: String,
     pub reachable: bool,
     pub error: Option<String>,
+    pub field: String,
     pub vectors: Vec<VectorResult>,
 }
 
@@ -184,6 +190,7 @@ pub async fn scan_route(
         return result;
     }
     result.reachable = true;
+    result.field = working_field.clone();
 
     let tasks = build_tasks(options.categories, options.thorough);
 

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/probe.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/probe.rs
@@ -19,6 +19,7 @@ use reqwest::{Client, Method};
 use serde_json::Value;
 use tokio::sync::Semaphore;
 
+use super::auth::AuthConfig;
 use super::classifier::classify;
 use super::payloads::{attack_categories, slug};
 
@@ -66,6 +67,11 @@ pub struct ScanOptions<'a> {
     /// `c.lower().replace(" ", "")`.
     pub categories: Option<&'a [String]>,
     pub thorough: bool,
+    /// Optional auth state. `None` is the zero-cost no-auth path
+    /// (no header-map allocation, no `default_headers` call). Carries
+    /// the bearer token (and, in follow-up commits, cookies + login
+    /// artifacts) injected on every probe + vector request.
+    pub auth: Option<&'a AuthConfig>,
 }
 
 /// Send one HTTP request with `payload` injected into `field`. Returns
@@ -161,7 +167,14 @@ pub async fn scan_route(
         ..Default::default()
     };
 
-    let client = match Client::builder().timeout(options.timeout).build() {
+    // Single header-injection site for all auth flags. `default_headers`
+    // is set once on the Client; probe step + every vector inherits.
+    // No-auth path skips the call entirely (no allocation, no copy).
+    let mut builder = Client::builder().timeout(options.timeout);
+    if let Some(auth) = options.auth {
+        builder = builder.default_headers(auth.to_header_map());
+    }
+    let client = match builder.build() {
         Ok(c) => c,
         Err(e) => {
             result.error = Some(format!("client init failed: {e}"));
@@ -407,6 +420,7 @@ mod tests {
             timeout: Duration::from_millis(500),
             categories: None,
             thorough: false,
+            auth: None,
         };
         let rr = scan_route(&format!("http://{addr}"), "POST", "/api/login", &opts).await;
         assert!(!rr.reachable);
@@ -422,6 +436,7 @@ mod tests {
             timeout: Duration::from_secs(2),
             categories: None,
             thorough: false,
+            auth: None,
         };
         let rr = scan_route(&format!("http://{addr}"), "POST", "/missing", &opts).await;
         assert!(!rr.reachable);
@@ -452,6 +467,7 @@ mod tests {
             timeout: Duration::from_secs(2),
             categories: Some(&cats),
             thorough: false,
+            auth: None,
         };
         let rr = scan_route(&format!("http://{addr}"), "POST", "/api/x", &opts).await;
         assert!(rr.reachable);
@@ -487,6 +503,7 @@ mod tests {
             timeout: Duration::from_secs(2),
             categories: None, // all categories
             thorough: false,
+            auth: None,
         };
         let rr = scan_route(&format!("http://{addr}"), "POST", "/api/x", &opts).await;
         assert!(rr.reachable);
@@ -541,5 +558,67 @@ mod tests {
         assert!(names.contains("NoSQL Injection"));
         assert!(names.contains("SQL Blind"));
         assert_eq!(names.len(), 2);
+    }
+
+    // The two tests below use the per-route mock server from
+    // `super::test_server` rather than `spawn_mock`, since they assert
+    // against captured request headers — a surface the single-responder
+    // mock doesn't expose.
+    #[tokio::test]
+    async fn scan_route_with_bearer_sends_authorization_on_every_request() {
+        use crate::scan::test_server::{MockResponse, MockServer};
+
+        let server = MockServer::start().await;
+        // Every request: 200 OK so the probe step succeeds and vector
+        // dispatch fires.
+        server.on("POST", "/api/test", |_req| MockResponse::ok("{}"));
+
+        let auth = AuthConfig::with_bearer("test-bearer-token-xyz").unwrap();
+        let cats = vec!["xss".to_string()];
+        let opts = ScanOptions {
+            fields: &["q"],
+            timeout: Duration::from_secs(2),
+            categories: Some(&cats),
+            thorough: false,
+            auth: Some(&auth),
+        };
+        let _ = scan_route(&server.url(), "POST", "/api/test", &opts).await;
+
+        let captured = server.requests();
+        assert!(!captured.is_empty(), "expected at least one request");
+        for req in &captured {
+            assert_eq!(
+                req.headers.get("authorization").map(String::as_str),
+                Some("Bearer test-bearer-token-xyz"),
+                "every probe + vector request must carry the bearer header; got: {req:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn scan_route_without_auth_omits_authorization_header() {
+        use crate::scan::test_server::{MockResponse, MockServer};
+
+        let server = MockServer::start().await;
+        server.on("POST", "/api/test", |_req| MockResponse::ok("{}"));
+
+        let cats = vec!["xss".to_string()];
+        let opts = ScanOptions {
+            fields: &["q"],
+            timeout: Duration::from_secs(2),
+            categories: Some(&cats),
+            thorough: false,
+            auth: None,
+        };
+        let _ = scan_route(&server.url(), "POST", "/api/test", &opts).await;
+
+        let captured = server.requests();
+        assert!(!captured.is_empty(), "expected at least one request");
+        for req in &captured {
+            assert!(
+                !req.headers.contains_key("authorization"),
+                "no-auth runs must NOT send an Authorization header; got: {req:?}"
+            );
+        }
     }
 }

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/probe.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/probe.rs
@@ -619,6 +619,95 @@ mod tests {
                 !req.headers.contains_key("authorization"),
                 "no-auth runs must NOT send an Authorization header; got: {req:?}"
             );
+            assert!(
+                !req.headers.contains_key("cookie"),
+                "no-auth runs must NOT send a Cookie header; got: {req:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn scan_route_with_cookie_sends_cookie_header_verbatim() {
+        use crate::scan::test_server::{MockResponse, MockServer};
+
+        let server = MockServer::start().await;
+        server.on("POST", "/api/test", |_req| MockResponse::ok("{}"));
+
+        // Multi-cookie semicolon form must round-trip on the wire
+        // exactly as the user pasted it — no parsing, no reordering.
+        let cookie = "session=abc; csrf=xyz; flavor=chocolate";
+        let auth = AuthConfig::with_cookie(cookie).unwrap();
+        let cats = vec!["xss".to_string()];
+        let opts = ScanOptions {
+            fields: &["q"],
+            timeout: Duration::from_secs(2),
+            categories: Some(&cats),
+            thorough: false,
+            auth: Some(&auth),
+        };
+        let _ = scan_route(&server.url(), "POST", "/api/test", &opts).await;
+
+        let captured = server.requests();
+        assert!(!captured.is_empty(), "expected at least one request");
+        for req in &captured {
+            assert_eq!(
+                req.headers.get("cookie").map(String::as_str),
+                Some(cookie),
+                "every probe + vector request must carry the cookie verbatim; got: {req:?}"
+            );
+            assert!(
+                !req.headers.contains_key("authorization"),
+                "cookie-only run must NOT carry Authorization; got: {req:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn scan_route_with_bearer_and_cookie_sends_both_headers() {
+        // Composition test: per session direction, assert presence and
+        // per-header value equality independently. HTTP treats headers
+        // as orderless, HeaderMap iteration order is not stable —
+        // never compare full sequences.
+        use crate::scan::test_server::{MockResponse, MockServer};
+
+        let server = MockServer::start().await;
+        server.on("POST", "/api/test", |_req| MockResponse::ok("{}"));
+
+        let auth = AuthConfig {
+            bearer: Some("test-bearer-token-xyz".into()),
+            cookie: Some("session=abc; csrf=xyz".into()),
+        };
+        let cats = vec!["xss".to_string()];
+        let opts = ScanOptions {
+            fields: &["q"],
+            timeout: Duration::from_secs(2),
+            categories: Some(&cats),
+            thorough: false,
+            auth: Some(&auth),
+        };
+        let _ = scan_route(&server.url(), "POST", "/api/test", &opts).await;
+
+        let captured = server.requests();
+        assert!(!captured.is_empty(), "expected at least one request");
+        for req in &captured {
+            // Presence — independent checks per header.
+            assert!(
+                req.headers.contains_key("authorization"),
+                "missing authorization header; got: {req:?}"
+            );
+            assert!(
+                req.headers.contains_key("cookie"),
+                "missing cookie header; got: {req:?}"
+            );
+            // Value equality — per-header, no order assumptions.
+            assert_eq!(
+                req.headers.get("authorization").map(String::as_str),
+                Some("Bearer test-bearer-token-xyz")
+            );
+            assert_eq!(
+                req.headers.get("cookie").map(String::as_str),
+                Some("session=abc; csrf=xyz")
+            );
         }
     }
 }

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/probe.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/probe.rs
@@ -676,6 +676,7 @@ mod tests {
         let auth = AuthConfig {
             bearer: Some("test-bearer-token-xyz".into()),
             cookie: Some("session=abc; csrf=xyz".into()),
+            ..Default::default()
         };
         let cats = vec!["xss".to_string()];
         let opts = ScanOptions {

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/repro.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/repro.rs
@@ -1,0 +1,151 @@
+//! `curl` one-liner reproducer for a single (route, vector) probe.
+//!
+//! Mirrors the request shape `probe::send_one` actually puts on the wire
+//! so the user can paste the line into a POSIX shell and reproduce the
+//! exact probe — useful both for vulnerable findings ("show me what got
+//! through") and blocked ones ("show me what the middleware rejected").
+
+use serde_json::Value;
+
+/// Format a portable POSIX-shell `curl` invocation that mirrors how
+/// `probe::send_one` would dispatch the same probe.
+///
+/// * `GET`  → `curl -fsSL '<base>/<path>?<field>=<urlencoded payload>'`
+/// * other  → `curl -fsSL -X <METHOD> '<base>/<path>'
+///            -H 'Content-Type: application/json' --data-raw '<json body>'`
+///
+/// `target_url` is treated like `probe::scan_route` does — trailing `/`
+/// trimmed, `path` leading `/` trimmed, then joined with a single `/`.
+/// `field` is the JSON body / query key. NoSQL payloads that parse as
+/// JSON stay nested in the body, just like `send_one`.
+pub fn format_curl(
+    target_url: &str,
+    method: &str,
+    path: &str,
+    field: &str,
+    payload: &str,
+) -> String {
+    let url = format!(
+        "{}/{}",
+        target_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    );
+    if method.eq_ignore_ascii_case("GET") {
+        let encoded = urlencoding::encode(payload);
+        let sep = if url.contains('?') { '&' } else { '?' };
+        let full_url = format!("{url}{sep}{field}={encoded}");
+        format!("curl -fsSL {}", shell_quote(&full_url))
+    } else {
+        let json_value: Value =
+            serde_json::from_str(payload).unwrap_or_else(|_| Value::String(payload.to_string()));
+        let body = serde_json::json!({ field: json_value }).to_string();
+        format!(
+            "curl -fsSL -X {} {} -H 'Content-Type: application/json' --data-raw {}",
+            method.to_uppercase(),
+            shell_quote(&url),
+            shell_quote(&body),
+        )
+    }
+}
+
+/// Wrap `s` in single quotes for POSIX shell, escaping any embedded `'`
+/// via the standard `'\''` close-quote / escaped-quote / re-open-quote
+/// dance. Safe for arbitrary payload bytes.
+fn shell_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for ch in s.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_url_encodes_payload_into_query() {
+        let s = format_curl(
+            "http://localhost:5000",
+            "GET",
+            "/search",
+            "q",
+            "<script>alert(1)</script>",
+        );
+        assert_eq!(
+            s,
+            "curl -fsSL 'http://localhost:5000/search?q=%3Cscript%3Ealert%281%29%3C%2Fscript%3E'"
+        );
+    }
+
+    #[test]
+    fn get_appends_with_ampersand_when_path_already_has_query() {
+        let s = format_curl("http://h", "GET", "/p?x=1", "q", "y");
+        assert!(
+            s.contains("/p?x=1&q=y"),
+            "expected & separator when path already has ?, got: {s}"
+        );
+    }
+
+    #[test]
+    fn post_emits_json_body_and_method_uppercased() {
+        let s = format_curl("http://h", "post", "/api/login", "username", "admin");
+        assert_eq!(
+            s,
+            "curl -fsSL -X POST 'http://h/api/login' -H 'Content-Type: application/json' --data-raw '{\"username\":\"admin\"}'"
+        );
+    }
+
+    #[test]
+    fn post_keeps_nosql_payload_nested() {
+        let s = format_curl("http://h", "POST", "/login", "password", "{\"$gt\": \"\"}");
+        assert!(
+            s.contains("'{\"password\":{\"$gt\":\"\"}}'"),
+            "NoSQL payload should round-trip nested in the body, got: {s}"
+        );
+    }
+
+    #[test]
+    fn payload_with_single_quote_is_shell_escaped() {
+        // Classic SQLi payload contains literal single quotes — they must
+        // be escaped inside the single-quoted shell argument.
+        let s = format_curl("http://h", "POST", "/q", "user", "' OR '1'='1' --");
+        // Body in JSON: {"user":"' OR '1'='1' --"} — every `'` in that
+        // string must be replaced by the `'\''` escape sequence.
+        let body_segment = "'{\"user\":\"'\\''  OR '\\''1'\\''='\\''1'\\'' --\"}'";
+        // Allow either 1 or 2 spaces between OR — JSON serialiser preserves
+        // whatever was in the input. We sent " OR " with one space, so
+        // the asserted segment uses a single space too.
+        let single_space = body_segment.replace("'\\''  OR", "'\\'' OR");
+        assert!(
+            s.ends_with(&single_space),
+            "expected single-quote escape via '\\\\''  pattern, got tail: {}",
+            &s[s.len().saturating_sub(120)..]
+        );
+    }
+
+    #[test]
+    fn put_method_honored() {
+        let s = format_curl("http://h", "PUT", "/p", "f", "v");
+        assert!(s.starts_with("curl -fsSL -X PUT "), "got: {s}");
+    }
+
+    #[test]
+    fn trailing_slash_in_target_and_leading_slash_in_path_collapse() {
+        let s = format_curl("http://h/", "GET", "/p", "q", "v");
+        assert!(s.contains("'http://h/p?q=v'"), "got: {s}");
+    }
+
+    #[test]
+    fn shell_quote_escapes_embedded_quote() {
+        assert_eq!(shell_quote("a'b"), "'a'\\''b'");
+        assert_eq!(shell_quote("plain"), "'plain'");
+        assert_eq!(shell_quote(""), "''");
+    }
+}

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/test_server.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/test_server.rs
@@ -1,0 +1,445 @@
+//! In-process mock HTTP server for scan-module unit tests.
+//!
+//! Lives alongside `probe::spawn_mock` (single-responder, fixed headers)
+//! because Phase B items 5/6/9 need:
+//!
+//! * Per-route routing — login flow expects different responses on
+//!   `POST /auth/login` vs `GET /api/secret`.
+//! * Custom response headers — `Set-Cookie`, repeatable for multi-cookie
+//!   logins. Headers are stored as `Vec<(String, String)>` so duplicate
+//!   names round-trip as separate header lines on the wire.
+//! * Request capture — assertion-side reads of every header/body that
+//!   reached the server, in arrival order.
+//! * Sequence-aware closures — handlers can capture their own
+//!   `Arc<Mutex<State>>` and vary response on subsequent calls. No
+//!   bespoke server-state API needed.
+//!
+//! Hand-rolled HTTP/1.1 (no `axum`/`wiremock`) to stay zero-dep — same
+//! pattern as `probe::spawn_mock` plus the surface above. Listener binds
+//! `127.0.0.1:0`; the ephemeral port is exposed via [`MockServer::url`].
+//!
+//! `pub(crate)` and gated `#[cfg(test)]` at the include site, so any
+//! scan submodule's `#[cfg(test)] mod tests` can reach it (today
+//! `probe`, soon `auth`).
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// One request as observed by the server. `headers` keys are lowercased
+/// (last-write-wins on duplicates — fine for assertion-side reads in
+/// tests). `path` is the request-target verbatim, query string included.
+#[derive(Debug, Clone, Default)]
+pub struct RecordedRequest {
+    pub method: String,
+    pub path: String,
+    pub headers: HashMap<String, String>,
+    pub body: String,
+}
+
+/// Server response built by a handler closure. Headers are an ordered
+/// `Vec` (not a map) so duplicates such as multi-cookie `Set-Cookie:`
+/// emit multiple lines on the wire in registration order.
+#[derive(Debug, Clone)]
+pub struct MockResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: String,
+}
+
+impl MockResponse {
+    /// 200 OK with the given body. No `Content-Type` set — caller adds
+    /// via [`MockResponse::with_header`] or uses [`MockResponse::json`].
+    pub fn ok(body: impl Into<String>) -> Self {
+        Self {
+            status: 200,
+            headers: Vec::new(),
+            body: body.into(),
+        }
+    }
+
+    /// 200 OK with `Content-Type: application/json` set automatically.
+    /// The body is sent verbatim — caller is responsible for emitting
+    /// valid JSON. The `Content-Type` header IS part of this method's
+    /// contract; tests assert it on the wire so it can't quietly drift.
+    pub fn json(body: impl Into<String>) -> Self {
+        Self::ok(body).with_header("Content-Type", "application/json")
+    }
+
+    pub fn status(mut self, code: u16) -> Self {
+        self.status = code;
+        self
+    }
+
+    pub fn with_header(mut self, name: &str, value: &str) -> Self {
+        self.headers.push((name.to_string(), value.to_string()));
+        self
+    }
+
+    /// Sugar for `with_header("Set-Cookie", cookie)`. Repeatable —
+    /// chain to emit multiple cookies on one response.
+    pub fn set_cookie(self, cookie: &str) -> Self {
+        self.with_header("Set-Cookie", cookie)
+    }
+}
+
+type Handler = Arc<dyn Fn(&RecordedRequest) -> MockResponse + Send + Sync + 'static>;
+
+struct Route {
+    method: String,
+    path: String,
+    handler: Handler,
+}
+
+struct MockState {
+    routes: Mutex<Vec<Route>>,
+    requests: Mutex<Vec<RecordedRequest>>,
+}
+
+/// Mock server bound to an ephemeral port on `127.0.0.1`. The accept
+/// loop is implicit on the surrounding tokio runtime; drop the instance
+/// when the test ends.
+pub struct MockServer {
+    addr: SocketAddr,
+    state: Arc<MockState>,
+}
+
+impl MockServer {
+    /// Bind `127.0.0.1:0` and spawn the accept loop. Returns once the
+    /// listener is ready.
+    pub async fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener bind");
+        let addr = listener.local_addr().expect("test listener local_addr");
+        let state = Arc::new(MockState {
+            routes: Mutex::new(Vec::new()),
+            requests: Mutex::new(Vec::new()),
+        });
+        let st = state.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((sock, _)) = listener.accept().await else {
+                    return;
+                };
+                let st = st.clone();
+                tokio::spawn(async move {
+                    handle_connection(sock, st).await;
+                });
+            }
+        });
+        Self { addr, state }
+    }
+
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub fn url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    /// Register a handler for `(method, path)`. Method match is
+    /// case-insensitive; path match is exact (no pattern syntax — tests
+    /// pass concrete paths). First registered handler that matches wins.
+    pub fn on<F>(&self, method: &str, path: &str, handler: F)
+    where
+        F: Fn(&RecordedRequest) -> MockResponse + Send + Sync + 'static,
+    {
+        self.state.routes.lock().unwrap().push(Route {
+            method: method.to_ascii_uppercase(),
+            path: path.to_string(),
+            handler: Arc::new(handler),
+        });
+    }
+
+    /// Snapshot of every request received so far, in arrival order.
+    /// Cloned out so the caller doesn't hold the internal mutex.
+    pub fn requests(&self) -> Vec<RecordedRequest> {
+        self.state.requests.lock().unwrap().clone()
+    }
+}
+
+async fn handle_connection(mut sock: tokio::net::TcpStream, state: Arc<MockState>) {
+    let mut buf: Vec<u8> = Vec::with_capacity(8192);
+    let mut tmp = [0u8; 4096];
+
+    // Read until end of headers. Bound at 64 KB to keep test surface
+    // bounded — production HTTP allows more, but tests don't.
+    let header_end = loop {
+        let n = match sock.read(&mut tmp).await {
+            Ok(0) => return,
+            Ok(n) => n,
+            Err(_) => return,
+        };
+        buf.extend_from_slice(&tmp[..n]);
+        if let Some(idx) = find_double_crlf(&buf) {
+            break idx;
+        }
+        if buf.len() > 65_536 {
+            return;
+        }
+    };
+
+    let head = match std::str::from_utf8(&buf[..header_end]) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let mut lines = head.split("\r\n");
+    let request_line = match lines.next() {
+        Some(l) => l,
+        None => return,
+    };
+    let mut parts = request_line.splitn(3, ' ');
+    let method = parts.next().unwrap_or("").to_string();
+    let path = parts.next().unwrap_or("").to_string();
+    // HTTP version (`parts.next()` third field) ignored — tests don't
+    // exercise it.
+
+    let mut headers: HashMap<String, String> = HashMap::new();
+    for line in lines {
+        if line.is_empty() {
+            continue;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+        }
+    }
+
+    let body_start = header_end + 4; // skip the CRLFCRLF
+    let content_length = headers
+        .get("content-length")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(0);
+
+    while buf.len() < body_start + content_length {
+        let n = match sock.read(&mut tmp).await {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => return,
+        };
+        buf.extend_from_slice(&tmp[..n]);
+    }
+
+    let body_end = (body_start + content_length).min(buf.len());
+    let body = String::from_utf8_lossy(&buf[body_start..body_end]).to_string();
+
+    let request = RecordedRequest {
+        method: method.clone(),
+        path: path.clone(),
+        headers,
+        body,
+    };
+
+    state.requests.lock().unwrap().push(request.clone());
+
+    let response = {
+        let routes = state.routes.lock().unwrap();
+        let matched = routes
+            .iter()
+            .find(|r| r.method.eq_ignore_ascii_case(&method) && path_matches(&r.path, &path));
+        match matched {
+            Some(route) => {
+                let h = route.handler.clone();
+                drop(routes);
+                h(&request)
+            }
+            None => MockResponse {
+                status: 404,
+                headers: Vec::new(),
+                body: String::new(),
+            },
+        }
+    };
+
+    let _ = write_response(&mut sock, &response).await;
+}
+
+fn find_double_crlf(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+fn path_matches(registered: &str, actual: &str) -> bool {
+    let actual_path = actual.split_once('?').map(|(p, _)| p).unwrap_or(actual);
+    registered == actual_path
+}
+
+async fn write_response(
+    sock: &mut tokio::net::TcpStream,
+    resp: &MockResponse,
+) -> std::io::Result<()> {
+    let reason = match resp.status {
+        200 => "OK",
+        201 => "Created",
+        204 => "No Content",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        403 => "Forbidden",
+        404 => "Not Found",
+        429 => "Too Many Requests",
+        500 => "Internal Server Error",
+        _ => "Status",
+    };
+    let mut out = format!("HTTP/1.1 {} {}\r\n", resp.status, reason);
+    let mut has_content_length = false;
+    for (name, value) in &resp.headers {
+        if name.eq_ignore_ascii_case("content-length") {
+            has_content_length = true;
+        }
+        out.push_str(&format!("{name}: {value}\r\n"));
+    }
+    if !has_content_length {
+        out.push_str(&format!("Content-Length: {}\r\n", resp.body.len()));
+    }
+    out.push_str("Connection: close\r\n\r\n");
+    sock.write_all(out.as_bytes()).await?;
+    sock.write_all(resp.body.as_bytes()).await?;
+    sock.shutdown().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    async fn raw_request(addr: SocketAddr, request: &str) -> String {
+        let mut sock = TcpStream::connect(addr).await.unwrap();
+        sock.write_all(request.as_bytes()).await.unwrap();
+        let mut out = Vec::new();
+        sock.read_to_end(&mut out).await.unwrap();
+        String::from_utf8_lossy(&out).into_owned()
+    }
+
+    #[tokio::test]
+    async fn mock_server_url_returns_loopback_with_ephemeral_port() {
+        let server = MockServer::start().await;
+        let url = server.url();
+        assert!(url.starts_with("http://127.0.0.1:"), "url was: {url}");
+        assert_eq!(url, format!("http://{}", server.addr()));
+    }
+
+    #[tokio::test]
+    async fn mock_server_returns_404_for_unregistered_route() {
+        let server = MockServer::start().await;
+        let response = raw_request(server.addr(), "GET /nope HTTP/1.1\r\nHost: x\r\n\r\n").await;
+        assert!(response.starts_with("HTTP/1.1 404 Not Found"));
+        let captured = server.requests();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].path, "/nope");
+    }
+
+    #[tokio::test]
+    async fn mock_server_get_returns_configured_response_with_json_content_type() {
+        let server = MockServer::start().await;
+        server.on("GET", "/api/me", |_req| MockResponse::json(r#"{"id":42}"#));
+        let response = raw_request(server.addr(), "GET /api/me HTTP/1.1\r\nHost: x\r\n\r\n").await;
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        // `MockResponse::json` MUST emit Content-Type — explicit assertion
+        // so this contract doesn't quietly drift later.
+        assert!(
+            response
+                .to_ascii_lowercase()
+                .contains("content-type: application/json"),
+            "json() must emit Content-Type: application/json header; got:\n{response}"
+        );
+        assert!(response.ends_with(r#"{"id":42}"#));
+    }
+
+    #[tokio::test]
+    async fn mock_server_post_captures_body_and_returns_set_cookie() {
+        let server = MockServer::start().await;
+        server.on("POST", "/auth/login", |req| {
+            assert!(req.body.contains("user=admin"));
+            MockResponse::ok("")
+                .set_cookie("session=abc123; HttpOnly")
+                .set_cookie("flavor=chocolate")
+        });
+        let body = "user=admin&pass=hunter2";
+        let request = format!(
+            "POST /auth/login HTTP/1.1\r\nHost: x\r\nContent-Length: {}\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\n{body}",
+            body.len()
+        );
+        let response = raw_request(server.addr(), &request).await;
+
+        // Multi-cookie wire emission — both Set-Cookie headers must
+        // appear as separate lines, in registration order. This pins
+        // the `Vec<(String, String)>` preservation contract.
+        let cookie_lines: Vec<&str> = response
+            .lines()
+            .filter(|l| l.to_ascii_lowercase().starts_with("set-cookie:"))
+            .collect();
+        assert_eq!(cookie_lines.len(), 2, "got: {response}");
+        assert!(cookie_lines[0].contains("session=abc123"));
+        assert!(cookie_lines[1].contains("flavor=chocolate"));
+
+        let captured = server.requests();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].method, "POST");
+        assert_eq!(captured[0].path, "/auth/login");
+        assert_eq!(captured[0].body, body);
+    }
+
+    #[tokio::test]
+    async fn mock_server_records_multiple_requests_in_order() {
+        let server = MockServer::start().await;
+        server.on("GET", "/a", |_| MockResponse::ok("A"));
+        server.on("GET", "/b", |_| MockResponse::ok("B"));
+        let _ = raw_request(server.addr(), "GET /a HTTP/1.1\r\nHost: x\r\n\r\n").await;
+        let _ = raw_request(server.addr(), "GET /b HTTP/1.1\r\nHost: x\r\n\r\n").await;
+        let _ = raw_request(server.addr(), "GET /a?q=1 HTTP/1.1\r\nHost: x\r\n\r\n").await;
+        let captured = server.requests();
+        assert_eq!(captured.len(), 3);
+        assert_eq!(captured[0].path, "/a");
+        assert_eq!(captured[1].path, "/b");
+        assert_eq!(captured[2].path, "/a?q=1");
+    }
+
+    #[tokio::test]
+    async fn mock_server_sequence_aware_handler_uses_captured_state() {
+        // Closure captures `Arc<Mutex<...>>` and varies response between
+        // calls. Proves that the auth login-then-cookie flow can be
+        // modeled without a bespoke server-state API.
+        let server = MockServer::start().await;
+        let logged_in = Arc::new(Mutex::new(false));
+
+        let li = logged_in.clone();
+        server.on("POST", "/auth/login", move |_req| {
+            *li.lock().unwrap() = true;
+            MockResponse::ok("").set_cookie("session=abc123")
+        });
+
+        let li = logged_in.clone();
+        server.on("GET", "/api/secret", move |req| {
+            if !*li.lock().unwrap() {
+                return MockResponse::ok("").status(401);
+            }
+            let cookie = req.headers.get("cookie").cloned().unwrap_or_default();
+            MockResponse::ok(format!("hello, cookie={cookie}"))
+        });
+
+        // First call without auth: handler returns 401.
+        let r1 = raw_request(server.addr(), "GET /api/secret HTTP/1.1\r\nHost: x\r\n\r\n").await;
+        assert!(r1.starts_with("HTTP/1.1 401"));
+
+        // Login flips the captured state.
+        let _ = raw_request(
+            server.addr(),
+            "POST /auth/login HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n",
+        )
+        .await;
+
+        // Now allowed; cookie header is read by the handler.
+        let r2 = raw_request(
+            server.addr(),
+            "GET /api/secret HTTP/1.1\r\nHost: x\r\nCookie: session=abc123\r\n\r\n",
+        )
+        .await;
+        assert!(r2.starts_with("HTTP/1.1 200"));
+        assert!(r2.contains("hello, cookie=session=abc123"));
+    }
+}


### PR DESCRIPTION
## Summary

Three cli-scan.md Phase B items shipped on track/rust-scan-phaseb, plus mock-fixture infrastructure used by all auth tests.

- **Item 8** — `--categories` accepts comma-separated values (`--categories xss,sqli` in addition to existing space-separated `--categories xss sqli`). One small surface, one commit.
- **Item 7** — Per-finding curl reproducer in JSON output (`reproduce` field). Inline so users can paste-and-run a vector that fired.
- **Mock-server fixture** — In-process tokio TcpListener + hand-rolled HTTP/1.1, used by all auth tests. Verifies header emission at the wire level.
- **Item 5 (auth flags)** — `--bearer`, `--cookie`, `--login` shipped end-to-end:
  - `--bearer <token>` — `Authorization: Bearer <token>` header. Empty/whitespace rejected at parse + engine.
  - `--cookie <value>` — verbatim `Cookie:` header value (no parsing, no dedup, no name=value extraction). Composes with `--bearer`.
  - `--login <url>` — POST credentials, capture artifact (Set-Cookie or `access_token`/`token`/`jwt` body field, in priority order), then run scan with the captured artifact. Mutex with `--bearer`/`--cookie`. `redirect::Policy::none()` so Set-Cookie from intermediate 302s is observable. Form encoding default (`application/x-www-form-urlencoded`); `--login-json` toggles JSON. Same timeout + TLS as scan client (no `--login-timeout`, no `--insecure`).
  - **Locked JSON schema:** `{"methods": ["bearer"|"cookie"|"login"|...]}` always-array, alphabetical, no `loginUrl` or other sibling keys. `redact_for_json` doc-comment enumerates exhaustively with a "future flags MUST extend the methods array, never add sibling keys" clause.
  - **Sentinel-pinned redaction:** `TEST_BEARER_TOKEN`, `TEST_COOKIE_VALUE`, `TEST_LOGIN_PASSWORD` literals asserted absent from `--json` output across all paths (login-only, login-with-captured-bearer, login-with-captured-cookie, both manual flags). Form keys (`password`, `admin`) and login URL also asserted absent.
  - **Mutex error message** pinned exactly: `"--login is mutually exclusive with --bearer / --cookie. Use --login OR manual flags, not both."` Three tests assert this string verbatim.
  - **Capture-priority help-text pin:** `help_text_documents_login_capture_priority` asserts the literal `"Set-Cookie -> access_token -> token -> jwt"` is present in `--help`. Future help-text refactors that drop this fail loudly.

## Test surface

- `cargo test -p arcis-engine` → 236/236 (was 222 before login engine; +14 across auth.rs + login.rs)
- `cargo test -p arcis-cli --bin arcis` → 85/85 (was 70 before login CLI; +15 for `--login` parser + mutex + help-text + redaction)
- `rustfmt --check` clean on all changed files
- `cargo clippy` clean on new code

## cli-scan.md item 5 spec note

Original spec for `--cookie` was `<name=value>` and "can be repeated." Overridden during sketch review per orchestrator direction: verbatim string, single instance, semicolon-join for multiple. Simpler parser, browser-paste-friendly. The plan file (`documents/plans/cli-scan.md`) was updated on disk in the cookie commit (workspace-level plan, not git-tracked, persists for future agents).

## Next on this track

Item 9 (speculative cancellable dispatch) is the next session — short-circuits remaining vector probes when a high-severity finding lands, halving worst-case scan time.