### PR TITLE
feat(scan): speculative cancellable dispatch (item 9)

### DIFF
--- a/packages/arcis-rust/crates/arcis-cli/src/scan.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/scan.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 
 use arcis_engine::scan::{
     attack_categories, discover_routes, execute_login, format_curl, payloads::slug, scan_route,
-    AuthConfig, DiscoveredRoute, LoginConfig, RouteResult, ScanOptions, DEFAULT_FIELDS,
+    AuthConfig, CancelMode, DiscoveredRoute, LoginConfig, RouteResult, ScanOptions, DEFAULT_FIELDS,
 };
 
 const RESET: &str = "\x1b[0m";
@@ -43,6 +43,7 @@ struct Args {
     login_url: Option<String>,
     login_form: Vec<(String, String)>,
     login_json: bool,
+    cancel_on: CancelMode,
 }
 
 #[derive(Debug)]
@@ -72,6 +73,7 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
         login_url: None,
         login_form: Vec::new(),
         login_json: false,
+        cancel_on: CancelMode::default(),
     };
 
     let mut i = 0;
@@ -209,6 +211,23 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
                 }
             }
             "--login-json" => args.login_json = true,
+            "--cancel-on" => {
+                i += 1;
+                let Some(v) = argv.get(i) else {
+                    return ParseOutcome::Err("arcis scan: --cancel-on needs a value".into());
+                };
+                match parse_cancel_on(v) {
+                    Ok(m) => args.cancel_on = m,
+                    Err(e) => return ParseOutcome::Err(e),
+                }
+            }
+            arg if arg.starts_with("--cancel-on=") => {
+                let v = &arg["--cancel-on=".len()..];
+                match parse_cancel_on(v) {
+                    Ok(m) => args.cancel_on = m,
+                    Err(e) => return ParseOutcome::Err(e),
+                }
+            }
             other if other.starts_with("--") || (other.starts_with('-') && other.len() > 1) => {
                 return ParseOutcome::Err(format!("arcis scan: unknown flag: {other}"));
             }
@@ -270,6 +289,19 @@ fn validate_login_url(value: &str) -> Result<String, String> {
         ));
     }
     Ok(value.to_string())
+}
+
+/// Parse the `--cancel-on` value. Two valid values, locked in help text
+/// and pinned by tests. Empty / unknown / cased-differently are rejected
+/// with a message that lists both literal options.
+fn parse_cancel_on(value: &str) -> Result<CancelMode, String> {
+    match value {
+        "first-vuln" => Ok(CancelMode::FirstVuln),
+        "never" => Ok(CancelMode::Never),
+        other => Err(format!(
+            "arcis scan: invalid --cancel-on value: {other}\n  Valid values: first-vuln, never"
+        )),
+    }
 }
 
 fn parse_login_form_pair(value: &str) -> Result<(String, String), String> {
@@ -463,6 +495,22 @@ fn print_help(out: &mut dyn Write) -> io::Result<()> {
     )?;
     writeln!(
         out,
+        "      --cancel-on MODE         Cancel remaining vector probes after the first vulnerable"
+    )?;
+    writeln!(
+        out,
+        "                               finding lands. MODE = first-vuln (default) | never."
+    )?;
+    writeln!(
+        out,
+        "                               first-vuln cuts wall-clock on slow targets; never runs"
+    )?;
+    writeln!(
+        out,
+        "                               every vector to completion for full coverage."
+    )?;
+    writeln!(
+        out,
         "  -h, --help                   Show this help and exit."
     )?;
     writeln!(out)?;
@@ -505,8 +553,18 @@ fn summarize(results: &[RouteResult], duration: Duration) -> ScanSummary {
         if rr.reachable {
             s.routes_reachable += 1;
         }
-        s.total_vectors += rr.vectors.len();
+        // Cancelled vectors were never tested — they neither block nor
+        // expose a vuln. Excluding them from ALL THREE counters
+        // (`total_vectors`, `total_blocked`, `total_vulnerable`) keeps
+        // the summary an honest accounting of probed vectors AND
+        // preserves the invariant `total_vectors == total_blocked +
+        // total_vulnerable`. Day-over-day diffs of the summary stay
+        // self-consistent regardless of where cancellation lands.
         for v in &rr.vectors {
+            if v.cancelled_kind.is_some() {
+                continue;
+            }
+            s.total_vectors += 1;
             if v.blocked {
                 s.total_blocked += 1;
             } else {
@@ -551,8 +609,24 @@ fn print_human_report(
             "  {bold}{} {}{reset}  {blocked}/{total} blocked",
             rr.method, rr.path
         )?;
+        // Honest UI: when cancellation fired, surface a one-line dim
+        // notice naming the trigger + skipped count so the user does
+        // not mistake the route for incomplete.
+        if let Some(info) = &rr.cancelled_after {
+            writeln!(
+                out,
+                "    {dim}cancelled after [{}] {} \u{2014} {} vector(s) skipped to save time{reset}",
+                info.category, info.label, info.vectors_skipped
+            )?;
+        }
         for v in &rr.vectors {
-            let mark = if v.blocked { "ok" } else { "!!" };
+            let mark = if v.cancelled_kind.is_some() {
+                "--"
+            } else if v.blocked {
+                "ok"
+            } else {
+                "!!"
+            };
             writeln!(
                 out,
                 "    {dim}{mark}{reset} [{}] {} {dim}{}{reset}",
@@ -561,8 +635,10 @@ fn print_human_report(
             // Emit a copyable curl reproducer for each vulnerable finding
             // so the user can reproduce the probe + verify their fix
             // without re-running the full scan. Blocked findings are
-            // intentionally skipped to keep the report scannable.
-            if !v.blocked {
+            // intentionally skipped to keep the report scannable, and
+            // cancelled findings are skipped because the row is a slot
+            // placeholder — no probe was confirmed against the server.
+            if !v.blocked && v.cancelled_kind.is_none() {
                 let curl = format_curl(target_url, &rr.method, &rr.path, &rr.field, &v.payload);
                 writeln!(out, "       {dim}{curl}{reset}")?;
             }
@@ -614,6 +690,13 @@ fn print_json_report(
                             target_url, &rr.method, &rr.path, &rr.field, &v.payload,
                         )),
                     );
+                    // Cancellation marker. Key is OMITTED entirely when
+                    // the vector ran normally so prior JSON output stays
+                    // byte-equal for non-cancel runs. Wire format pinned
+                    // by `CancelKind::as_str` — see VectorResult doc.
+                    if let Some(kind) = v.cancelled_kind {
+                        m.insert("cancelled_kind".into(), Value::String(kind.as_str().into()));
+                    }
                     Value::Object(m)
                 })
                 .collect();
@@ -627,6 +710,17 @@ fn print_json_report(
             );
             m.insert("field".into(), Value::String(rr.field.clone()));
             m.insert("vectors".into(), Value::Array(vectors));
+            // Cancellation summary. Key is OMITTED when no cancel
+            // fired, so prior JSON output stays byte-equal for routes
+            // that completed without short-circuit. See
+            // RouteResult::cancelled_after for the locked schema.
+            if let Some(info) = &rr.cancelled_after {
+                let mut ci = Map::new();
+                ci.insert("category".into(), Value::String(info.category.clone()));
+                ci.insert("label".into(), Value::String(info.label.clone()));
+                ci.insert("vectors_skipped".into(), json!(info.vectors_skipped));
+                m.insert("cancelled_after".into(), Value::Object(ci));
+            }
             Value::Object(m)
         })
         .collect();
@@ -817,6 +911,7 @@ pub fn run(argv: &[String]) -> ExitCode {
                 categories: categories.as_deref(),
                 thorough: args.thorough,
                 auth: auth_config.as_ref(),
+                cancel_on: args.cancel_on,
             };
             out.push(scan_route(&target_url, method, path, &opts).await);
         }
@@ -1517,6 +1612,7 @@ mod tests {
                     status: 200,
                     blocked: false,
                     note: "reflected in response (200)".into(),
+                    cancelled_kind: None,
                 },
                 VectorResult {
                     category: "SQL Injection".into(),
@@ -1525,8 +1621,10 @@ mod tests {
                     status: 400,
                     blocked: true,
                     note: "rejected (400)".into(),
+                    cancelled_kind: None,
                 },
             ],
+            cancelled_after: None,
         }
     }
 
@@ -1574,5 +1672,321 @@ mod tests {
         let xss_curl = vectors[0]["curl"].as_str().unwrap();
         assert!(xss_curl.contains("-X POST"), "got: {xss_curl}");
         assert!(xss_curl.contains("/api/login"), "got: {xss_curl}");
+    }
+
+    // -------- --cancel-on flag tests --------
+
+    #[test]
+    fn parses_cancel_on_first_vuln_space_separated() {
+        let a = args(&["--cancel-on", "first-vuln"]);
+        assert_eq!(a.cancel_on, CancelMode::FirstVuln);
+    }
+
+    #[test]
+    fn parses_cancel_on_never_space_separated() {
+        let a = args(&["--cancel-on", "never"]);
+        assert_eq!(a.cancel_on, CancelMode::Never);
+    }
+
+    #[test]
+    fn parses_cancel_on_inline_equals() {
+        let a = args(&["--cancel-on=never"]);
+        assert_eq!(a.cancel_on, CancelMode::Never);
+    }
+
+    #[test]
+    fn cancel_on_default_is_first_vuln() {
+        // Locked default: cancellation is on by default. This pins the
+        // CLI surface alongside `CancelMode::default` in the engine
+        // — both must agree, both are tested.
+        let a = args(&[]);
+        assert_eq!(a.cancel_on, CancelMode::FirstVuln);
+    }
+
+    #[test]
+    fn cancel_on_unknown_value_rejected() {
+        let argv: Vec<String> = ["--cancel-on", "always"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        match parse_args(&argv) {
+            ParseOutcome::Err(e) => {
+                assert!(e.contains("invalid --cancel-on value"), "got: {e}");
+                // Error message MUST list both valid values so the user
+                // can self-correct without re-reading help.
+                assert!(e.contains("first-vuln"), "got: {e}");
+                assert!(e.contains("never"), "got: {e}");
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cancel_on_case_sensitive_uppercase_rejected() {
+        // Locked: `--cancel-on Never` is rejected. Same policy as the
+        // value-is-an-identifier convention used elsewhere — the user
+        // gets a clear error rather than a silently-different mode.
+        let argv: Vec<String> = ["--cancel-on", "Never"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert!(matches!(parse_args(&argv), ParseOutcome::Err(_)));
+    }
+
+    #[test]
+    fn cancel_on_empty_value_rejected() {
+        let argv: Vec<String> = ["--cancel-on", ""].iter().map(|s| s.to_string()).collect();
+        assert!(matches!(parse_args(&argv), ParseOutcome::Err(_)));
+    }
+
+    #[test]
+    fn help_text_documents_cancel_modes() {
+        // Pin both literal mode strings + the explanatory line in the
+        // help block. If a future help-text refactor drops a mode or
+        // muddies the description, this test fails loudly. Same shape
+        // as `help_text_documents_login_capture_priority`.
+        let mut buf: Vec<u8> = Vec::new();
+        print_help(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("--cancel-on MODE"), "missing flag entry: {s}");
+        // Both literal mode names — pinning prevents silent rename.
+        assert!(s.contains("first-vuln"), "missing first-vuln mode: {s}");
+        assert!(s.contains("never"), "missing never mode: {s}");
+        // Default annotation — users skimming help should see which
+        // mode is active without setting the flag.
+        assert!(
+            s.contains("first-vuln (default)"),
+            "missing default annotation: {s}"
+        );
+        // Behaviour summary (load-bearing for users deciding when to
+        // opt out for full coverage).
+        assert!(
+            s.contains("Cancel remaining vector probes"),
+            "missing cancel description: {s}"
+        );
+    }
+
+    fn fixture_route_with_cancel() -> RouteResult {
+        use arcis_engine::scan::{CancelInfo, CancelKind, VectorResult};
+        RouteResult {
+            method: "POST".into(),
+            path: "/api/login".into(),
+            reachable: true,
+            error: None,
+            field: "username".into(),
+            vectors: vec![
+                // The trigger: vulnerable reflection finding.
+                VectorResult {
+                    category: "XSS".into(),
+                    label: "script tag".into(),
+                    payload: "<script>alert(1)</script>".into(),
+                    status: 200,
+                    blocked: false,
+                    note: "reflected in response (200)".into(),
+                    cancelled_kind: None,
+                },
+                // Skipped (permit-blocked) — never sent.
+                VectorResult {
+                    category: "SQL Injection".into(),
+                    label: "OR bypass".into(),
+                    payload: "' OR '1'='1' --".into(),
+                    status: 0,
+                    blocked: false,
+                    note: "skipped (cancelled)".into(),
+                    cancelled_kind: Some(CancelKind::Skipped),
+                },
+                // In-flight cancelled — request was dropped at await.
+                VectorResult {
+                    category: "Path Traversal".into(),
+                    label: "etc/passwd".into(),
+                    payload: "../../etc/passwd".into(),
+                    status: 0,
+                    blocked: false,
+                    note: "cancelled in-flight".into(),
+                    cancelled_kind: Some(CancelKind::InFlight),
+                },
+            ],
+            cancelled_after: Some(CancelInfo {
+                category: "XSS".into(),
+                label: "script tag".into(),
+                vectors_skipped: 2,
+            }),
+        }
+    }
+
+    #[test]
+    fn json_emits_cancelled_after_block_when_cancel_fires() {
+        // Sentinel-pin contains-checks against the SERIALIZED string
+        // (not just deserialized field access) so a refactor that
+        // renames the key to `cancelledAt` or drops it fails loudly.
+        // Mirrors the auth-redaction sentinel-pin pattern.
+        let rr = fixture_route_with_cancel();
+        let summary = summarize(std::slice::from_ref(&rr), Duration::from_millis(50));
+        let mut buf: Vec<u8> = Vec::new();
+        print_json_report(&mut buf, "http://localhost:5000", None, &[rr], &summary).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+
+        // Literal-key pins. Locked schema — these strings must appear
+        // verbatim in any future iteration of the JSON renderer.
+        assert!(
+            s.contains("\"cancelled_after\""),
+            "missing cancelled_after key in JSON: {s}"
+        );
+        assert!(
+            s.contains("\"cancelled_kind\""),
+            "missing cancelled_kind key in JSON: {s}"
+        );
+        assert!(
+            s.contains("\"vectors_skipped\""),
+            "missing vectors_skipped key in JSON: {s}"
+        );
+        // Wire-format pins for the two CancelKind variants — must
+        // serialize as snake_case literal strings.
+        assert!(
+            s.contains("\"skipped\""),
+            "missing skipped wire literal: {s}"
+        );
+        assert!(
+            s.contains("\"in_flight\""),
+            "missing in_flight wire literal: {s}"
+        );
+
+        // Structural assertions on the parsed JSON for shape.
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        let route0 = &v["routes"][0];
+        let info = &route0["cancelled_after"];
+        assert_eq!(info["category"], "XSS");
+        assert_eq!(info["label"], "script tag");
+        assert_eq!(info["vectors_skipped"], 2);
+
+        // Per-vector cancelled_kind — present only on skipped/in-flight
+        // rows, OMITTED on the trigger vector that ran normally.
+        let vectors = route0["vectors"].as_array().unwrap();
+        assert!(vectors[0].get("cancelled_kind").is_none());
+        assert_eq!(vectors[1]["cancelled_kind"], "skipped");
+        assert_eq!(vectors[2]["cancelled_kind"], "in_flight");
+    }
+
+    #[test]
+    fn json_omits_cancelled_after_when_no_cancellation() {
+        // Byte-equal-prior-output guarantee: a route that did not
+        // cancel must NOT carry the `cancelled_after` key. Same shape
+        // as the `auth` field omission for unauthenticated runs.
+        let rr = fixture_route(); // No cancellation in this fixture.
+        let summary = summarize(std::slice::from_ref(&rr), Duration::from_millis(50));
+        let mut buf: Vec<u8> = Vec::new();
+        print_json_report(&mut buf, "http://localhost:5000", None, &[rr], &summary).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            !s.contains("\"cancelled_after\""),
+            "cancelled_after must not appear when no cancel fired: {s}"
+        );
+        assert!(
+            !s.contains("\"cancelled_kind\""),
+            "cancelled_kind must not appear when no vectors were cancelled: {s}"
+        );
+    }
+
+    #[test]
+    fn human_report_shows_cancelled_after_line_dim() {
+        // Honest UI: the user must see the cancellation notice in the
+        // human report so they don't mistake a cancel for an
+        // incomplete scan. Pin the trigger label + skip count.
+        let rr = fixture_route_with_cancel();
+        let summary = summarize(std::slice::from_ref(&rr), Duration::from_millis(50));
+        let mut buf: Vec<u8> = Vec::new();
+        print_human_report(&mut buf, "http://localhost:5000", &[rr], &summary, true).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        // The dim notice. Em-dash is the visual separator between the
+        // trigger and the skip count.
+        assert!(
+            s.contains("cancelled after [XSS] script tag"),
+            "missing cancellation notice: {s}"
+        );
+        assert!(s.contains("2 vector(s) skipped"), "missing skip count: {s}");
+    }
+
+    #[test]
+    fn human_report_marks_cancelled_vectors_with_dashes_not_blocks() {
+        // Cancelled rows must use a distinct mark (`--`) — not `ok`
+        // or `!!` — so users skimming the report can see at a glance
+        // which vectors actually ran.
+        let rr = fixture_route_with_cancel();
+        let summary = summarize(std::slice::from_ref(&rr), Duration::from_millis(50));
+        let mut buf: Vec<u8> = Vec::new();
+        print_human_report(&mut buf, "http://localhost:5000", &[rr], &summary, true).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        // The two cancelled rows should each carry the `--` marker.
+        assert!(
+            s.contains("-- [SQL Injection] OR bypass"),
+            "skipped row missing -- mark: {s}"
+        );
+        assert!(
+            s.contains("-- [Path Traversal] etc/passwd"),
+            "in-flight row missing -- mark: {s}"
+        );
+    }
+
+    #[test]
+    fn human_report_does_not_emit_curl_for_cancelled_vectors() {
+        // The curl reproducer is a "go reproduce this finding" tool;
+        // emitting it for a vector that was never tested would mislead.
+        let rr = fixture_route_with_cancel();
+        let summary = summarize(std::slice::from_ref(&rr), Duration::from_millis(50));
+        let mut buf: Vec<u8> = Vec::new();
+        print_human_report(&mut buf, "http://localhost:5000", &[rr], &summary, true).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        // The XSS payload (which DID land as vulnerable) should have
+        // its curl emitted; the OR-bypass and path-traversal payloads
+        // (cancelled) must NOT show in any curl line.
+        assert!(
+            s.contains("curl -fsSL"),
+            "expected at least one curl line: {s}"
+        );
+        assert!(
+            !s.contains("OR '1'='1'"),
+            "blocked OR-bypass payload leaked into curl: {s}"
+        );
+        assert!(
+            !s.contains("/etc/passwd"),
+            "cancelled path-traversal payload leaked into curl: {s}"
+        );
+    }
+
+    #[test]
+    fn summary_excludes_cancelled_vectors_from_all_counters() {
+        // Cancelled vectors didn't run; counting them anywhere in the
+        // summary is a lie. Pin the honest accounting AND the
+        // self-consistency invariant `total_vectors == total_blocked +
+        // total_vulnerable` — so day-over-day summary diffs stay
+        // internally consistent regardless of where cancel landed.
+        // Fixture has 3 slots: 1 vulnerable XSS trigger + 2 cancelled.
+        // Probed count = 1.
+        let rr = fixture_route_with_cancel();
+        let summary = summarize(std::slice::from_ref(&rr), Duration::from_millis(50));
+        assert_eq!(summary.total_vectors, 1, "should count probed only");
+        assert_eq!(summary.total_blocked, 0);
+        assert_eq!(summary.total_vulnerable, 1);
+        // Self-consistency invariant.
+        assert_eq!(
+            summary.total_vectors,
+            summary.total_blocked + summary.total_vulnerable
+        );
+    }
+
+    #[test]
+    fn summary_invariant_holds_when_no_cancellation() {
+        // Self-consistency invariant must hold regardless of cancel
+        // policy. Pin the no-cancel case so the regression bar covers
+        // both paths.
+        let rr = fixture_route(); // 1 vuln XSS, 1 blocked SQL, no cancel.
+        let summary = summarize(std::slice::from_ref(&rr), Duration::from_millis(50));
+        assert_eq!(summary.total_vectors, 2);
+        assert_eq!(summary.total_blocked, 1);
+        assert_eq!(summary.total_vulnerable, 1);
+        assert_eq!(
+            summary.total_vectors,
+            summary.total_blocked + summary.total_vulnerable
+        );
     }
 }

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/mod.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/mod.rs
@@ -40,5 +40,8 @@ pub use login::{execute_login, LoginConfig, LoginError};
 pub use payloads::{
     attack_categories, AttackCategory, AttackVector, BLOCKED_STATUS_CODES, DEFAULT_FIELDS,
 };
-pub use probe::{scan_route, send_one, RouteResult, ScanOptions, VectorResult};
+pub use probe::{
+    scan_route, send_one, CancelInfo, CancelKind, CancelMode, RouteResult, ScanOptions,
+    VectorResult,
+};
 pub use repro::format_curl;

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/probe.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/probe.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use reqwest::{Client, Method};
 use serde_json::Value;
-use tokio::sync::Semaphore;
+use tokio::sync::{watch, Semaphore};
 
 use super::auth::AuthConfig;
 use super::classifier::classify;
@@ -30,7 +30,81 @@ const PROBE_PAYLOAD: &str = "hello";
 /// Same cap as Python's `ThreadPoolExecutor(max_workers=10)`.
 const MAX_CONCURRENCY: usize = 10;
 
+/// Cancel-trigger policy for one scan run. `FirstVuln` (default) cuts
+/// the per-route fan-out short as soon as any vector lands as confirmed
+/// vulnerable (reflection in a 2xx response — see [`classify`]); `Never`
+/// runs every active vector to completion regardless. Connection
+/// errors, 3xx, 4xx (including 404), and 5xx do NOT trigger cancel —
+/// only the "got through" reflection case does, so the cancel signal
+/// never fires on infrastructure noise.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CancelMode {
+    /// Cancel siblings on first confirmed reflection finding.
+    #[default]
+    FirstVuln,
+    /// Disable cancellation; run every vector to completion.
+    Never,
+}
+
+/// How a vector got cancelled. Two cases — see
+/// [`VectorResult::cancelled_kind`] for the full schema contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancelKind {
+    /// Permit-blocked vector that was never started; cancel fired
+    /// while the task was waiting for a semaphore permit. No request
+    /// was sent.
+    Skipped,
+    /// Vector whose request was in flight when cancel fired; the
+    /// future was dropped at a `select!` await point. The request may
+    /// or may not have reached the server.
+    InFlight,
+}
+
+impl CancelKind {
+    /// Wire-format string. Stable contract — pinned by tests against
+    /// the literal output. New variants MUST extend this `match` AND
+    /// the [`VectorResult::cancelled_kind`] doc-comment in lockstep.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Skipped => "skipped",
+            Self::InFlight => "in_flight",
+        }
+    }
+}
+
+/// Identity of the finding that triggered route-level cancellation
+/// plus the count of vectors that did not run as a result. Surfaces
+/// in JSON output as the per-route `cancelled_after` block; see
+/// [`RouteResult::cancelled_after`] for the locked schema.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CancelInfo {
+    pub category: String,
+    pub label: String,
+    pub vectors_skipped: usize,
+}
+
 /// Result of one attack vector against one route.
+///
+/// `cancelled_kind` is `None` for vectors that completed normally
+/// (request sent, classifier ran). It's `Some` only when the vector
+/// was short-circuited by [`CancelMode::FirstVuln`] cancellation —
+/// either skipped pre-permit or aborted in flight. See
+/// [`CancelKind`] for the variant contract.
+///
+/// **Locked schema (JSON output).** `cancelled_kind` is rendered into
+/// the per-vector JSON object as `"cancelled_kind"` (snake_case) when
+/// `Some`. The string values are exactly `"skipped"` or `"in_flight"`,
+/// matching [`CancelKind::as_str`]. The key is **omitted entirely**
+/// when `None` so prior JSON output stays byte-equal for non-cancel
+/// runs. Future cancel kinds MUST extend the `CancelKind` enum AND
+/// add a bullet to that doc-comment — never add sibling keys to the
+/// vector object.
+///
+/// On cancelled vectors: `status == 0`, `blocked == false`,
+/// `note == "skipped (cancelled)"` or `"cancelled in-flight"`. These
+/// rows still occupy their original index in `RouteResult::vectors`
+/// so consumers see the full task set in original order — slot
+/// preservation is a load-bearing contract.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VectorResult {
     pub category: String,
@@ -39,6 +113,7 @@ pub struct VectorResult {
     pub status: u16,
     pub blocked: bool,
     pub note: String,
+    pub cancelled_kind: Option<CancelKind>,
 }
 
 /// Result of scanning one route (probe + all active vectors).
@@ -47,6 +122,15 @@ pub struct VectorResult {
 /// string when the route never reached the vector dispatch stage. Carried
 /// here so renderers (human + JSON) can build a faithful `curl`
 /// reproducer per vector — see `scan::repro::format_curl`.
+///
+/// **Locked schema (JSON output).** `cancelled_after` is rendered into
+/// the per-route JSON object as `"cancelled_after"` (snake_case) when
+/// `Some`, with shape `{"category": String, "label": String,
+/// "vectors_skipped": Number}`. The key is **omitted entirely** when
+/// `None` so prior JSON output stays byte-equal for runs that did not
+/// trigger cancellation. Future cancel-related metadata MUST extend
+/// this struct AND update this doc-comment in lockstep — never add
+/// sibling keys to the route object.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RouteResult {
     pub method: String,
@@ -55,6 +139,7 @@ pub struct RouteResult {
     pub error: Option<String>,
     pub field: String,
     pub vectors: Vec<VectorResult>,
+    pub cancelled_after: Option<CancelInfo>,
 }
 
 /// Caller-supplied options for [`scan_route`]. Names mirror the Python
@@ -72,6 +157,9 @@ pub struct ScanOptions<'a> {
     /// the bearer token (and, in follow-up commits, cookies + login
     /// artifacts) injected on every probe + vector request.
     pub auth: Option<&'a AuthConfig>,
+    /// Speculative-cancellation policy. See [`CancelMode`]. The CLI
+    /// surfaces this as `--cancel-on first-vuln|never`.
+    pub cancel_on: CancelMode,
 }
 
 /// Send one HTTP request with `payload` injected into `field`. Returns
@@ -213,6 +301,16 @@ pub async fn scan_route(
     let field = Arc::new(working_field);
     let method = Arc::new(method.to_string());
     let timeout = options.timeout;
+    let cancel_mode = options.cancel_on;
+
+    // Cancellation channel. `watch` retains the latest value so a task
+    // that subscribes after `tx.send(true)` still sees `true` on the
+    // initial `rx.borrow()` check — the property `Notify::notify_waiters`
+    // does not have. `Sender::send` returns `Err` only after every
+    // receiver drops, which never happens while spawned tasks live;
+    // ignored via `.ok()` either way (idempotent, multi-fire safe).
+    let (cancel_tx, _initial_rx) = watch::channel(false);
+    let cancel_tx = Arc::new(cancel_tx);
 
     let mut handles: Vec<tokio::task::JoinHandle<(usize, VectorResult)>> =
         Vec::with_capacity(tasks.len());
@@ -222,21 +320,57 @@ pub async fn scan_route(
         let url = url.clone();
         let field = field.clone();
         let method = method.clone();
+        let cancel_tx = cancel_tx.clone();
+        let mut cancel_rx = cancel_tx.subscribe();
         handles.push(tokio::spawn(async move {
             let _permit = sem.acquire_owned().await.expect("semaphore not closed");
-            let (status, body) = send_one(&client, &url, &method, &field, &payload, timeout).await;
-            let cls = classify(status, &body, &payload);
-            (
-                idx,
-                VectorResult {
-                    category: cat,
-                    label,
-                    payload,
-                    status,
-                    blocked: cls.blocked,
-                    note: cls.note,
-                },
-            )
+
+            // Pre-flight check: cancel may have fired while this task
+            // was permit-blocked. Skip the request entirely and emit a
+            // synthetic `Skipped` row so original-task ordering is
+            // preserved in the result vector.
+            if *cancel_rx.borrow() {
+                return (
+                    idx,
+                    cancelled_vector_result(cat, label, payload, CancelKind::Skipped),
+                );
+            }
+
+            // `biased` so the cancel arm wins ties — when both are
+            // ready in the same poll, we prefer to abort the request
+            // rather than record a normal completion.
+            tokio::select! {
+                biased;
+                _ = cancel_rx.changed() => {
+                    (idx, cancelled_vector_result(cat, label, payload, CancelKind::InFlight))
+                }
+                (status, body) = send_one(&client, &url, &method, &field, &payload, timeout) => {
+                    let cls = classify(status, &body, &payload);
+                    let blocked = cls.blocked;
+                    let vr = VectorResult {
+                        category: cat,
+                        label,
+                        payload,
+                        status,
+                        blocked,
+                        note: cls.note,
+                        cancelled_kind: None,
+                    };
+                    // Fire cancel signal on confirmed reflection: a 2xx
+                    // response that was NOT classified as blocked. This
+                    // excludes connection errors (status==0), 3xx, 4xx
+                    // (including 404), and 5xx — none of which are
+                    // confirmed bypasses. Idempotent across concurrent
+                    // hits (watch retains "true" once set).
+                    if matches!(cancel_mode, CancelMode::FirstVuln)
+                        && !blocked
+                        && (200..300).contains(&status)
+                    {
+                        let _ = cancel_tx.send(true);
+                    }
+                    (idx, vr)
+                }
+            }
         }));
     }
 
@@ -249,7 +383,57 @@ pub async fn scan_route(
         }
     }
     result.vectors = slots.into_iter().flatten().collect();
+
+    // Identify the cancellation trigger by walking the original-order
+    // slots and picking the first vulnerable finding. Race-free even
+    // if multiple tasks completed with vuln before the watch propagated:
+    // the lowest-indexed one wins, which is deterministic on re-run.
+    if matches!(cancel_mode, CancelMode::FirstVuln) {
+        let skipped = result
+            .vectors
+            .iter()
+            .filter(|v| v.cancelled_kind.is_some())
+            .count();
+        if skipped > 0 {
+            if let Some(trigger) = result.vectors.iter().find(|v| {
+                v.cancelled_kind.is_none() && !v.blocked && (200..300).contains(&v.status)
+            }) {
+                result.cancelled_after = Some(CancelInfo {
+                    category: trigger.category.clone(),
+                    label: trigger.label.clone(),
+                    vectors_skipped: skipped,
+                });
+            }
+        }
+    }
+
     result
+}
+
+/// Build a synthetic `VectorResult` for a cancellation-short-circuited
+/// vector. Status zeroed (no request reached the wire reliably);
+/// `blocked` is `false` because we did NOT confirm the server blocks
+/// this payload — the row is a placeholder that preserves task order
+/// without claiming a fact we never tested.
+fn cancelled_vector_result(
+    category: String,
+    label: String,
+    payload: String,
+    kind: CancelKind,
+) -> VectorResult {
+    let note = match kind {
+        CancelKind::Skipped => "skipped (cancelled)".into(),
+        CancelKind::InFlight => "cancelled in-flight".into(),
+    };
+    VectorResult {
+        category,
+        label,
+        payload,
+        status: 0,
+        blocked: false,
+        note,
+        cancelled_kind: Some(kind),
+    }
 }
 
 #[cfg(test)]
@@ -421,6 +605,7 @@ mod tests {
             categories: None,
             thorough: false,
             auth: None,
+            cancel_on: CancelMode::FirstVuln,
         };
         let rr = scan_route(&format!("http://{addr}"), "POST", "/api/login", &opts).await;
         assert!(!rr.reachable);
@@ -437,6 +622,7 @@ mod tests {
             categories: None,
             thorough: false,
             auth: None,
+            cancel_on: CancelMode::FirstVuln,
         };
         let rr = scan_route(&format!("http://{addr}"), "POST", "/missing", &opts).await;
         assert!(!rr.reachable);
@@ -468,6 +654,7 @@ mod tests {
             categories: Some(&cats),
             thorough: false,
             auth: None,
+            cancel_on: CancelMode::FirstVuln,
         };
         let rr = scan_route(&format!("http://{addr}"), "POST", "/api/x", &opts).await;
         assert!(rr.reachable);
@@ -504,6 +691,7 @@ mod tests {
             categories: None, // all categories
             thorough: false,
             auth: None,
+            cancel_on: CancelMode::FirstVuln,
         };
         let rr = scan_route(&format!("http://{addr}"), "POST", "/api/x", &opts).await;
         assert!(rr.reachable);
@@ -581,6 +769,7 @@ mod tests {
             categories: Some(&cats),
             thorough: false,
             auth: Some(&auth),
+            cancel_on: CancelMode::FirstVuln,
         };
         let _ = scan_route(&server.url(), "POST", "/api/test", &opts).await;
 
@@ -609,6 +798,7 @@ mod tests {
             categories: Some(&cats),
             thorough: false,
             auth: None,
+            cancel_on: CancelMode::FirstVuln,
         };
         let _ = scan_route(&server.url(), "POST", "/api/test", &opts).await;
 
@@ -644,6 +834,7 @@ mod tests {
             categories: Some(&cats),
             thorough: false,
             auth: Some(&auth),
+            cancel_on: CancelMode::FirstVuln,
         };
         let _ = scan_route(&server.url(), "POST", "/api/test", &opts).await;
 
@@ -685,6 +876,7 @@ mod tests {
             categories: Some(&cats),
             thorough: false,
             auth: Some(&auth),
+            cancel_on: CancelMode::FirstVuln,
         };
         let _ = scan_route(&server.url(), "POST", "/api/test", &opts).await;
 
@@ -710,5 +902,307 @@ mod tests {
                 Some("session=abc; csrf=xyz")
             );
         }
+    }
+
+    // -------- speculative-cancellation tests --------
+
+    #[test]
+    fn cancel_kind_as_str_pins_wire_format() {
+        // The `as_str` strings are the JSON wire format. Pinned here so
+        // a refactor that renames a variant doesn't silently break the
+        // documented schema downstream consumers depend on.
+        assert_eq!(CancelKind::Skipped.as_str(), "skipped");
+        assert_eq!(CancelKind::InFlight.as_str(), "in_flight");
+    }
+
+    #[test]
+    fn cancel_mode_default_is_first_vuln() {
+        // Default-on cancellation is the locked policy (item 9). If
+        // someone flips this default, every existing call site that
+        // omits the field changes behaviour silently — pin it.
+        assert_eq!(CancelMode::default(), CancelMode::FirstVuln);
+    }
+
+    /// Mock that reflects the request body verbatim in its response so
+    /// the classifier sees the payload and rules `reflected (200)` —
+    /// the only classifier outcome that triggers cancellation. Adds a
+    /// configurable per-request delay to model slow vector probes.
+    async fn spawn_reflecting_mock(delay: Duration) -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 16_384];
+                    let n = match sock.read(&mut buf).await {
+                        Ok(n) => n,
+                        Err(_) => return,
+                    };
+                    let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                    // Echo the request back as the response body so any
+                    // payload contained in the request is "reflected".
+                    let body = req;
+                    tokio::time::sleep(delay).await;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = sock.write_all(resp.as_bytes()).await;
+                    let _ = sock.shutdown().await;
+                });
+            }
+        });
+        addr
+    }
+
+    #[tokio::test]
+    async fn cancel_fires_on_first_vuln_in_thorough_mode_with_wall_clock_budget() {
+        // Reflecting server with an 800ms per-request delay — so a scan
+        // that fires every vector serially would take many seconds.
+        // With cancellation on, the first reflected vuln (~800ms,
+        // limited by the slowest in the first concurrency batch) fires
+        // cancel, and the remaining vectors short-circuit. Budget is
+        // a loose 2.0s ceiling that cleanly separates "cancelled"
+        // (~800ms) from "all 27 ran" (~3 batches × 800ms ≈ 2.4s+).
+        // Loose enough to survive Windows-under-load jitter.
+        let addr = spawn_reflecting_mock(Duration::from_millis(800)).await;
+        let opts = ScanOptions {
+            fields: &["q"],
+            timeout: Duration::from_secs(5),
+            categories: None,
+            thorough: true,
+            auth: None,
+            cancel_on: CancelMode::FirstVuln,
+        };
+
+        let start = std::time::Instant::now();
+        let rr = scan_route(&format!("http://{addr}"), "POST", "/api/x", &opts).await;
+        let elapsed = start.elapsed();
+
+        assert!(rr.reachable);
+        assert!(rr.error.is_none());
+        // Cancellation must have fired — the reflecting server makes
+        // every payload classify as vulnerable.
+        let info = rr.cancelled_after.expect("cancel should have triggered");
+        assert!(info.vectors_skipped > 0, "expected non-zero skipped count");
+        // Wall-clock: well under "all 27 vectors ran" budget.
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "cancellation did not save wall-clock time: elapsed={elapsed:?}"
+        );
+
+        // At least one vector must carry a cancellation marker so JSON
+        // consumers can see what was short-circuited.
+        let cancelled_count = rr
+            .vectors
+            .iter()
+            .filter(|v| v.cancelled_kind.is_some())
+            .count();
+        assert!(cancelled_count > 0, "no vectors were marked cancelled");
+        assert_eq!(cancelled_count, info.vectors_skipped);
+    }
+
+    #[tokio::test]
+    async fn cancel_disabled_runs_all_vectors_even_when_vulnerable() {
+        // Same reflecting server but with --cancel-on never. Every
+        // vector must run to completion — full coverage path.
+        let addr = spawn_reflecting_mock(Duration::from_millis(20)).await;
+        let opts = ScanOptions {
+            fields: &["q"],
+            timeout: Duration::from_secs(5),
+            categories: None,
+            thorough: true,
+            auth: None,
+            cancel_on: CancelMode::Never,
+        };
+
+        let rr = scan_route(&format!("http://{addr}"), "POST", "/api/x", &opts).await;
+        assert!(rr.reachable);
+        assert!(
+            rr.cancelled_after.is_none(),
+            "Never mode must not produce cancelled_after; got: {:?}",
+            rr.cancelled_after
+        );
+        // No vector may carry a cancellation marker.
+        let cancelled = rr
+            .vectors
+            .iter()
+            .filter(|v| v.cancelled_kind.is_some())
+            .count();
+        assert_eq!(cancelled, 0, "Never mode left {cancelled} cancelled rows");
+        // Thorough = 27 vectors total (4+4+3+4+4+4+2+2). All must be
+        // present, in original task order.
+        assert_eq!(rr.vectors.len(), 27);
+    }
+
+    #[tokio::test]
+    async fn cancelled_vectors_emit_synthetic_rows_in_original_task_order() {
+        // Run thorough mode against a reflecting server with a longish
+        // delay (so the concurrency window leaves clear skipped rows).
+        // Then assert: every result slot is filled (no flatten loss),
+        // categories appear in the original order, and every cancelled
+        // row keeps its category/label/payload from the task descriptor.
+        let addr = spawn_reflecting_mock(Duration::from_millis(400)).await;
+        let opts = ScanOptions {
+            fields: &["q"],
+            timeout: Duration::from_secs(5),
+            categories: None,
+            thorough: true,
+            auth: None,
+            cancel_on: CancelMode::FirstVuln,
+        };
+        let rr = scan_route(&format!("http://{addr}"), "POST", "/api/x", &opts).await;
+
+        // Thorough = 27 task descriptors. Every slot must be present —
+        // even cancelled ones. This pins the "skipped emit synthetic"
+        // contract.
+        assert_eq!(rr.vectors.len(), 27);
+
+        // Original-task-order categories — same expected sequence as
+        // `scan_route_preserves_task_order_under_concurrency`. The
+        // synthetic cancelled rows must keep their category from the
+        // task descriptor, not collapse to a placeholder.
+        let first_per_category: Vec<&str> = {
+            let mut seen = std::collections::HashSet::new();
+            let mut out = Vec::new();
+            for v in &rr.vectors {
+                if seen.insert(v.category.clone()) {
+                    out.push(v.category.as_str());
+                }
+            }
+            out
+        };
+        assert_eq!(
+            first_per_category,
+            vec![
+                "XSS",
+                "SQL Injection",
+                "SQL Blind",
+                "NoSQL Injection",
+                "Path Traversal",
+                "Command Injection",
+                "Prototype Pollution",
+                "LDAP Injection",
+            ]
+        );
+
+        // Cancelled rows: status 0, blocked false, note matches one of
+        // the two locked strings, payload non-empty.
+        for v in &rr.vectors {
+            if let Some(kind) = v.cancelled_kind {
+                assert_eq!(v.status, 0);
+                assert!(!v.blocked);
+                assert!(!v.payload.is_empty());
+                match kind {
+                    CancelKind::Skipped => assert_eq!(v.note, "skipped (cancelled)"),
+                    CancelKind::InFlight => assert_eq!(v.note, "cancelled in-flight"),
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_does_not_fire_when_all_vectors_blocked() {
+        // 400 to every payload — nothing classifies as vulnerable, no
+        // cancel fires. Pin the happy-path no-cancel contract.
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = counter.clone();
+        let addr = spawn_mock(move |_req: &str| {
+            let n = c.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                (200, "ok".into())
+            } else {
+                (400, "blocked".into())
+            }
+        })
+        .await;
+        let opts = ScanOptions {
+            fields: &["q"],
+            timeout: Duration::from_secs(2),
+            categories: None,
+            thorough: false,
+            auth: None,
+            cancel_on: CancelMode::FirstVuln,
+        };
+        let rr = scan_route(&format!("http://{addr}"), "POST", "/api/x", &opts).await;
+        assert!(rr.reachable);
+        assert!(rr.cancelled_after.is_none());
+        let cancelled = rr
+            .vectors
+            .iter()
+            .filter(|v| v.cancelled_kind.is_some())
+            .count();
+        assert_eq!(cancelled, 0);
+    }
+
+    #[tokio::test]
+    async fn cancel_does_not_fire_on_404_or_500_responses() {
+        // 200/empty for the probe so the route is reachable, then 500
+        // for every payload. 5xx is `!blocked` per classifier (note:
+        // "status 500") but is NOT a confirmed bypass — the cancel
+        // trigger is restricted to the 2xx-reflection case to avoid
+        // firing on infrastructure noise.
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = counter.clone();
+        let addr = spawn_mock(move |_req: &str| {
+            let n = c.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                (200, String::new())
+            } else {
+                (500, "boom".into())
+            }
+        })
+        .await;
+        let opts = ScanOptions {
+            fields: &["q"],
+            timeout: Duration::from_secs(2),
+            categories: None,
+            thorough: false,
+            auth: None,
+            cancel_on: CancelMode::FirstVuln,
+        };
+        let rr = scan_route(&format!("http://{addr}"), "POST", "/api/x", &opts).await;
+        assert!(rr.reachable);
+        assert!(
+            rr.cancelled_after.is_none(),
+            "5xx must not trigger cancel; got: {:?}",
+            rr.cancelled_after
+        );
+        // Every vector ran to completion with the 500 classification.
+        for v in &rr.vectors {
+            assert!(v.cancelled_kind.is_none());
+            assert_eq!(v.status, 500);
+            assert!(!v.blocked);
+            assert_eq!(v.note, "status 500");
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_info_identifies_first_vulnerable_finding_by_original_order() {
+        // The `cancelled_after` trigger is the LOWEST-indexed
+        // vulnerable finding, regardless of which task fired the
+        // watch first. With original task order = [XSS, SQL, ...],
+        // XSS is index 0. Reflecting server makes XSS vulnerable
+        // (and every other vector too, but the trigger reports the
+        // first by index). Pins the deterministic-rerun contract.
+        let addr = spawn_reflecting_mock(Duration::from_millis(50)).await;
+        let opts = ScanOptions {
+            fields: &["q"],
+            timeout: Duration::from_secs(5),
+            categories: None,
+            thorough: false,
+            auth: None,
+            cancel_on: CancelMode::FirstVuln,
+        };
+        let rr = scan_route(&format!("http://{addr}"), "POST", "/api/x", &opts).await;
+        let info = rr.cancelled_after.expect("cancel should have fired");
+        // First task descriptor in the table is XSS primary vector;
+        // its label is "script tag" (see payloads.rs).
+        assert_eq!(info.category, "XSS");
+        assert_eq!(info.label, "script tag");
+        assert!(info.vectors_skipped > 0);
     }
 }

--- a/packages/arcis-rust/crates/arcis-engine/src/scan/test_server.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/scan/test_server.rs
@@ -25,6 +25,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -43,11 +44,18 @@ pub struct RecordedRequest {
 /// Server response built by a handler closure. Headers are an ordered
 /// `Vec` (not a map) so duplicates such as multi-cookie `Set-Cookie:`
 /// emit multiple lines on the wire in registration order.
+///
+/// `delay` is applied AFTER the handler closure runs and BEFORE the
+/// response writes back to the wire — so handlers stay synchronous
+/// (the closure can't `.await`) while still letting tests model slow
+/// endpoints. Used by the speculative-cancellation tests in `probe`
+/// where one fast probe must complete before slow siblings finish.
 #[derive(Debug, Clone)]
 pub struct MockResponse {
     pub status: u16,
     pub headers: Vec<(String, String)>,
     pub body: String,
+    pub delay: Option<Duration>,
 }
 
 impl MockResponse {
@@ -58,6 +66,7 @@ impl MockResponse {
             status: 200,
             headers: Vec::new(),
             body: body.into(),
+            delay: None,
         }
     }
 
@@ -83,6 +92,17 @@ impl MockResponse {
     /// chain to emit multiple cookies on one response.
     pub fn set_cookie(self, cookie: &str) -> Self {
         self.with_header("Set-Cookie", cookie)
+    }
+
+    /// Delay this response by `d` before writing it to the wire.
+    /// Handler closures must stay synchronous (no `.await` allowed in
+    /// `Fn(&RecordedRequest) -> MockResponse`), so the sleep happens
+    /// inside `handle_connection` AFTER the closure returns. Each
+    /// connection is its own spawned task — delays do not block the
+    /// accept loop or other in-flight requests.
+    pub fn with_delay(mut self, d: Duration) -> Self {
+        self.delay = Some(d);
+        self
     }
 }
 
@@ -251,10 +271,14 @@ async fn handle_connection(mut sock: tokio::net::TcpStream, state: Arc<MockState
                 status: 404,
                 headers: Vec::new(),
                 body: String::new(),
+                delay: None,
             },
         }
     };
 
+    if let Some(d) = response.delay {
+        tokio::time::sleep(d).await;
+    }
     let _ = write_response(&mut sock, &response).await;
 }
 
@@ -397,6 +421,66 @@ mod tests {
         assert_eq!(captured[0].path, "/a");
         assert_eq!(captured[1].path, "/b");
         assert_eq!(captured[2].path, "/a?q=1");
+    }
+
+    #[tokio::test]
+    async fn mock_response_with_delay_actually_delays_response() {
+        // Validates the timing primitive that the speculative-cancel
+        // tests in `probe` rely on. Floor assertion only — we assert the
+        // wall-clock is AT LEAST the configured delay (minus a small
+        // jitter slack) to avoid flaking on under-load CI runners.
+        let server = MockServer::start().await;
+        server.on("GET", "/slow", |_req| {
+            MockResponse::ok("late").with_delay(Duration::from_millis(120))
+        });
+
+        let start = std::time::Instant::now();
+        let response = raw_request(server.addr(), "GET /slow HTTP/1.1\r\nHost: x\r\n\r\n").await;
+        let elapsed = start.elapsed();
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.ends_with("late"));
+        // Floor: response must take at least the configured delay (with
+        // a tiny slack for tokio timer granularity).
+        assert!(
+            elapsed >= Duration::from_millis(100),
+            "delay was not honored: elapsed={elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_response_delay_does_not_block_other_connections() {
+        // Two endpoints, one slow, one fast. Issued concurrently, the
+        // fast one must complete WITHOUT waiting for the slow one's
+        // delay. This pins the per-connection-task isolation that the
+        // speculative-cancel tests depend on (a fast probe must finish
+        // and trigger cancel BEFORE the slow probes get to write).
+        let server = MockServer::start().await;
+        server.on("GET", "/slow", |_req| {
+            MockResponse::ok("slow").with_delay(Duration::from_millis(800))
+        });
+        server.on("GET", "/fast", |_req| MockResponse::ok("fast"));
+
+        let addr = server.addr();
+        let slow = tokio::spawn(async move {
+            raw_request(addr, "GET /slow HTTP/1.1\r\nHost: x\r\n\r\n").await
+        });
+        let fast = tokio::spawn(async move {
+            raw_request(addr, "GET /fast HTTP/1.1\r\nHost: x\r\n\r\n").await
+        });
+
+        let fast_start = std::time::Instant::now();
+        let fast_resp = fast.await.unwrap();
+        let fast_elapsed = fast_start.elapsed();
+        assert!(fast_resp.ends_with("fast"));
+        // Fast endpoint must NOT pay the slow endpoint's delay budget.
+        assert!(
+            fast_elapsed < Duration::from_millis(400),
+            "fast endpoint blocked behind slow: elapsed={fast_elapsed:?}"
+        );
+
+        // Drain the slow handle so the test doesn't leak a join.
+        let _ = slow.await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Implements `cli-scan.md` Phase B item 9 — speculative cancellable dispatch. `scan_route` short-circuits remaining vector probes once a confirmed vulnerable finding lands, halving worst-case wall-clock on slow targets without sacrificing the original-task-order result contract.

* CLI: \`--cancel-on first-vuln|never\` (default \`first-vuln\`).
* Engine: watch::channel<bool> + \`tokio::select!\` cancellation in the per-route fan-out — zero new deps; \`JoinHandle::abort\` deliberately avoided so in-flight cancels can emit honest \`InFlight\` markers.
* JSON: per-route \`cancelled_after\` block + per-vector \`cancelled_kind\`. Keys omitted entirely when no cancel fired so prior output stays byte-equal.
* Mock fixture: \`MockResponse::with_delay(Duration)\` for the wall-clock budget tests.

## Design choices

**Cancel trigger pinned to confirmed reflection** — \`!blocked && (200..300).contains(&status)\`. 404, 5xx, 3xx, and connection errors do NOT fire cancel. Tested explicitly (\`cancel_does_not_fire_on_404_or_500_responses\`) so infrastructure noise stays quiet.

**Honest accounting** — skipped vectors retain their original slot in \`RouteResult.vectors\` (slot preservation contract). Summary excludes cancelled vectors from \`total_vectors\`, \`total_blocked\`, AND \`total_vulnerable\` so the invariant \`total_vectors == total_blocked + total_vulnerable\` holds regardless of where cancel landed — day-over-day summary diffs stay self-consistent.

**Locked schema** — \`RouteResult.cancelled_after\` and \`VectorResult.cancelled_kind\` carry doc-comment contracts mirroring the \`redact_for_json\` pattern. Sentinel-pinned literal-string tests against the serialized JSON guard against drift.

## Test plan

- [x] 24 new tests (10 engine, 14 CLI). Workspace: 334 engine + 125 CLI unit tests green.
- [x] \`cargo fmt --all -- --check\` clean.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] Wall-clock budget test in \`--thorough\` mode: reflecting server with 800ms delay → asserts total < 2s (vs. uncancelled ≥ 2.4s). Loose enough for Windows-under-load jitter.
- [x] \`json_emits_cancelled_after_block_when_cancel_fires\` — sentinel-pin checks for \`"cancelled_after"\`, \`"cancelled_kind"\`, \`"skipped"\`, \`"in_flight"\`, \`"vectors_skipped"\` literals in serialized output.
- [x] \`json_omits_cancelled_after_when_no_cancellation\` — byte-equal-prior-output pin.
- [x] \`help_text_documents_cancel_modes\` — pins \`--cancel-on MODE\`, \`first-vuln (default)\`, \`never\` literals + behaviour summary.
- [x] \`summary_excludes_cancelled_vectors_from_all_counters\` + \`summary_invariant_holds_when_no_cancellation\` — pin the self-consistency invariant in both cancel and no-cancel paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)