### PR TITLE
feat(rust-audit): baseline mode + diff (cli-audit.md items 8 + 9)

### DIFF
--- a/packages/arcis-rust/Cargo.lock
+++ b/packages/arcis-rust/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
  "arcis-engine",
  "clap",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/packages/arcis-rust/crates/arcis-cli/Cargo.toml
+++ b/packages/arcis-rust/crates/arcis-cli/Cargo.toml
@@ -22,3 +22,10 @@ serde_json = { workspace = true }
 # Async runtime for `arcis scan`. Runtime is constructed once in scan.rs
 # and dropped after the run; the rest of the CLI stays synchronous.
 tokio = { workspace = true }
+
+[dev-dependencies]
+# End-to-end CLI tests under `tests/` need scratch dirs for fixtures
+# and baseline files. Already present in `arcis-engine`'s dev-deps;
+# adding here for the new `tests/audit_baseline.rs` integration suite
+# (cli-audit.md item 9b).
+tempfile = "3.10"

--- a/packages/arcis-rust/crates/arcis-cli/src/audit.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/audit.rs
@@ -326,6 +326,11 @@ pub fn run(argv: &[String]) -> ExitCode {
                     severity_filter: args.severity,
                     suppressed: 0,
                     ignored: ignored_count,
+                    // cli-audit.md item 9 (9b): baseline mode plumbing.
+                    // 9a ships the engine surface; CLI is still
+                    // baseline-unaware so we pass the disabled defaults.
+                    baseline: None,
+                    resolved_findings: &[],
                 })
             } else {
                 render_sarif(&SarifReport {
@@ -426,6 +431,11 @@ pub fn run(argv: &[String]) -> ExitCode {
                 severity_filter: args.severity,
                 suppressed: suppressed_total,
                 ignored: ignored_count,
+                // cli-audit.md item 9 (9b): baseline mode plumbing
+                // lands in the next commit. 9a leaves the CLI
+                // baseline-unaware; the engine surface is in place.
+                baseline: None,
+                resolved_findings: &[],
             })
         } else {
             render_sarif(&SarifReport {

--- a/packages/arcis-rust/crates/arcis-cli/src/audit.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/audit.rs
@@ -14,9 +14,10 @@ use std::process::ExitCode;
 use std::time::Instant;
 
 use arcis_engine::audit::{
-    assign_ids, collect_files_with_options, detect_language, render_json, render_sarif,
-    rules as compiled_rules, scan_file_with_suppression, Finding, IgnoreOptions, JsonReport,
-    Language, SarifReport, Severity,
+    assign_ids, classify_baseline, collect_files_with_options, detect_language, render_json,
+    render_sarif, rules as compiled_rules, scan_file_with_suppression, Baseline, BaselineEntry,
+    BaselineError, BaselineSummary, Finding, IgnoreOptions, JsonReport, Language, SarifReport,
+    Severity,
 };
 
 const TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -39,6 +40,17 @@ struct Args {
     /// stays active. Useful in monorepos with broad gitignore lines
     /// over vendored dirs you do want to scan. Mirrors ripgrep.
     no_gitignore: bool,
+    /// `--baseline <path>`: read mode. Read a baseline JSON file,
+    /// classify current findings against it, suppress unchanged from
+    /// output. Exit code reflects added findings only. Mutually
+    /// exclusive with [`Self::baseline_write`] — see cli-audit.md
+    /// item 9.
+    baseline: Option<PathBuf>,
+    /// `--baseline-write <path>`: write mode. Run a normal scan, then
+    /// write a baseline JSON snapshot to `path` (atomic via deterministic
+    /// `<path>.tmp` rename). Always exits 0 — recording IS success by
+    /// definition. Mutually exclusive with [`Self::baseline`].
+    baseline_write: Option<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -61,6 +73,8 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
     let mut sarif_output = false;
     let mut no_ignore = false;
     let mut no_gitignore = false;
+    let mut baseline: Option<PathBuf> = None;
+    let mut baseline_write: Option<PathBuf> = None;
 
     let mut iter = argv.iter().enumerate();
     while let Some((_, arg)) = iter.next() {
@@ -73,6 +87,46 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
             "--sarif" => sarif_output = true,
             "--no-ignore" => no_ignore = true,
             "--no-gitignore" => no_gitignore = true,
+            // cli-audit.md item 9: baseline mode (read). Mutex with
+            // `--baseline-write` is enforced HERE at parse time, not
+            // post-parse, so the error message can name the second
+            // (offending) flag — easier to find when editing a config
+            // or a long argv. The first-given flag always "wins" the
+            // semantic slot; the second one is the one we point at.
+            "--baseline" => match iter.next() {
+                Some((_, v)) => {
+                    if baseline_write.is_some() {
+                        return ParseOutcome::Err(
+                            "arcis audit: --baseline conflicts with --baseline-write \
+                             (already given) — pick one: read OR write a baseline, not both"
+                                .into(),
+                        );
+                    }
+                    baseline = Some(PathBuf::from(v));
+                }
+                None => {
+                    return ParseOutcome::Err(
+                        "arcis audit: --baseline requires a path argument".into(),
+                    );
+                }
+            },
+            "--baseline-write" => match iter.next() {
+                Some((_, v)) => {
+                    if baseline.is_some() {
+                        return ParseOutcome::Err(
+                            "arcis audit: --baseline-write conflicts with --baseline \
+                             (already given) — pick one: read OR write a baseline, not both"
+                                .into(),
+                        );
+                    }
+                    baseline_write = Some(PathBuf::from(v));
+                }
+                None => {
+                    return ParseOutcome::Err(
+                        "arcis audit: --baseline-write requires a path argument".into(),
+                    );
+                }
+            },
             "--language" | "-l" => match iter.next() {
                 Some((_, v)) => match Language::parse(v) {
                     Some(l) => language = Some(l),
@@ -128,6 +182,8 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
         sarif_output,
         no_ignore,
         no_gitignore,
+        baseline,
+        baseline_write,
     })
 }
 
@@ -196,6 +252,39 @@ fn print_help<W: Write>(out: &mut W) -> io::Result<()> {
     writeln!(
         out,
         "      --no-gitignore   Disable .gitignore only; keep .arcisignore active."
+    )?;
+    writeln!(
+        out,
+        "      --baseline PATH  Read mode: classify findings against PATH; suppress unchanged,"
+    )?;
+    writeln!(
+        out,
+        "                       fail only on new ones. Resolved findings reported as a positive"
+    )?;
+    writeln!(
+        out,
+        "                       signal. Mutually exclusive with --baseline-write."
+    )?;
+    writeln!(out, "      --baseline-write PATH")?;
+    writeln!(
+        out,
+        "                       Write mode: record current findings to PATH as a baseline JSON"
+    )?;
+    writeln!(
+        out,
+        "                       file (atomic write). Always exits 0. Mutually exclusive with"
+    )?;
+    writeln!(
+        out,
+        "                       --baseline. Note: --severity applies BEFORE diff classification —"
+    )?;
+    writeln!(
+        out,
+        "                       writing a baseline at one severity then reading at a stricter one"
+    )?;
+    writeln!(
+        out,
+        "                       will surface the lower-severity entries as resolved."
     )?;
     writeln!(out, "  -h, --help           Show this message and exit.")?;
     Ok(())
@@ -314,6 +403,9 @@ pub fn run(argv: &[String]) -> ExitCode {
             let by_lang: BTreeMap<String, usize> = BTreeMap::new();
             let by_sev: BTreeMap<Severity, usize> = BTreeMap::new();
             let out = if args.json_output {
+                // No-files-found path: baseline mode is moot — there's
+                // nothing to diff. Emit the empty document with no
+                // baseline block regardless of `--baseline*` flags.
                 render_json(&JsonReport {
                     tool_version: TOOL_VERSION,
                     target: &target_str,
@@ -326,9 +418,6 @@ pub fn run(argv: &[String]) -> ExitCode {
                     severity_filter: args.severity,
                     suppressed: 0,
                     ignored: ignored_count,
-                    // cli-audit.md item 9 (9b): baseline mode plumbing.
-                    // 9a ships the engine surface; CLI is still
-                    // baseline-unaware so we pass the disabled defaults.
                     baseline: None,
                     resolved_findings: &[],
                 })
@@ -406,16 +495,122 @@ pub fn run(argv: &[String]) -> ExitCode {
     // Deterministic finding ids — `<RULE_ID>-<16hex>` over
     // `(rule_id, relpath, line, snippet)`. Pinned to the user's input
     // path so `arcis audit .` and `arcis audit /abs/repo` produce the
-    // same id for the same source line. cli-audit.md item 10.
+    // same id for the same source line. cli-audit.md item 10. MUST
+    // run before baseline classification — the diff is keyed on `id`.
     assign_ids(&mut findings, &path);
 
-    // Per-severity counts. Sorted by Severity Ord so the JSON
-    // `bySeverity` map keys come out in [critical, high, medium, low]
-    // order — matches Python's audit.py once the sort tweak lands.
+    // ── cli-audit.md item 9: --baseline-write (terminal branch in
+    // human mode; falls through with forced exit 0 in machine mode so
+    // the user gets BOTH the recorded baseline AND the JSON/SARIF
+    // output a CI pipeline expects). Mutex with --baseline is
+    // enforced parse-side; can't both be set here.
+    let baseline_write_succeeded = if let Some(write_path) = args.baseline_write.as_ref() {
+        let new_baseline = Baseline::from_findings(&findings, TOOL_VERSION);
+        if let Err(e) = new_baseline.write(write_path) {
+            let _ = writeln!(stderr_lock, "arcis audit: {e}");
+            return ExitCode::from(2);
+        }
+        if !args.quiet && !machine_mode {
+            let _ = writeln!(
+                stderr_lock,
+                "wrote baseline to {} ({} finding(s))",
+                write_path.display(),
+                new_baseline.findings.len(),
+            );
+        }
+        if !machine_mode {
+            // Pure write run with human stdout: nothing more to print.
+            // Recording is success — exit 0 even if findings exist.
+            return ExitCode::from(0);
+        }
+        true
+    } else {
+        false
+    };
+
+    // ── cli-audit.md item 9: --baseline (read mode). Reads the
+    // baseline file, classifies current findings against it, replaces
+    // `findings` with diff.added so the rest of the render path
+    // naturally surfaces NEW findings only. Resolved + unchanged are
+    // surfaced via the BaselineSummary block, not the findings array.
+    //
+    // Backing String storage lives at this scope so the `&str` refs
+    // in the borrowed BaselineSummary outlive the JsonReport build.
+    let mut baseline_path_owned: Option<String> = None;
+    let mut baseline_created_owned: Option<String> = None;
+    let mut baseline_added_count: usize = 0;
+    let mut baseline_resolved_count: usize = 0;
+    let mut baseline_unchanged_count: usize = 0;
+    let mut baseline_stale_count: usize = 0;
+    let mut resolved_entries: Vec<BaselineEntry> = Vec::new();
+
+    if let Some(read_path) = args.baseline.as_ref() {
+        let baseline_doc = match Baseline::read(read_path) {
+            Ok(b) => b,
+            Err(BaselineError::NotFound(p)) => {
+                let _ = writeln!(stderr_lock, "arcis audit: baseline file not found: {p}");
+                return ExitCode::from(2);
+            }
+            Err(e) => {
+                let _ = writeln!(stderr_lock, "arcis audit: {e}");
+                return ExitCode::from(2);
+            }
+        };
+        let diff = classify_baseline(&findings, &baseline_doc);
+
+        // Stale-rule warning is informational — doesn't fail the run,
+        // just surfaces orphaned baseline rows (rule deleted/renamed
+        // since the baseline was written). Quiet/machine modes get a
+        // count via summary.baseline.staleCount, not a stderr line.
+        if !args.quiet && !machine_mode && diff.stale_count > 0 {
+            let _ = writeln!(
+                stderr_lock,
+                "warning: baseline has {} stale {} (rule no longer in registry: {})",
+                diff.stale_count,
+                if diff.stale_count == 1 {
+                    "entry"
+                } else {
+                    "entries"
+                },
+                diff.stale_rule_ids.join(", "),
+            );
+        }
+
+        baseline_path_owned = Some(read_path.display().to_string());
+        baseline_created_owned = Some(baseline_doc.created_at);
+        baseline_added_count = diff.added.len();
+        baseline_resolved_count = diff.resolved.len();
+        baseline_unchanged_count = diff.unchanged_count;
+        baseline_stale_count = diff.stale_count;
+        findings = diff.added;
+        resolved_entries = diff.resolved;
+    }
+
+    // Per-severity counts over the (possibly diffed) findings vec.
+    // Sorted by Severity Ord so the JSON `bySeverity` map keys come
+    // out in [critical, high, medium, low] order — matches Python's
+    // audit.py once the sort tweak lands.
     let mut by_severity: BTreeMap<Severity, usize> = BTreeMap::new();
     for f in &findings {
         *by_severity.entry(f.severity).or_insert(0) += 1;
     }
+
+    // Borrow-bridge: BaselineSummary's `&str`s point into the owned
+    // strings declared above. Same scope, same lifetime — safe.
+    let baseline_summary = match (
+        baseline_path_owned.as_ref(),
+        baseline_created_owned.as_ref(),
+    ) {
+        (Some(p), Some(c)) => Some(BaselineSummary {
+            path: p.as_str(),
+            created_at: c.as_str(),
+            added: baseline_added_count,
+            resolved_count: baseline_resolved_count,
+            unchanged_count: baseline_unchanged_count,
+            stale_count: baseline_stale_count,
+        }),
+        _ => None,
+    };
 
     if machine_mode {
         let out = if args.json_output {
@@ -431,13 +626,14 @@ pub fn run(argv: &[String]) -> ExitCode {
                 severity_filter: args.severity,
                 suppressed: suppressed_total,
                 ignored: ignored_count,
-                // cli-audit.md item 9 (9b): baseline mode plumbing
-                // lands in the next commit. 9a leaves the CLI
-                // baseline-unaware; the engine surface is in place.
-                baseline: None,
-                resolved_findings: &[],
+                baseline: baseline_summary.as_ref(),
+                resolved_findings: &resolved_entries,
             })
         } else {
+            // SARIF schema has no baseline block; the diffed findings
+            // slice naturally surfaces "new" results only when in
+            // baseline mode, which is what GitHub Code Scanning wants
+            // anyway (it computes the rest from partialFingerprints).
             render_sarif(&SarifReport {
                 tool_version: TOOL_VERSION,
                 target_abspath: &target_str,
@@ -445,7 +641,11 @@ pub fn run(argv: &[String]) -> ExitCode {
             })
         };
         let _ = writeln!(stdout_lock, "{out}");
-        return if findings.is_empty() {
+        // --baseline-write owns the exit code: always 0 (recording IS
+        // success). Otherwise, classic "exit 1 on findings, 0 on
+        // clean" — and in baseline read mode `findings` IS diff.added
+        // so the same expression already gates on new only.
+        return if baseline_write_succeeded || findings.is_empty() {
             ExitCode::from(0)
         } else {
             ExitCode::from(1)
@@ -467,6 +667,8 @@ pub fn run(argv: &[String]) -> ExitCode {
         duration_ms,
         suppressed_total,
         ignored_count,
+        baseline_summary.as_ref(),
+        &resolved_entries,
     );
 
     if findings.is_empty() {
@@ -489,6 +691,8 @@ fn print_human_report<W: Write>(
     duration_ms: u64,
     suppressed: usize,
     ignored: usize,
+    baseline_summary: Option<&BaselineSummary<'_>>,
+    resolved_entries: &[BaselineEntry],
 ) -> io::Result<()> {
     writeln!(out)?;
     writeln!(out, "  Arcis Audit")?;
@@ -511,6 +715,16 @@ fn print_human_report<W: Write>(
     writeln!(out, "  Files:    {} scanned ({})", files.len(), breakdown)?;
     if let Some(s) = severity_filter {
         writeln!(out, "  Filter:   severity >= {}", s.as_str())?;
+    }
+    // cli-audit.md item 9: header gains a baseline line in baseline
+    // mode so users see at-a-glance which file was diffed against and
+    // a punch-card of the result.
+    if let Some(bs) = baseline_summary {
+        writeln!(
+            out,
+            "  Baseline: {} ({} new, {} resolved, {} unchanged)",
+            bs.path, bs.added, bs.resolved_count, bs.unchanged_count
+        )?;
     }
     writeln!(
         out,
@@ -595,6 +809,30 @@ fn print_human_report<W: Write>(
         writeln!(out, "    Files ignored   {ignored}")?;
     }
     writeln!(out, "    Time            {duration_ms}ms")?;
+
+    // cli-audit.md item 9: Summary block gains baseline lines in
+    // baseline mode — resolved is shown even at 0 (positive signal is
+    // the point), stale gated on > 0 (warning, not the common case).
+    if let Some(bs) = baseline_summary {
+        writeln!(out)?;
+        writeln!(out, "    Baseline        {}", bs.path)?;
+        writeln!(out, "    New             {}", bs.added)?;
+        writeln!(out, "    Unchanged       {}", bs.unchanged_count)?;
+        writeln!(out, "    Resolved        {}", bs.resolved_count)?;
+        if bs.stale_count > 0 {
+            writeln!(out, "    Stale entries   {}", bs.stale_count)?;
+        }
+        // Per-line resolved list (each up to 80-ish chars). Helpful for
+        // a human auditor; machine consumers get the structured data
+        // via the top-level `resolvedFindings` array.
+        if !resolved_entries.is_empty() {
+            writeln!(out)?;
+            writeln!(out, "  Resolved findings")?;
+            for e in resolved_entries {
+                writeln!(out, "    {} {}:{}", e.rule_id, e.file, e.line)?;
+            }
+        }
+    }
     Ok(())
 }
 
@@ -736,6 +974,8 @@ mod tests {
             42,
             7,
             0,
+            None,
+            &[],
         )
         .unwrap();
         let out = String::from_utf8(buf).unwrap();
@@ -765,6 +1005,8 @@ mod tests {
             42,
             0,
             0,
+            None,
+            &[],
         )
         .unwrap();
         let out = String::from_utf8(buf).unwrap();
@@ -857,6 +1099,8 @@ mod tests {
             42,
             0,
             5,
+            None,
+            &[],
         )
         .unwrap();
         let out = String::from_utf8(buf).unwrap();
@@ -883,12 +1127,151 @@ mod tests {
             42,
             0,
             0,
+            None,
+            &[],
         )
         .unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(
             !out.contains("Files ignored"),
             "Files ignored line should not appear when count is 0, got:\n{out}"
+        );
+    }
+
+    // ── baseline mode (cli-audit.md item 9) ───────────────────────────
+
+    #[test]
+    fn parse_args_baseline_flag() {
+        match parse_args(&[
+            ".".to_string(),
+            "--baseline".to_string(),
+            "b.json".to_string(),
+        ]) {
+            ParseOutcome::Args(a) => {
+                assert_eq!(a.baseline, Some(PathBuf::from("b.json")));
+                assert!(a.baseline_write.is_none());
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_baseline_write_flag() {
+        match parse_args(&[
+            ".".to_string(),
+            "--baseline-write".to_string(),
+            "out.json".to_string(),
+        ]) {
+            ParseOutcome::Args(a) => {
+                assert_eq!(a.baseline_write, Some(PathBuf::from("out.json")));
+                assert!(a.baseline.is_none());
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_baseline_then_write_errors_pointing_to_second_flag() {
+        // User asked for --baseline first, then --baseline-write — the
+        // second flag is the offender. The error message MUST name it
+        // by its long form so a user editing a config file or a long
+        // argv can spot the offending line at a glance.
+        let r = parse_args(&[
+            ".".to_string(),
+            "--baseline".to_string(),
+            "b.json".to_string(),
+            "--baseline-write".to_string(),
+            "w.json".to_string(),
+        ]);
+        match r {
+            ParseOutcome::Err(msg) => {
+                assert!(
+                    msg.contains("--baseline-write"),
+                    "second flag --baseline-write must appear in error: {msg}"
+                );
+                assert!(
+                    msg.contains("conflicts with --baseline"),
+                    "error must point at the prior flag for context: {msg}"
+                );
+                assert!(
+                    msg.contains("read OR write"),
+                    "error should explain WHY the mutex exists: {msg}"
+                );
+            }
+            other => panic!("expected mutex error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_write_then_baseline_errors_pointing_to_second_flag() {
+        // Inverse order — `--baseline-write` first, then `--baseline`.
+        // Now `--baseline` is the second/offending flag.
+        let r = parse_args(&[
+            ".".to_string(),
+            "--baseline-write".to_string(),
+            "w.json".to_string(),
+            "--baseline".to_string(),
+            "b.json".to_string(),
+        ]);
+        match r {
+            ParseOutcome::Err(msg) => {
+                assert!(
+                    msg.contains("--baseline"),
+                    "second flag --baseline must appear in error: {msg}"
+                );
+                assert!(
+                    msg.contains("conflicts with --baseline-write"),
+                    "error must point at the prior flag for context: {msg}"
+                );
+            }
+            other => panic!("expected mutex error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_baseline_without_path_errors() {
+        let r = parse_args(&[".".to_string(), "--baseline".to_string()]);
+        assert!(matches!(r, ParseOutcome::Err(msg) if msg.contains("requires a path")));
+    }
+
+    #[test]
+    fn parse_args_baseline_write_without_path_errors() {
+        let r = parse_args(&[".".to_string(), "--baseline-write".to_string()]);
+        assert!(matches!(r, ParseOutcome::Err(msg) if msg.contains("requires a path")));
+    }
+
+    #[test]
+    fn help_text_documents_baseline_flags() {
+        // Refinement #3: help-text pin. Future help-text refactors that
+        // drop these fail loudly. Asserts BOTH flags appear, the mutex
+        // note is surfaced, AND a one-liner explaining diff
+        // classification (the "fail only on new" semantic) is present.
+        let mut buf: Vec<u8> = Vec::new();
+        print_help(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains("--baseline "),
+            "help must mention --baseline (with trailing space, not as a prefix match for --baseline-write)"
+        );
+        assert!(
+            out.contains("--baseline-write"),
+            "help must mention --baseline-write"
+        );
+        assert!(
+            out.to_lowercase().contains("mutually exclusive"),
+            "help must surface the --baseline / --baseline-write mutex: {out}"
+        );
+        // "Fail only on new" semantic — the user-visible reason to use
+        // baseline mode at all. Keep the assertion permissive so a
+        // wording polish doesn't trip it.
+        assert!(
+            out.to_lowercase().contains("new")
+                && (out.to_lowercase().contains("fail") || out.to_lowercase().contains("exit")),
+            "help must explain the diff classification (fail/exit on NEW only): {out}"
+        );
+        assert!(
+            out.to_lowercase().contains("resolved"),
+            "help must surface the resolved-as-positive-signal contract: {out}"
         );
     }
 }

--- a/packages/arcis-rust/crates/arcis-cli/tests/audit_baseline.rs
+++ b/packages/arcis-rust/crates/arcis-cli/tests/audit_baseline.rs
@@ -1,0 +1,522 @@
+//! End-to-end CLI tests for cli-audit.md item 9 (baseline mode) and
+//! item 8 standalone (`--severity`).
+//!
+//! These spawn the actual `arcis` binary via `CARGO_BIN_EXE_arcis` so
+//! the assertions cover argv parsing, mutex enforcement, file IO,
+//! exit codes, and JSON shape end-to-end. Unit tests in `audit.rs`
+//! cover individual fns; this file pins the user-visible contract.
+//!
+//! ## Fixture conventions
+//!
+//! * Each test uses its own [`tempfile::TempDir`] for hermetic source
+//!   trees and baseline files.
+//! * Source fixtures use real audit rule patterns so the scanner
+//!   actually fires (`eval(...)` → `EVAL-EXEC` critical, `yaml.load(f)`
+//!   → `YAML-UNSAFE` high). Avoids stubbing the engine.
+//! * Baseline files are JSON the test writes directly when it needs
+//!   to pin specific contents (e.g. stale-rule case, version mismatch);
+//!   otherwise we round-trip via `--baseline-write`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+const ARCIS_BIN: &str = env!("CARGO_BIN_EXE_arcis");
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+struct RunOutput {
+    stdout: String,
+    stderr: String,
+    code: i32,
+}
+
+fn run_audit(cwd: &Path, args: &[&str]) -> RunOutput {
+    let out = Command::new(ARCIS_BIN)
+        .arg("audit")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("spawn arcis audit");
+    RunOutput {
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        code: out.status.code().unwrap_or(-1),
+    }
+}
+
+fn write_fixture(td: &Path, rel: &str, body: &str) -> PathBuf {
+    let p = td.join(rel);
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&p, body).unwrap();
+    p
+}
+
+/// A Python source body that fires multiple rules at known severities.
+/// Used as the "before" snapshot in drift tests.
+const PY_MIXED: &str = "\
+import yaml
+def parse(s):
+    return yaml.load(s)
+
+def run(expr):
+    return eval(expr)
+";
+
+/// Two findings — same shape as `PY_MIXED` but no `eval`. Used as the
+/// "after fixing critical" snapshot in resolved-finding tests.
+const PY_YAML_ONLY: &str = "\
+import yaml
+def parse(s):
+    return yaml.load(s)
+
+def run(expr):
+    return parse(expr)
+";
+
+// ── Round-trip ─────────────────────────────────────────────────────────────
+
+#[test]
+fn baseline_write_then_read_roundtrip_no_new_findings() {
+    let td = tempfile::TempDir::new().unwrap();
+    let src = td.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    write_fixture(&src, "a.py", PY_MIXED);
+
+    let baseline_path = td.path().join("base.json");
+
+    // Pass 1: write baseline.
+    let r1 = run_audit(
+        td.path(),
+        &[
+            "src",
+            "--baseline-write",
+            baseline_path.to_str().unwrap(),
+            "--quiet",
+        ],
+    );
+    assert_eq!(r1.code, 0, "write run must exit 0 (recording is success)");
+    assert!(
+        baseline_path.exists(),
+        "baseline file should have been written"
+    );
+    let raw = std::fs::read_to_string(&baseline_path).unwrap();
+    let v: Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(v["version"], Value::from(1));
+    assert!(v["createdAt"].as_str().unwrap().ends_with('Z'));
+    assert!(
+        v["findings"].as_array().unwrap().len() >= 2,
+        "expected at least 2 baseline entries, got {raw}"
+    );
+
+    // Pass 2: read baseline. No source change → zero added → exit 0.
+    let r2 = run_audit(
+        td.path(),
+        &[
+            "src",
+            "--baseline",
+            baseline_path.to_str().unwrap(),
+            "--json",
+        ],
+    );
+    assert_eq!(
+        r2.code, 0,
+        "round-trip read must exit 0 with no new findings (got {}: stderr={})",
+        r2.code, r2.stderr
+    );
+    let doc: Value = serde_json::from_str(&r2.stdout).unwrap();
+    assert_eq!(doc["summary"]["baseline"]["added"], Value::from(0));
+    assert!(
+        doc["summary"]["baseline"]["unchangedCount"]
+            .as_u64()
+            .unwrap()
+            >= 2
+    );
+    assert_eq!(doc["findings"].as_array().unwrap().len(), 0);
+    assert_eq!(doc["resolvedFindings"].as_array().unwrap().len(), 0);
+}
+
+// ── Drift +1 ───────────────────────────────────────────────────────────────
+
+#[test]
+fn baseline_diff_detects_added_finding() {
+    let td = tempfile::TempDir::new().unwrap();
+    let src = td.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    write_fixture(&src, "a.py", PY_YAML_ONLY);
+
+    let baseline_path = td.path().join("base.json");
+
+    // Pass 1: write baseline at the "before adding eval" state.
+    let r1 = run_audit(
+        td.path(),
+        &[
+            "src",
+            "--baseline-write",
+            baseline_path.to_str().unwrap(),
+            "--quiet",
+        ],
+    );
+    assert_eq!(r1.code, 0);
+
+    // Mutate source: add an eval call (= a new EVAL-EXEC finding).
+    std::fs::write(src.join("a.py"), PY_MIXED).unwrap();
+
+    // Pass 2: diff. Expect exit 1 + exactly one added finding.
+    let r2 = run_audit(
+        td.path(),
+        &[
+            "src",
+            "--baseline",
+            baseline_path.to_str().unwrap(),
+            "--json",
+        ],
+    );
+    assert_eq!(
+        r2.code, 1,
+        "expected exit 1 on new finding, got {}: stderr={}",
+        r2.code, r2.stderr
+    );
+    let doc: Value = serde_json::from_str(&r2.stdout).unwrap();
+    assert_eq!(doc["summary"]["baseline"]["added"], Value::from(1));
+    let arr = doc["findings"].as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["ruleId"], Value::from("EVAL-EXEC"));
+}
+
+// ── Drift -1 (resolved) ────────────────────────────────────────────────────
+
+#[test]
+fn baseline_diff_detects_resolved_finding() {
+    let td = tempfile::TempDir::new().unwrap();
+    let src = td.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    write_fixture(&src, "a.py", PY_MIXED);
+
+    let baseline_path = td.path().join("base.json");
+    let r1 = run_audit(
+        td.path(),
+        &[
+            "src",
+            "--baseline-write",
+            baseline_path.to_str().unwrap(),
+            "--quiet",
+        ],
+    );
+    assert_eq!(r1.code, 0);
+
+    // Remove the eval — EVAL-EXEC finding goes away.
+    std::fs::write(src.join("a.py"), PY_YAML_ONLY).unwrap();
+
+    let r2 = run_audit(
+        td.path(),
+        &[
+            "src",
+            "--baseline",
+            baseline_path.to_str().unwrap(),
+            "--json",
+        ],
+    );
+    assert_eq!(
+        r2.code, 0,
+        "resolved-only run must NOT fail (positive signal): code={} stderr={}",
+        r2.code, r2.stderr
+    );
+    let doc: Value = serde_json::from_str(&r2.stdout).unwrap();
+    assert_eq!(doc["summary"]["baseline"]["added"], Value::from(0));
+    assert_eq!(doc["summary"]["baseline"]["resolvedCount"], Value::from(1));
+    let resolved = doc["resolvedFindings"].as_array().unwrap();
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(resolved[0]["ruleId"], Value::from("EVAL-EXEC"));
+}
+
+// ── Severity × baseline (item 8 fold-in) ───────────────────────────────────
+
+#[test]
+fn severity_filter_applies_before_baseline_classification() {
+    // Severity-filter runs BEFORE diff classification. A baseline
+    // captured at default severity contains a YAML-UNSAFE (high) AND
+    // a JSONP-CALLBACK (medium). Re-running with `--severity high`
+    // filters the medium out of the current run, so it surfaces as
+    // resolved relative to the baseline — even though the source
+    // didn't change. Documented behavior; pin it here.
+    let td = tempfile::TempDir::new().unwrap();
+    let src = td.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+
+    // Mixed-severity source: high (yaml.load) + medium (JSONP via
+    // request.args.get('callback')).
+    write_fixture(
+        &src,
+        "a.py",
+        "\
+import yaml
+def parse(s):
+    return yaml.load(s)
+
+def jsonp(request):
+    cb = request.args.get('callback')
+    return cb
+",
+    );
+
+    let baseline_path = td.path().join("base.json");
+    let r1 = run_audit(
+        td.path(),
+        &[
+            "src",
+            "--baseline-write",
+            baseline_path.to_str().unwrap(),
+            "--quiet",
+        ],
+    );
+    assert_eq!(r1.code, 0);
+
+    // Filter to high+ AND diff. Medium baseline entry must surface
+    // as resolved even though the code path still exists.
+    let r2 = run_audit(
+        td.path(),
+        &[
+            "src",
+            "--severity",
+            "high",
+            "--baseline",
+            baseline_path.to_str().unwrap(),
+            "--json",
+        ],
+    );
+    let doc: Value = serde_json::from_str(&r2.stdout).unwrap();
+    assert_eq!(doc["severityFilter"], Value::from("high"));
+    let resolved = doc["resolvedFindings"].as_array().unwrap();
+    let resolved_rule_ids: Vec<&str> = resolved
+        .iter()
+        .map(|e| e.get("ruleId").and_then(Value::as_str).unwrap_or(""))
+        .collect();
+    assert!(
+        resolved_rule_ids.contains(&"JSONP-CALLBACK"),
+        "medium-severity baseline entry should surface as resolved when filtered out by --severity high; got {resolved_rule_ids:?}",
+    );
+    assert_eq!(
+        r2.code, 0,
+        "no NEW findings → exit 0 even though the medium entry is now classified as resolved"
+    );
+}
+
+// ── Standalone --severity (item 8 independent pin per refinement #1) ───────
+
+#[test]
+fn severity_filter_applies_to_findings_without_baseline() {
+    // Pins the standalone --severity behavior independently of the
+    // baseline machinery, so a future refactor to baseline-mode can't
+    // silently break the `--severity` contract.
+    let td = tempfile::TempDir::new().unwrap();
+    let src = td.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+
+    // Mixed: critical (eval) + high (yaml.load) + medium (jsonp).
+    write_fixture(
+        &src,
+        "a.py",
+        "\
+import yaml
+
+def run(expr):
+    return eval(expr)
+
+def parse(s):
+    return yaml.load(s)
+
+def jsonp(request):
+    cb = request.args.get('callback')
+    return cb
+",
+    );
+
+    let r = run_audit(td.path(), &["src", "--severity", "high", "--json"]);
+    assert_eq!(r.code, 1, "findings present → exit 1: stderr={}", r.stderr);
+    let doc: Value = serde_json::from_str(&r.stdout).unwrap();
+    assert_eq!(doc["severityFilter"], Value::from("high"));
+    let arr = doc["findings"].as_array().unwrap();
+    let rule_ids: Vec<&str> = arr.iter().map(|e| e["ruleId"].as_str().unwrap()).collect();
+    // critical + high pass; medium dropped.
+    assert!(
+        rule_ids.contains(&"EVAL-EXEC"),
+        "critical EVAL-EXEC must pass `--severity high`: {rule_ids:?}"
+    );
+    assert!(
+        rule_ids.contains(&"YAML-UNSAFE"),
+        "high YAML-UNSAFE must pass `--severity high`: {rule_ids:?}"
+    );
+    assert!(
+        !rule_ids.contains(&"JSONP-CALLBACK"),
+        "medium JSONP-CALLBACK must be dropped by `--severity high`: {rule_ids:?}"
+    );
+    // Sanity: no baseline block, no resolvedFindings key.
+    assert!(doc["summary"].get("baseline").is_none());
+    assert!(doc.get("resolvedFindings").is_none());
+}
+
+// ── Stale rule ─────────────────────────────────────────────────────────────
+
+#[test]
+fn baseline_with_stale_rule_id_warns_but_does_not_fail() {
+    let td = tempfile::TempDir::new().unwrap();
+    let src = td.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    // Clean source — no current findings. Isolates the stale-baseline
+    // signal so we test it without an added finding muddying the exit
+    // code. The fixture HAS to be clean: a current finding becomes a
+    // NEW (in current, not in baseline) entry and pushes exit to 1,
+    // which is a different code path than the one this test pins.
+    write_fixture(&src, "a.py", "def hello():\n    return 1\n");
+
+    // Hand-craft a baseline whose rule_id no longer exists in the
+    // registry. classify() must surface staleCount > 0 + the rule
+    // name, but exit code stays 0 (no NEW findings) — staleness is
+    // informational, not a failure.
+    let baseline_path = td.path().join("base.json");
+    let stale = r#"{
+        "version": 1,
+        "createdAt": "2026-05-07T00:00:00Z",
+        "toolVersion": "0.1.0",
+        "findings": [
+            {"id": "BOGUS-RULE-NEVER-EXISTED-1111111111111111",
+             "ruleId": "BOGUS-RULE-NEVER-EXISTED",
+             "file": "src/a.py",
+             "line": 1}
+        ]
+    }"#;
+    std::fs::write(&baseline_path, stale).unwrap();
+
+    let r = run_audit(
+        td.path(),
+        &[
+            "src",
+            "--baseline",
+            baseline_path.to_str().unwrap(),
+            "--json",
+        ],
+    );
+    let doc: Value = serde_json::from_str(&r.stdout).unwrap();
+    assert_eq!(doc["summary"]["baseline"]["staleCount"], Value::from(1));
+    // The stale entry has no current-run match, so it ALSO appears as
+    // resolved. Both count.
+    assert_eq!(doc["summary"]["baseline"]["resolvedCount"], Value::from(1));
+    assert_eq!(
+        r.code, 0,
+        "stale-only baseline must not fail the run: stderr={}",
+        r.stderr
+    );
+}
+
+// ── Schema errors ──────────────────────────────────────────────────────────
+
+#[test]
+fn baseline_unsupported_version_errors_with_exit_2() {
+    let td = tempfile::TempDir::new().unwrap();
+    let src = td.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    write_fixture(&src, "a.py", PY_YAML_ONLY);
+
+    let baseline_path = td.path().join("base.json");
+    std::fs::write(
+        &baseline_path,
+        r#"{
+            "version": 999,
+            "createdAt": "2026-05-07T00:00:00Z",
+            "toolVersion": "0.1.0",
+            "findings": []
+        }"#,
+    )
+    .unwrap();
+
+    let r = run_audit(
+        td.path(),
+        &["src", "--baseline", baseline_path.to_str().unwrap()],
+    );
+    assert_eq!(r.code, 2, "unsupported version → exit 2");
+    assert!(
+        r.stderr.contains("schema version") || r.stderr.contains("not supported"),
+        "stderr should explain the version mismatch: {}",
+        r.stderr
+    );
+}
+
+#[test]
+fn baseline_file_not_found_errors_with_exit_2() {
+    let td = tempfile::TempDir::new().unwrap();
+    let src = td.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    write_fixture(&src, "a.py", PY_YAML_ONLY);
+
+    let r = run_audit(td.path(), &["src", "--baseline", "does/not/exist.json"]);
+    assert_eq!(r.code, 2, "missing baseline → exit 2");
+    assert!(
+        r.stderr.contains("baseline file not found") || r.stderr.contains("not found"),
+        "stderr should mention the missing baseline: {}",
+        r.stderr
+    );
+}
+
+// ── Mutex (parse-side) ─────────────────────────────────────────────────────
+
+#[test]
+fn baseline_and_baseline_write_mutex_errors_with_second_flag_named() {
+    // Refinement: error message points to the second/offending flag
+    // by name so users editing a config can find it quickly.
+    let td = tempfile::TempDir::new().unwrap();
+    let r = run_audit(
+        td.path(),
+        &[".", "--baseline", "b.json", "--baseline-write", "w.json"],
+    );
+    assert_eq!(r.code, 2, "mutex violation → exit 2");
+    assert!(
+        r.stderr.contains("--baseline-write"),
+        "second flag must be named in the error: {}",
+        r.stderr
+    );
+    assert!(
+        r.stderr.contains("conflicts with --baseline"),
+        "error must show prior flag for context: {}",
+        r.stderr
+    );
+}
+
+// ── --baseline-write coexistence with machine modes ────────────────────────
+
+#[test]
+fn baseline_write_with_json_emits_both_file_and_machine_output() {
+    // --baseline-write + --json: write the file AND emit JSON to
+    // stdout (no diff filtering, since this is write mode). Exit 0.
+    let td = tempfile::TempDir::new().unwrap();
+    let src = td.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    write_fixture(&src, "a.py", PY_MIXED);
+
+    let baseline_path = td.path().join("base.json");
+    let r = run_audit(
+        td.path(),
+        &[
+            "src",
+            "--baseline-write",
+            baseline_path.to_str().unwrap(),
+            "--json",
+        ],
+    );
+    assert_eq!(r.code, 0, "write-mode always exits 0: stderr={}", r.stderr);
+    assert!(baseline_path.exists(), "baseline file must be written");
+
+    // stdout is valid JSON with the full findings (NO baseline block,
+    // since we wrote, didn't read).
+    let doc: Value = serde_json::from_str(&r.stdout).unwrap();
+    assert!(doc["summary"].get("baseline").is_none());
+    assert!(doc.get("resolvedFindings").is_none());
+    assert!(
+        doc["findings"].as_array().unwrap().len() >= 2,
+        "machine output must reflect ALL findings in write mode, got: {}",
+        r.stdout
+    );
+}

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/baseline.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/baseline.rs
@@ -1,0 +1,662 @@
+//! Baseline snapshots for `arcis audit` (cli-audit.md Phase B item 9).
+//!
+//! A baseline is a JSON record of a previous audit run's finding IDs.
+//! The CLI consumes one in two modes:
+//!
+//! * **Write** (`--baseline-write <path>`) — record current findings to
+//!   disk so future runs can compare against them. Always exit 0.
+//! * **Read** (`--baseline <path>`) — classify current findings against
+//!   the recorded set, emit only NEW ones, ignore unchanged, surface
+//!   resolved as a positive signal. Exit code reflects added only.
+//!
+//! Identity comes from [`super::finding_id`] — `<RULE_ID>-<16hex>` over
+//! `(rule_id, relpath, line, snippet.trim_end())`. Because `rule_id`
+//! participates in the hash, a rename of a rule produces a NEW id and
+//! falls into a paired resolved+added entry, NOT a stale entry. "Stale"
+//! is reserved for rule IDs that no longer appear in the registry at
+//! all (rule deleted or renamed without baseline regeneration).
+//!
+//! ## Hand-rolled timestamp duplication
+//!
+//! [`iso8601_utc`] duplicates the helper in `sca_sbom.rs`. Per the
+//! cross-track ADD-ONLY rule we don't reach into a sibling track's
+//! file to expose its private formatter; both copies will fold into a
+//! shared `arcis_engine::time` module after Phase 1 consolidates.
+
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use super::engine::Finding;
+use super::rules::rules as compiled_rules;
+
+/// Current baseline schema version. Bump if the on-disk shape of a
+/// baseline file changes incompatibly. [`Baseline::read`] enforces
+/// equality and returns [`BaselineError::UnsupportedVersion`] on
+/// mismatch.
+pub const BASELINE_SCHEMA_VERSION: u32 = 1;
+
+/// One entry in a baseline file. Carries enough to display a resolved
+/// finding in human output without rerunning the original scan, but no
+/// message / severity / snippet bodies — those are the current run's
+/// responsibility, not the baseline's.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BaselineEntry {
+    pub id: String,
+    #[serde(rename = "ruleId")]
+    pub rule_id: String,
+    pub file: String,
+    pub line: usize,
+}
+
+/// On-disk baseline snapshot.
+///
+/// **Locked schema (version 1).** This struct serializes to exactly
+/// these top-level keys, in this order:
+///
+/// 1. `version`     — integer, equal to [`BASELINE_SCHEMA_VERSION`]
+/// 2. `createdAt`   — ISO 8601 UTC string `YYYY-MM-DDTHH:MM:SSZ`
+/// 3. `toolVersion` — informational; never enforced on read
+/// 4. `findings`    — array of [`BaselineEntry`] in scan order
+///
+/// Each [`BaselineEntry`] serializes as `{id, ruleId, file, line}` —
+/// no other keys.
+///
+/// Future schema extensions MUST bump [`BASELINE_SCHEMA_VERSION`] AND
+/// add the field to the enumeration above. Adding a field without
+/// bumping the version is a contract break — older Arcis builds would
+/// silently ignore the new field and produce wrong diffs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Baseline {
+    pub version: u32,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "toolVersion")]
+    pub tool_version: String,
+    pub findings: Vec<BaselineEntry>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BaselineError {
+    #[error("baseline file not found: {0}")]
+    NotFound(String),
+    #[error("baseline file unreadable ({0}): {1}")]
+    Io(String, io::Error),
+    #[error("baseline file malformed ({0}): {1}")]
+    Malformed(String, serde_json::Error),
+    #[error("baseline schema version {0} not supported (this build expects {1})")]
+    UnsupportedVersion(u32, u32),
+}
+
+impl Baseline {
+    /// Build a baseline from current scan findings. Caller MUST have
+    /// already populated `Finding.id` via
+    /// [`super::finding_id::assign_ids`]; findings with an empty id are
+    /// skipped because the baseline could not recognise them on a
+    /// later run.
+    pub fn from_findings(findings: &[Finding], tool_version: &str) -> Self {
+        let entries: Vec<BaselineEntry> = findings
+            .iter()
+            .filter(|f| !f.id.is_empty())
+            .map(|f| BaselineEntry {
+                id: f.id.clone(),
+                rule_id: f.rule_id.to_string(),
+                file: f.file.clone(),
+                line: f.line,
+            })
+            .collect();
+        Self {
+            version: BASELINE_SCHEMA_VERSION,
+            created_at: iso8601_utc_now(),
+            tool_version: tool_version.to_string(),
+            findings: entries,
+        }
+    }
+
+    /// Read a baseline from disk. Returns typed errors for
+    /// missing-file, IO, malformed-JSON, and version-mismatch — the
+    /// CLI maps each to exit 2 with a specific stderr message.
+    pub fn read(path: &Path) -> Result<Self, BaselineError> {
+        let raw = match fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                return Err(BaselineError::NotFound(path.display().to_string()));
+            }
+            Err(e) => return Err(BaselineError::Io(path.display().to_string(), e)),
+        };
+        let parsed: Self = serde_json::from_str(&raw)
+            .map_err(|e| BaselineError::Malformed(path.display().to_string(), e))?;
+        if parsed.version != BASELINE_SCHEMA_VERSION {
+            return Err(BaselineError::UnsupportedVersion(
+                parsed.version,
+                BASELINE_SCHEMA_VERSION,
+            ));
+        }
+        Ok(parsed)
+    }
+
+    /// Atomically write the baseline to `path`.
+    ///
+    /// Strategy: write to `<path>.tmp` (deterministic suffix so a
+    /// crashed run leaves at most one easy-to-clean turd, never a
+    /// PID/nonce-suffixed pile), `sync_all`, then rename over the
+    /// destination. `std::fs::rename` is atomic on POSIX and uses
+    /// `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` on Windows for files
+    /// in the same directory — both atomic in the sense relevant here
+    /// (a reader either sees the old file or the new one, never a
+    /// half-written one).
+    pub fn write(&self, path: &Path) -> Result<(), BaselineError> {
+        let tmp = tmp_path(path);
+        let payload = serde_json::to_string_pretty(self)
+            .map_err(|e| BaselineError::Malformed(path.display().to_string(), e))?;
+        {
+            let mut f =
+                File::create(&tmp).map_err(|e| BaselineError::Io(tmp.display().to_string(), e))?;
+            f.write_all(payload.as_bytes())
+                .map_err(|e| BaselineError::Io(tmp.display().to_string(), e))?;
+            f.write_all(b"\n")
+                .map_err(|e| BaselineError::Io(tmp.display().to_string(), e))?;
+            f.sync_all()
+                .map_err(|e| BaselineError::Io(tmp.display().to_string(), e))?;
+        }
+        fs::rename(&tmp, path).map_err(|e| BaselineError::Io(path.display().to_string(), e))?;
+        Ok(())
+    }
+}
+
+fn tmp_path(path: &Path) -> PathBuf {
+    let mut s = path.as_os_str().to_os_string();
+    s.push(".tmp");
+    s.into()
+}
+
+/// Result of comparing a current scan's findings against a baseline.
+///
+/// `added` carries the full current [`Finding`] bodies — they will be
+/// surfaced in the JSON output and human report. `resolved` carries
+/// only the minimal records that were in the baseline; the original
+/// finding context is lost (not a regression — the baseline was the
+/// last record we kept of those findings).
+///
+/// `stale_rule_ids` is populated when a baseline entry's `ruleId` is
+/// not present in the current rule registry. Surfaced as a warning;
+/// never fails the run. Stale entries also flow through the
+/// resolved-vs-unchanged classification on `id` like any other entry —
+/// staleness is orthogonal to whether the id matches.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Diff {
+    pub added: Vec<Finding>,
+    pub resolved: Vec<BaselineEntry>,
+    pub unchanged_count: usize,
+    pub stale_count: usize,
+    pub stale_rule_ids: Vec<String>,
+}
+
+/// Classify `current` findings against `baseline`.
+///
+/// Identity is by [`Finding::id`] exclusively. A finding's id encodes
+/// `(rule_id, relpath, line, snippet)` so any of: rule rename, file
+/// move, line drift past the snippet, code edit on the offending line
+/// — surfaces as a paired resolved+added pair, the correct outcome.
+///
+/// Stale-baseline detection scans every baseline `ruleId` against the
+/// compiled rule registry; entries whose rule has been removed from
+/// the registry are counted in `stale_count` (and de-duplicated into
+/// `stale_rule_ids`) but still flow through the classification on `id`
+/// like any other entry. The CLI surfaces stale as a warning, not a
+/// failure.
+pub fn classify(current: &[Finding], baseline: &Baseline) -> Diff {
+    use std::collections::HashSet;
+
+    let baseline_ids: HashSet<&str> = baseline.findings.iter().map(|e| e.id.as_str()).collect();
+    let current_ids: HashSet<&str> = current.iter().map(|f| f.id.as_str()).collect();
+
+    let valid_rule_ids: HashSet<&str> = compiled_rules().iter().map(|r| r.id).collect();
+
+    let mut added: Vec<Finding> = Vec::new();
+    let mut unchanged_count = 0usize;
+    for f in current {
+        if baseline_ids.contains(f.id.as_str()) {
+            unchanged_count += 1;
+        } else {
+            added.push(f.clone());
+        }
+    }
+
+    let mut resolved: Vec<BaselineEntry> = Vec::new();
+    let mut stale_count = 0usize;
+    let mut stale_rule_ids: Vec<String> = Vec::new();
+    for entry in &baseline.findings {
+        if !current_ids.contains(entry.id.as_str()) {
+            resolved.push(entry.clone());
+        }
+        if !valid_rule_ids.contains(entry.rule_id.as_str()) {
+            stale_count += 1;
+            if !stale_rule_ids.contains(&entry.rule_id) {
+                stale_rule_ids.push(entry.rule_id.clone());
+            }
+        }
+    }
+    stale_rule_ids.sort();
+
+    Diff {
+        added,
+        resolved,
+        unchanged_count,
+        stale_count,
+        stale_rule_ids,
+    }
+}
+
+/// Compact summary of a baseline + diff, ready to render into the
+/// `--json` output's `summary.baseline` block. Owned by the engine so
+/// the render layer stays a pure serializer over scalar inputs.
+///
+/// **Locked schema (matches [`super::render::JsonReport`]).** This
+/// struct's fields map 1:1 to the keys emitted under `summary.baseline`
+/// in the JSON output:
+///
+/// - `path`           → `path`
+/// - `created_at`     → `createdAt`
+/// - `added`          → `added`
+/// - `resolved_count` → `resolvedCount`
+/// - `unchanged_count`→ `unchangedCount`
+/// - `stale_count`    → `staleCount`
+///
+/// Future fields MUST be added in BOTH places (here and the render
+/// site) AND get a doc-comment bullet here so the contract is auditable
+/// from the engine side without reading render.rs.
+pub struct BaselineSummary<'a> {
+    pub path: &'a str,
+    pub created_at: &'a str,
+    pub added: usize,
+    pub resolved_count: usize,
+    pub unchanged_count: usize,
+    pub stale_count: usize,
+}
+
+// ── ISO 8601 helper ────────────────────────────────────────────────────────
+
+fn iso8601_utc_now() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    iso8601_utc(secs)
+}
+
+/// Format `secs` since UNIX_EPOCH as `YYYY-MM-DDTHH:MM:SSZ`. Pure
+/// arithmetic via Howard Hinnant's civil-from-days algorithm; no
+/// chrono dep, no leap-second handling, valid for all proleptic
+/// Gregorian dates representable by `i64` days. Mirrors the helper in
+/// `sca_sbom.rs` (see module-doc note).
+fn iso8601_utc(secs: u64) -> String {
+    let days = (secs / 86_400) as i64;
+    let secs_of_day = secs % 86_400;
+    let hour = secs_of_day / 3600;
+    let minute = (secs_of_day % 3600) / 60;
+    let second = secs_of_day % 60;
+
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = (yoe as i64) + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if m <= 2 { y + 1 } else { y };
+    format!("{year:04}-{m:02}-{d:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::engine::Finding;
+    use crate::audit::rules::Severity;
+    use tempfile::TempDir;
+
+    // ── ISO 8601 ───────────────────────────────────────────────────────
+
+    #[test]
+    fn iso8601_at_epoch_zero() {
+        assert_eq!(iso8601_utc(0), "1970-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn iso8601_at_known_date() {
+        // 2026-01-01T00:00:00Z = 56*365 days + 14 leap days
+        // (1972,76,80,84,88,92,96,2000,04,08,12,16,20,24) since 1970,
+        // each day = 86_400s. 56*365 + 14 = 20_454. * 86_400 = 1_767_225_600.
+        assert_eq!(iso8601_utc(1_767_225_600), "2026-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn iso8601_with_hms_components() {
+        // 2026-01-01T05:07:13Z = 1_767_225_600 + 5*3600 + 7*60 + 13.
+        let secs = 1_767_225_600 + 5 * 3600 + 7 * 60 + 13;
+        assert_eq!(iso8601_utc(secs), "2026-01-01T05:07:13Z");
+    }
+
+    #[test]
+    fn iso8601_now_has_z_suffix_and_t_separator() {
+        let s = iso8601_utc_now();
+        assert!(s.ends_with('Z'), "missing Z suffix: {s}");
+        assert_eq!(s.chars().filter(|&c| c == 'T').count(), 1);
+        assert_eq!(s.len(), 20); // YYYY-MM-DDTHH:MM:SSZ
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    fn finding(id: &str, rule_id: &'static str, file: &str, line: usize) -> Finding {
+        Finding {
+            rule_id,
+            severity: Severity::High,
+            message: "msg",
+            file: file.to_string(),
+            line,
+            snippet: "x".to_string(),
+            id: id.to_string(),
+        }
+    }
+
+    fn entry(id: &str, rule_id: &str, file: &str, line: usize) -> BaselineEntry {
+        BaselineEntry {
+            id: id.to_string(),
+            rule_id: rule_id.to_string(),
+            file: file.to_string(),
+            line,
+        }
+    }
+
+    // ── from_findings ──────────────────────────────────────────────────
+
+    #[test]
+    fn from_findings_skips_empty_id_findings() {
+        // Findings with empty id can't be recognised on a re-run, so
+        // omitting them from the baseline is the right call — silently.
+        let mut f1 = finding("YAML-UNSAFE-aaaaaaaaaaaaaaaa", "YAML-UNSAFE", "a.py", 1);
+        let mut f2 = finding("", "YAML-UNSAFE", "b.py", 2);
+        f1.snippet = "yaml.load(f)".into();
+        f2.snippet = "yaml.load(g)".into();
+        let b = Baseline::from_findings(&[f1, f2], "0.1.0");
+        assert_eq!(b.findings.len(), 1);
+        assert_eq!(b.findings[0].file, "a.py");
+    }
+
+    #[test]
+    fn from_findings_records_id_ruleid_file_line() {
+        let f = finding(
+            "YAML-UNSAFE-deadbeefcafef00d",
+            "YAML-UNSAFE",
+            "src/a.py",
+            42,
+        );
+        let b = Baseline::from_findings(&[f], "0.1.0");
+        assert_eq!(b.findings[0].id, "YAML-UNSAFE-deadbeefcafef00d");
+        assert_eq!(b.findings[0].rule_id, "YAML-UNSAFE");
+        assert_eq!(b.findings[0].file, "src/a.py");
+        assert_eq!(b.findings[0].line, 42);
+        assert_eq!(b.tool_version, "0.1.0");
+        assert_eq!(b.version, BASELINE_SCHEMA_VERSION);
+    }
+
+    // ── write + read round-trip ────────────────────────────────────────
+
+    #[test]
+    fn round_trip_write_then_read_preserves_data() {
+        let td = TempDir::new().unwrap();
+        let p = td.path().join("baseline.json");
+        let original = Baseline {
+            version: 1,
+            created_at: "2026-05-07T12:00:00Z".into(),
+            tool_version: "0.1.0".into(),
+            findings: vec![
+                entry("YAML-UNSAFE-1111111111111111", "YAML-UNSAFE", "a.py", 1),
+                entry("EVAL-USAGE-2222222222222222", "EVAL-USAGE", "b.py", 7),
+            ],
+        };
+        original.write(&p).unwrap();
+        let loaded = Baseline::read(&p).unwrap();
+        assert_eq!(loaded, original);
+    }
+
+    #[test]
+    fn write_atomic_leaves_no_tmp_on_success() {
+        let td = TempDir::new().unwrap();
+        let p = td.path().join("baseline.json");
+        let b = Baseline {
+            version: 1,
+            created_at: "2026-05-07T12:00:00Z".into(),
+            tool_version: "0.1.0".into(),
+            findings: vec![],
+        };
+        b.write(&p).unwrap();
+        assert!(p.exists(), "baseline file missing");
+        let tmp = tmp_path(&p);
+        assert!(!tmp.exists(), "tmp turd left behind: {}", tmp.display());
+    }
+
+    #[test]
+    fn write_uses_deterministic_tmp_suffix() {
+        // Cleanup-after-crash relies on a single, predictable filename.
+        // PID/nonce suffixes would produce a pile of orphans on
+        // repeated crashes.
+        let p = Path::new("/some/dir/baseline.json");
+        assert_eq!(tmp_path(p).to_string_lossy(), "/some/dir/baseline.json.tmp");
+    }
+
+    #[test]
+    fn write_emits_locked_schema_keys_in_order() {
+        // The on-disk format is a contract. Pin the key order so a
+        // future serde-derive flag flip can't silently scramble it.
+        let td = TempDir::new().unwrap();
+        let p = td.path().join("baseline.json");
+        let b = Baseline {
+            version: 1,
+            created_at: "2026-05-07T12:00:00Z".into(),
+            tool_version: "0.1.0".into(),
+            findings: vec![entry(
+                "YAML-UNSAFE-1111111111111111",
+                "YAML-UNSAFE",
+                "a.py",
+                1,
+            )],
+        };
+        b.write(&p).unwrap();
+        let raw = fs::read_to_string(&p).unwrap();
+        let i_version = raw.find("\"version\"").unwrap();
+        let i_created = raw.find("\"createdAt\"").unwrap();
+        let i_tool = raw.find("\"toolVersion\"").unwrap();
+        let i_findings = raw.find("\"findings\"").unwrap();
+        assert!(i_version < i_created);
+        assert!(i_created < i_tool);
+        assert!(i_tool < i_findings);
+        // Entry shape: {id, ruleId, file, line}, in that order.
+        let i_id = raw.find("\"id\"").unwrap();
+        let i_rule = raw.find("\"ruleId\"").unwrap();
+        let i_file = raw.find("\"file\"").unwrap();
+        let i_line = raw.find("\"line\"").unwrap();
+        assert!(i_id < i_rule);
+        assert!(i_rule < i_file);
+        assert!(i_file < i_line);
+    }
+
+    // ── read errors ────────────────────────────────────────────────────
+
+    #[test]
+    fn read_missing_file_returns_typed_not_found() {
+        let td = TempDir::new().unwrap();
+        let p = td.path().join("never-existed.json");
+        let r = Baseline::read(&p);
+        assert!(matches!(r, Err(BaselineError::NotFound(_))));
+    }
+
+    #[test]
+    fn read_malformed_json_returns_typed_malformed() {
+        let td = TempDir::new().unwrap();
+        let p = td.path().join("baseline.json");
+        fs::write(&p, b"not json {{{").unwrap();
+        let r = Baseline::read(&p);
+        assert!(matches!(r, Err(BaselineError::Malformed(..))));
+    }
+
+    #[test]
+    fn read_unsupported_version_returns_typed_error() {
+        let td = TempDir::new().unwrap();
+        let p = td.path().join("baseline.json");
+        fs::write(
+            &p,
+            r#"{"version": 999, "createdAt": "2026-05-07T00:00:00Z", "toolVersion": "x", "findings": []}"#,
+        )
+        .unwrap();
+        let r = Baseline::read(&p);
+        match r {
+            Err(BaselineError::UnsupportedVersion(found, expected)) => {
+                assert_eq!(found, 999);
+                assert_eq!(expected, BASELINE_SCHEMA_VERSION);
+            }
+            other => panic!("expected UnsupportedVersion, got {other:?}"),
+        }
+    }
+
+    // ── classify ───────────────────────────────────────────────────────
+
+    fn baseline_with(entries: Vec<BaselineEntry>) -> Baseline {
+        Baseline {
+            version: 1,
+            created_at: "2026-05-07T00:00:00Z".into(),
+            tool_version: "0.1.0".into(),
+            findings: entries,
+        }
+    }
+
+    #[test]
+    fn classify_empty_baseline_all_added() {
+        let current = vec![
+            finding("YAML-UNSAFE-1111111111111111", "YAML-UNSAFE", "a.py", 1),
+            finding("EVAL-USAGE-2222222222222222", "EVAL-USAGE", "b.py", 2),
+        ];
+        let b = baseline_with(vec![]);
+        let d = classify(&current, &b);
+        assert_eq!(d.added.len(), 2);
+        assert_eq!(d.resolved.len(), 0);
+        assert_eq!(d.unchanged_count, 0);
+    }
+
+    #[test]
+    fn classify_empty_current_all_resolved() {
+        let current: Vec<Finding> = vec![];
+        let b = baseline_with(vec![entry(
+            "YAML-UNSAFE-1111111111111111",
+            "YAML-UNSAFE",
+            "a.py",
+            1,
+        )]);
+        let d = classify(&current, &b);
+        assert_eq!(d.added.len(), 0);
+        assert_eq!(d.resolved.len(), 1);
+        assert_eq!(d.unchanged_count, 0);
+    }
+
+    #[test]
+    fn classify_identity_all_unchanged() {
+        let current = vec![finding(
+            "YAML-UNSAFE-1111111111111111",
+            "YAML-UNSAFE",
+            "a.py",
+            1,
+        )];
+        let b = baseline_with(vec![entry(
+            "YAML-UNSAFE-1111111111111111",
+            "YAML-UNSAFE",
+            "a.py",
+            1,
+        )]);
+        let d = classify(&current, &b);
+        assert!(d.added.is_empty());
+        assert!(d.resolved.is_empty());
+        assert_eq!(d.unchanged_count, 1);
+    }
+
+    #[test]
+    fn classify_mixed_one_each() {
+        // current: u (unchanged), n (new). baseline: u, r (resolved).
+        let current = vec![
+            finding("YAML-UNSAFE-aaaaaaaaaaaaaaaa", "YAML-UNSAFE", "a.py", 1), // unchanged
+            finding("EVAL-USAGE-bbbbbbbbbbbbbbbb", "EVAL-USAGE", "b.py", 2),   // new
+        ];
+        let b = baseline_with(vec![
+            entry("YAML-UNSAFE-aaaaaaaaaaaaaaaa", "YAML-UNSAFE", "a.py", 1), // unchanged
+            entry("PICKLE-LOAD-cccccccccccccccc", "PICKLE-LOAD", "c.py", 3), // resolved
+        ]);
+        let d = classify(&current, &b);
+        assert_eq!(d.added.len(), 1);
+        assert_eq!(d.added[0].id, "EVAL-USAGE-bbbbbbbbbbbbbbbb");
+        assert_eq!(d.resolved.len(), 1);
+        assert_eq!(d.resolved[0].id, "PICKLE-LOAD-cccccccccccccccc");
+        assert_eq!(d.unchanged_count, 1);
+        assert_eq!(d.stale_count, 0);
+    }
+
+    #[test]
+    fn classify_stale_rule_id_bumps_stale_count() {
+        // A baseline entry whose ruleId no longer exists in the
+        // registry. stale_count counts every such entry, but
+        // stale_rule_ids dedups by rule.
+        let current: Vec<Finding> = vec![];
+        let b = baseline_with(vec![
+            entry(
+                "BOGUS-RULE-NEVER-EXISTED-1111",
+                "BOGUS-RULE-NEVER-EXISTED",
+                "a.py",
+                1,
+            ),
+            entry(
+                "BOGUS-RULE-NEVER-EXISTED-2222",
+                "BOGUS-RULE-NEVER-EXISTED",
+                "a.py",
+                2,
+            ),
+            entry("YAML-UNSAFE-3333333333333333", "YAML-UNSAFE", "b.py", 3),
+        ]);
+        let d = classify(&current, &b);
+        assert_eq!(d.stale_count, 2);
+        assert_eq!(d.stale_rule_ids, vec!["BOGUS-RULE-NEVER-EXISTED"]);
+        // Unrelated to staleness, all three are also resolved (current
+        // is empty).
+        assert_eq!(d.resolved.len(), 3);
+    }
+
+    #[test]
+    fn classify_stale_rule_ids_sorted_deterministic() {
+        let current: Vec<Finding> = vec![];
+        let b = baseline_with(vec![
+            entry("ZZZ-OLD-1111111111111111", "ZZZ-OLD", "a.py", 1),
+            entry("AAA-OLD-2222222222222222", "AAA-OLD", "a.py", 2),
+            entry("MMM-OLD-3333333333333333", "MMM-OLD", "a.py", 3),
+        ]);
+        let d = classify(&current, &b);
+        assert_eq!(d.stale_rule_ids, vec!["AAA-OLD", "MMM-OLD", "ZZZ-OLD"]);
+    }
+
+    #[test]
+    fn classify_known_rule_id_not_stale() {
+        // YAML-UNSAFE is in the real registry. Even when the entry id
+        // is fake, the ruleId-validity check should NOT mark it stale.
+        let current: Vec<Finding> = vec![];
+        let b = baseline_with(vec![entry(
+            "YAML-UNSAFE-1111111111111111",
+            "YAML-UNSAFE",
+            "a.py",
+            1,
+        )]);
+        let d = classify(&current, &b);
+        assert_eq!(d.stale_count, 0);
+        assert!(d.stale_rule_ids.is_empty());
+    }
+}

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/mod.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/mod.rs
@@ -15,6 +15,7 @@
 //! Output formatting (human / `--json` / `--sarif`) lives in `arcis-cli`
 //! next to the clap glue.
 
+pub mod baseline;
 pub mod engine;
 pub mod finding_id;
 pub mod render;
@@ -22,6 +23,10 @@ pub mod rules;
 pub mod suppress;
 pub mod walker;
 
+pub use baseline::{
+    classify as classify_baseline, Baseline, BaselineEntry, BaselineError, BaselineSummary, Diff,
+    BASELINE_SCHEMA_VERSION,
+};
 pub use engine::{
     scan_directory, scan_directory_with_suppression, scan_file, scan_file_with_suppression,
     FileResult, Finding,

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/render.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/render.rs
@@ -27,6 +27,7 @@ use std::collections::BTreeMap;
 
 use serde_json::{Map, Value};
 
+use super::baseline::{BaselineEntry, BaselineSummary};
 use super::engine::Finding;
 use super::rules::{rules as compiled_rules, Rule, Severity};
 
@@ -64,6 +65,44 @@ pub struct JsonReport<'a> {
     /// informative — confirms the field exists even on a clean run).
     /// Ignored files do NOT appear in `filesScanned` or `byLanguage`.
     pub ignored: usize,
+    /// Baseline diff context (cli-audit.md item 9).
+    ///
+    /// **Locked schema.** When `Some`, an additional `summary.baseline`
+    /// nested object is emitted with EXACTLY these keys, in this order:
+    ///
+    /// 1. `path`           — string, the baseline file path the user gave
+    /// 2. `createdAt`      — string, ISO 8601 UTC from the baseline file
+    /// 3. `added`          — integer, count of new findings (also = `findings.len()`)
+    /// 4. `resolvedCount`  — integer, count of baseline entries no longer present
+    /// 5. `unchangedCount` — integer, count of baseline entries that re-fired
+    /// 6. `staleCount`     — integer, count of baseline entries whose ruleId
+    ///    no longer exists in the registry
+    ///
+    /// When `None`, the `summary.baseline` block is omitted entirely
+    /// (NOT emitted as `null` — absent). Future fields MUST be added to
+    /// the enumeration above AND to [`BaselineSummary`].
+    ///
+    /// Caller responsibility: when this is `Some`, `findings` should
+    /// already be filtered to "added only" — the renderer does not
+    /// filter for you.
+    pub baseline: Option<&'a BaselineSummary<'a>>,
+    /// Resolved findings from the baseline diff (cli-audit.md item 9).
+    ///
+    /// **Locked schema.** When [`Self::baseline`] is `Some`, a top-level
+    /// `resolvedFindings` array is emitted; each element has EXACTLY
+    /// these keys, in this order:
+    ///
+    /// 1. `id`     — deterministic finding fingerprint (verbatim from baseline)
+    /// 2. `ruleId` — rule that produced the original finding
+    /// 3. `file`   — relpath captured at baseline creation
+    /// 4. `line`   — 1-indexed line at baseline creation
+    ///
+    /// No message, severity, or snippet — those bodies were never
+    /// stored in the baseline and the current run can't resurrect them.
+    /// When [`Self::baseline`] is `None`, `resolvedFindings` is omitted
+    /// regardless of the slice contents (an empty slice + `None`
+    /// baseline produces no key, NOT an empty array).
+    pub resolved_findings: &'a [BaselineEntry],
 }
 
 /// Render the audit result as a JSON document. Schema:
@@ -127,6 +166,19 @@ pub fn render_json(report: &JsonReport<'_>) -> String {
     // `.gitignore` / `.git/info/exclude`. Always emitted (same noise
     // tradeoff as `suppressed`); the human report hides the line at 0.
     summary.insert("ignored".into(), Value::from(report.ignored));
+    // cli-audit.md item 9: baseline diff summary block. Emitted only
+    // when `report.baseline` is `Some` — absent (NOT null) on a
+    // baseline-less run. Schema is locked; see [`JsonReport::baseline`].
+    if let Some(b) = report.baseline {
+        let mut bm = Map::new();
+        bm.insert("path".into(), Value::from(b.path));
+        bm.insert("createdAt".into(), Value::from(b.created_at));
+        bm.insert("added".into(), Value::from(b.added));
+        bm.insert("resolvedCount".into(), Value::from(b.resolved_count));
+        bm.insert("unchangedCount".into(), Value::from(b.unchanged_count));
+        bm.insert("staleCount".into(), Value::from(b.stale_count));
+        summary.insert("baseline".into(), Value::Object(bm));
+    }
     doc.insert("summary".into(), Value::Object(summary));
 
     let mut findings_arr = Vec::with_capacity(report.findings.len());
@@ -146,6 +198,24 @@ pub fn render_json(report: &JsonReport<'_>) -> String {
         findings_arr.push(Value::Object(item));
     }
     doc.insert("findings".into(), Value::Array(findings_arr));
+
+    // cli-audit.md item 9: top-level `resolvedFindings` array. Gated on
+    // `baseline.is_some()` — if the caller is in baseline mode the array
+    // appears even when empty (consumers can rely on its presence in
+    // baseline mode). When the caller is NOT in baseline mode, the key
+    // is absent regardless of `resolved_findings` contents.
+    if report.baseline.is_some() {
+        let mut arr = Vec::with_capacity(report.resolved_findings.len());
+        for e in report.resolved_findings {
+            let mut item = Map::new();
+            item.insert("id".into(), Value::from(e.id.as_str()));
+            item.insert("ruleId".into(), Value::from(e.rule_id.as_str()));
+            item.insert("file".into(), Value::from(e.file.as_str()));
+            item.insert("line".into(), Value::from(e.line));
+            arr.push(Value::Object(item));
+        }
+        doc.insert("resolvedFindings".into(), Value::Array(arr));
+    }
 
     let raw = serde_json::to_string_pretty(&Value::Object(doc))
         .expect("serde_json never fails on values built from owned data");
@@ -408,6 +478,8 @@ mod tests {
             severity_filter: None,
             suppressed: 0,
             ignored: 0,
+            baseline: None,
+            resolved_findings: &[],
         };
         let out = render_json(&report);
         let doc = parse(&out);
@@ -441,6 +513,8 @@ mod tests {
             severity_filter: Some(Severity::High),
             suppressed: 0,
             ignored: 0,
+            baseline: None,
+            resolved_findings: &[],
         };
         let doc = parse(&render_json(&report));
         assert_eq!(doc["severityFilter"], Json::from("high"));
@@ -463,6 +537,8 @@ mod tests {
             severity_filter: None,
             suppressed: 0,
             ignored: 0,
+            baseline: None,
+            resolved_findings: &[],
         };
         let out = render_json(&report);
         let doc = parse(&out);
@@ -498,6 +574,8 @@ mod tests {
             severity_filter: None,
             suppressed: 0,
             ignored: 0,
+            baseline: None,
+            resolved_findings: &[],
         });
         // String-position sniff: ruleId opens the finding object, id
         // follows immediately, severity comes after.
@@ -530,6 +608,8 @@ mod tests {
             severity_filter: None,
             suppressed: 0,
             ignored: 0,
+            baseline: None,
+            resolved_findings: &[],
         });
         let positions: Vec<usize> = [
             "\"tool\"",
@@ -567,6 +647,8 @@ mod tests {
             severity_filter: None,
             suppressed: 0,
             ignored: 0,
+            baseline: None,
+            resolved_findings: &[],
         });
         assert!(
             out.contains("\\u2014"),
@@ -597,6 +679,8 @@ mod tests {
             severity_filter: None,
             suppressed: 12,
             ignored: 0,
+            baseline: None,
+            resolved_findings: &[],
         });
         let doc = parse(&out);
         assert_eq!(doc["summary"]["suppressed"], Json::from(12u64));
@@ -624,6 +708,8 @@ mod tests {
             severity_filter: None,
             suppressed: 0,
             ignored: 4,
+            baseline: None,
+            resolved_findings: &[],
         });
         let doc = parse(&out);
         assert_eq!(doc["summary"]["ignored"], Json::from(4u64));
@@ -649,6 +735,8 @@ mod tests {
             severity_filter: None,
             suppressed: 0,
             ignored: 0,
+            baseline: None,
+            resolved_findings: &[],
         });
         let doc = parse(&out);
         assert_eq!(doc["summary"]["ignored"], Json::from(0u64));
@@ -670,6 +758,8 @@ mod tests {
             severity_filter: None,
             suppressed: 0,
             ignored: 0,
+            baseline: None,
+            resolved_findings: &[],
         });
         // Python `json.dumps(..., indent=2)` uses 2-space indent. Our
         // serde_json::to_string_pretty default is also 2 spaces. Pin
@@ -679,6 +769,220 @@ mod tests {
         assert!(lines[1].starts_with("  "));
         assert!(!lines[1].starts_with("   ")); // not 3+
         assert!(!lines[1].starts_with('\t'));
+    }
+
+    // ── render_json: baseline diff (cli-audit.md item 9) ───────────────
+
+    fn baseline_entry_fixture(id: &str) -> BaselineEntry {
+        BaselineEntry {
+            id: id.to_string(),
+            rule_id: "YAML-UNSAFE".to_string(),
+            file: "src/a.py".to_string(),
+            line: 10,
+        }
+    }
+
+    #[test]
+    fn json_emits_summary_baseline_block_when_baseline_present() {
+        // Sentinel-pin contains-check: every locked-schema key for the
+        // `summary.baseline` block must appear literally in the output.
+        // Future renames or accidental drops surface here loudly.
+        let by_lang = BTreeMap::new();
+        let by_sev = BTreeMap::new();
+        let bs = BaselineSummary {
+            path: ".arcis-baseline.json",
+            created_at: "2026-05-07T12:00:00Z",
+            added: 3,
+            resolved_count: 1,
+            unchanged_count: 12,
+            stale_count: 0,
+        };
+        let out = render_json(&JsonReport {
+            tool_version: "1.0",
+            target: "/tmp",
+            findings: &[],
+            files_scanned: 0,
+            by_language: &by_lang,
+            rules_applied: 0,
+            by_severity: &by_sev,
+            duration_ms: 0,
+            severity_filter: None,
+            suppressed: 0,
+            ignored: 0,
+            baseline: Some(&bs),
+            resolved_findings: &[],
+        });
+        for needle in [
+            "\"baseline\"",
+            "\"path\"",
+            "\"createdAt\"",
+            "\"added\"",
+            "\"resolvedCount\"",
+            "\"unchangedCount\"",
+            "\"staleCount\"",
+        ] {
+            assert!(
+                out.contains(needle),
+                "summary.baseline block missing literal key {needle} in:\n{out}"
+            );
+        }
+        // Counts present as integers, not strings.
+        let doc = parse(&out);
+        assert_eq!(doc["summary"]["baseline"]["added"], Json::from(3u64));
+        assert_eq!(
+            doc["summary"]["baseline"]["resolvedCount"],
+            Json::from(1u64)
+        );
+        assert_eq!(
+            doc["summary"]["baseline"]["unchangedCount"],
+            Json::from(12u64)
+        );
+        assert_eq!(doc["summary"]["baseline"]["staleCount"], Json::from(0u64));
+        assert_eq!(
+            doc["summary"]["baseline"]["path"],
+            Json::from(".arcis-baseline.json")
+        );
+        assert_eq!(
+            doc["summary"]["baseline"]["createdAt"],
+            Json::from("2026-05-07T12:00:00Z")
+        );
+    }
+
+    #[test]
+    fn json_omits_baseline_block_when_baseline_none() {
+        // Absent — NOT null, NOT empty object. Consumers can use the
+        // key's presence to detect baseline mode.
+        let by_lang = BTreeMap::new();
+        let by_sev = BTreeMap::new();
+        let out = render_json(&JsonReport {
+            tool_version: "1.0",
+            target: "/tmp",
+            findings: &[],
+            files_scanned: 0,
+            by_language: &by_lang,
+            rules_applied: 0,
+            by_severity: &by_sev,
+            duration_ms: 0,
+            severity_filter: None,
+            suppressed: 0,
+            ignored: 0,
+            baseline: None,
+            resolved_findings: &[],
+        });
+        assert!(
+            !out.contains("\"baseline\""),
+            "summary.baseline must be absent when baseline is None, got:\n{out}"
+        );
+        let doc = parse(&out);
+        assert!(doc["summary"].get("baseline").is_none());
+    }
+
+    #[test]
+    fn json_emits_top_level_resolved_findings_when_present() {
+        // Sentinel-pin: the literal key `resolvedFindings` must appear,
+        // and each entry serializes as {id, ruleId, file, line}. Any
+        // future refactor that drops or renames the array breaks here.
+        let by_lang = BTreeMap::new();
+        let by_sev = BTreeMap::new();
+        let bs = BaselineSummary {
+            path: "b.json",
+            created_at: "2026-05-07T00:00:00Z",
+            added: 0,
+            resolved_count: 1,
+            unchanged_count: 0,
+            stale_count: 0,
+        };
+        let resolved = vec![baseline_entry_fixture("YAML-UNSAFE-deadbeefcafef00d")];
+        let out = render_json(&JsonReport {
+            tool_version: "1.0",
+            target: "/tmp",
+            findings: &[],
+            files_scanned: 0,
+            by_language: &by_lang,
+            rules_applied: 0,
+            by_severity: &by_sev,
+            duration_ms: 0,
+            severity_filter: None,
+            suppressed: 0,
+            ignored: 0,
+            baseline: Some(&bs),
+            resolved_findings: &resolved,
+        });
+        assert!(
+            out.contains("\"resolvedFindings\""),
+            "missing literal `resolvedFindings` key in:\n{out}"
+        );
+        let doc = parse(&out);
+        let arr = doc["resolvedFindings"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["id"], Json::from("YAML-UNSAFE-deadbeefcafef00d"));
+        assert_eq!(arr[0]["ruleId"], Json::from("YAML-UNSAFE"));
+        assert_eq!(arr[0]["file"], Json::from("src/a.py"));
+        assert_eq!(arr[0]["line"], Json::from(10u64));
+    }
+
+    #[test]
+    fn json_resolved_findings_emitted_even_when_array_empty_in_baseline_mode() {
+        // Locked-schema rule: in baseline mode the `resolvedFindings`
+        // key is present even if no resolutions exist. Consumers in
+        // baseline mode get a uniform shape.
+        let by_lang = BTreeMap::new();
+        let by_sev = BTreeMap::new();
+        let bs = BaselineSummary {
+            path: "b.json",
+            created_at: "2026-05-07T00:00:00Z",
+            added: 0,
+            resolved_count: 0,
+            unchanged_count: 0,
+            stale_count: 0,
+        };
+        let out = render_json(&JsonReport {
+            tool_version: "1.0",
+            target: "/tmp",
+            findings: &[],
+            files_scanned: 0,
+            by_language: &by_lang,
+            rules_applied: 0,
+            by_severity: &by_sev,
+            duration_ms: 0,
+            severity_filter: None,
+            suppressed: 0,
+            ignored: 0,
+            baseline: Some(&bs),
+            resolved_findings: &[],
+        });
+        let doc = parse(&out);
+        assert!(doc.get("resolvedFindings").is_some());
+        assert_eq!(doc["resolvedFindings"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn json_omits_resolved_findings_when_baseline_none() {
+        // Absent when not in baseline mode — even if the caller
+        // accidentally passes a non-empty `resolved_findings` slice.
+        // Gating is on `baseline.is_some()`, not on slice contents.
+        let by_lang = BTreeMap::new();
+        let by_sev = BTreeMap::new();
+        let resolved = vec![baseline_entry_fixture("YAML-UNSAFE-1111111111111111")];
+        let out = render_json(&JsonReport {
+            tool_version: "1.0",
+            target: "/tmp",
+            findings: &[],
+            files_scanned: 0,
+            by_language: &by_lang,
+            rules_applied: 0,
+            by_severity: &by_sev,
+            duration_ms: 0,
+            severity_filter: None,
+            suppressed: 0,
+            ignored: 0,
+            baseline: None,
+            resolved_findings: &resolved,
+        });
+        assert!(
+            !out.contains("\"resolvedFindings\""),
+            "resolvedFindings must be absent when baseline is None, got:\n{out}"
+        );
     }
 
     // ── render_sarif ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes cli-audit.md Phase B items **8** (`--severity` integration-test pin) and **9** (baseline mode + `--diff`). Two commits, engine + CLI:

- `5255afd` — **9a**: engine surface. New `audit::baseline` module with locked v1 schema, `BaselineEntry` / `Diff` / `classify`, atomic `<path>.tmp` + rename, hand-rolled ISO 8601. Extends `JsonReport` with `baseline: Option<&BaselineSummary>` and `resolved_findings: &[BaselineEntry]`, both with locked-schema doc-comments mirroring the `redact_for_json` pattern.
- `dc3e6ea` — **9b**: CLI surface. `--baseline <path>` (read) and `--baseline-write <path>` (write) with parse-time mutex pointing at the second/offending flag, machine-mode + baseline coexistence, human-output baseline lines, and 10 end-to-end integration tests spawning the actual `arcis` binary.

## What's new for users

| Flag | Mode | Exit code |
|---|---|---|
| `--baseline <path>` | Read mode: classify against snapshot, fail only on **new** findings | `0` if no new, `1` if any new (resolved/unchanged don't fail) |
| `--baseline-write <path>` | Write mode: record current state to JSON | always `0` |

CI usage:
```sh
arcis audit src --baseline-write .arcis-baseline.json   # one-time bootstrap
arcis audit src --baseline .arcis-baseline.json         # every PR; fails on regressions only
```

`--severity` applies BEFORE diff classification (documented in `--help`); the `severity_filter_applies_before_baseline_classification` test pins this. A separate `severity_filter_applies_to_findings_without_baseline` test pins the standalone `--severity` contract independently of baseline (item 8).

## Schema (locked v1)

Baseline file:
```json
{
  "version": 1,
  "createdAt": "2026-05-07T12:00:00Z",
  "toolVersion": "0.1.0",
  "findings": [{"id": "YAML-UNSAFE-...", "ruleId": "YAML-UNSAFE", "file": "src/a.py", "line": 10}]
}
```

JSON output deltas (only when `--baseline` is given):
- New `summary.baseline = {path, createdAt, added, resolvedCount, unchangedCount, staleCount}` block
- New top-level `resolvedFindings` array (gated on `baseline.is_some()`, present even when empty in baseline mode)
- Existing `findings` array filtered to **added only**

Key naming aligns with dashboard `/v1/audits/diff` (`added`, `resolvedCount`-as-count, `unchangedCount`).

## Mutex error UX

Per-flag, points to the second (offending) flag:

```
$ arcis audit . --baseline b.json --baseline-write w.json
arcis audit: --baseline-write conflicts with --baseline (already given) — pick one: read OR write a baseline, not both
```

## Stale-rule handling

A baseline entry whose `ruleId` no longer exists in the rule registry surfaces a stderr warning (human mode) + `summary.baseline.staleCount` (machine mode). Never fails. ID identity is by `Finding.id` only; rule renames produce a paired resolved+added entry naturally because `rule_id` participates in the SHA-256 fingerprint.

## Test plan

Verified under Docker `rust:1.88`:

- `cargo fmt --all -- --check`: clean
- `cargo build --workspace --tests`: green
- `cargo test --workspace`: **118 (cli) + 10 (audit_baseline integration) + 5 (data) + 349 (engine) = 482 passing, 0 failed**
- `cargo clippy --workspace --all-targets -- -D warnings`: clean

New tests by category:

- **engine baseline.rs** (17): ISO 8601 fixed points, schema round-trip, atomic-write deterministic tmp suffix, locked-schema key-order pin, missing/malformed/version-mismatch typed errors, classify cases (empty baseline / current / identity / mixed / stale-rule / dedup / sorted / known-rule-not-stale)
- **engine render.rs** (5): sentinel-pin contains-checks for every literal locked-schema key under `summary.baseline` and top-level `resolvedFindings`; omission tests for `baseline: None` and `baseline.is_some() && resolved_findings.is_empty()`
- **cli audit.rs unit** (6): both flags parse, both mutex orderings name the second flag, missing-arg errors, help-text pin (refinement #3 — both flags + mutex note + diff-classification semantic + `resolved` keyword)
- **cli audit_baseline.rs integration** (10): round-trip clean, drift +1, drift -1, severity × baseline (item 8 fold-in), standalone severity (item 8 independent pin), stale rule, unsupported version, missing file, mutex with second-flag-named error, `--baseline-write` + `--json` coexistence

## Out of scope / follow-ups

- `summary.baseline` doesn't carry the resolved findings inline (only counts) — `resolvedFindings` lives at top level. Consumers wanting flat shape need both keys.
- SARIF schema has no baseline block; we filter `findings` to added-only and let GitHub Code Scanning compute the rest from `partialFingerprints["arcis/v1"]` (already shipped in item 10).
- `iso8601_utc` duplicates the helper in `sca_sbom.rs` per the cross-track ADD-ONLY rule. Both copies fold into a shared `arcis_engine::time` module post-Phase-1 consolidation; module-doc notes the deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)