### PR TITLE
fix(security): close critical + high findings from internal review

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ At the checkpoint, Arcis:
 - **One-line setup**: `app.use(arcis())` activates sanitization, rate limiting, and security headers. CSRF, CORS, cookies, bot detection, prompt-injection guard, token-budget guard, and error handling are opt-in middleware.
 - **20+ attack types**: XSS, SQL/NoSQL injection, command injection, path traversal, SSTI, XXE, SSRF, CSRF, HPP, prototype pollution, header injection, open redirect, LDAP injection.
 - **AI-era protections**: `detectPromptInjection` + `sanitizePromptInjection` cover ~28 jailbreak signatures (DAN/STAN/DUDE, system-prompt extraction, fake `<system>` tags, base64 smuggling). `tokenBudget` middleware caps per-key LLM token spend over a sliding window.
-- **646-pattern bot corpus**: Generated from a curated MIT-licensed corpus plus supplementary entries. 7 categories (search engines, social, monitoring, AI crawlers, scrapers, automated tools, unknown) with allow/deny lists and behavioral signal detection.
+- **635-pattern bot corpus**: Generated from a curated MIT-licensed corpus plus supplementary entries. 7 categories (search engines, social, monitoring, AI crawlers, scrapers, automated tools, unknown) with allow/deny lists and behavioral signal detection.
 - **Zero dependencies**: Core is self-contained with no transitive dependencies. Go framework adapters (Gin, Echo) are optional.
 - **Three-language parity**: Same API, same behavior, same test results across Node.js, Python, and Go. Enforced by shared test vectors.
 - **First-party framework adapters (Node)**: Express, NestJS, SvelteKit, Astro, Nuxt, Bun + Hono. Each subpath import (`@arcis/node/nestjs`, `@arcis/node/sveltekit`, etc.) keeps the framework SDK as a type-only dependency, so non-users pay nothing.
@@ -478,7 +478,7 @@ The script is stripped. The rest of the comment is saved normally.
 - 20+ security flaw coverage (runtime + detection)
 - 3 SDKs (Node.js, Python, Go) at full parity
 - **12 framework adapters**: Express, NestJS, SvelteKit, Astro, Nuxt, Bun + Hono (Node), FastAPI, Flask, Django (Python), Gin, Echo, net/http (Go)
-- **646-pattern bot corpus** (was 80) with allow/deny categorization
+- **635-pattern bot corpus** (was 80) with allow/deny categorization
 - **AI/LLM prompt-injection detection** across all 3 SDKs (28 signatures, 3 severity tiers)
 - **`tokenBudget` middleware** for per-key LLM token spend caps
 - 3 rate limiting algorithms (fixed, sliding, token bucket)

--- a/packages/arcis-go/echo/echo.go
+++ b/packages/arcis-go/echo/echo.go
@@ -80,6 +80,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	arcis "github.com/GagancM/arcis"
+	"github.com/GagancM/arcis/sanitizers"
 	"github.com/GagancM/arcis/telemetry"
 )
 
@@ -746,13 +747,9 @@ func CsrfProtection(opts arcis.CsrfOptions) echo.MiddlewareFunc {
 				headerName = "X-Csrf-Token"
 			}
 			requestToken := c.Request().Header.Get(headerName)
-			if requestToken == "" {
-				fieldName := opts.FieldName
-				if fieldName == "" {
-					fieldName = "_csrf"
-				}
-				requestToken = c.QueryParam(fieldName)
-			}
+			// SECURITY: query string intentionally not supported. Tokens
+			// in URLs leak to server logs, Referer headers, browser
+			// history, and CDN/proxy caches. Header only.
 
 			if !csrf.Check(method, c.Request().URL.Path, cookieToken, requestToken) {
 				return c.JSON(http.StatusForbidden, map[string]string{
@@ -774,16 +771,21 @@ func csrfCookieName(opts arcis.CsrfOptions) string {
 }
 
 func buildEchoCsrfCookie(opts arcis.CsrfOptions, token string) string {
-	name := csrfCookieName(opts)
-	path := opts.Cookie.Path
+	// SECURITY: strip CRLF from any user-controlled cookie components
+	// before building the Set-Cookie value. Without this, a header
+	// value containing \r\n could split the response or inject
+	// arbitrary headers.
+	name := sanitizers.SanitizeHeaderValue(csrfCookieName(opts))
+	safeToken := sanitizers.SanitizeHeaderValue(token)
+	path := sanitizers.SanitizeHeaderValue(opts.Cookie.Path)
 	if path == "" {
 		path = "/"
 	}
-	sameSite := opts.Cookie.SameSite
+	sameSite := sanitizers.SanitizeHeaderValue(opts.Cookie.SameSite)
 	if sameSite == "" {
 		sameSite = "Lax"
 	}
-	parts := []string{name + "=" + token, "Path=" + path}
+	parts := []string{name + "=" + safeToken, "Path=" + path}
 	if opts.Cookie.HttpOnly {
 		parts = append(parts, "HttpOnly")
 	}
@@ -796,7 +798,7 @@ func buildEchoCsrfCookie(opts arcis.CsrfOptions, token string) string {
 	}
 	parts = append(parts, "SameSite="+sameSite)
 	if opts.Cookie.Domain != "" {
-		parts = append(parts, "Domain="+opts.Cookie.Domain)
+		parts = append(parts, "Domain="+sanitizers.SanitizeHeaderValue(opts.Cookie.Domain))
 	}
 	return strings.Join(parts, "; ")
 }

--- a/packages/arcis-node/src/middleware/csrf.ts
+++ b/packages/arcis-node/src/middleware/csrf.ts
@@ -101,12 +101,20 @@ export function generateCsrfToken(length: number = 32): string {
  */
 export function validateCsrfToken(cookieToken: string, requestToken: string): boolean {
   if (!cookieToken || !requestToken) return false;
-  if (cookieToken.length !== requestToken.length) return false;
 
-  // SECURITY: Use Node.js built-in constant-time comparison to prevent timing attacks
-  const a = Buffer.from(cookieToken);
-  const b = Buffer.from(requestToken);
-  return timingSafeEqual(a, b);
+  // SECURITY: Pad both buffers to a common reference length before
+  // timingSafeEqual so an early length-check does not leak token length
+  // through timing. Compute length-equality with a constant-time integer
+  // compare and AND it AFTER the byte compare so execution time is the
+  // same regardless of length mismatch.
+  const paddedLength = Math.max(64, cookieToken.length, requestToken.length);
+  const a = Buffer.alloc(paddedLength);
+  const b = Buffer.alloc(paddedLength);
+  Buffer.from(cookieToken, 'utf8').copy(a);
+  Buffer.from(requestToken, 'utf8').copy(b);
+  const bytesEqual = timingSafeEqual(a, b);
+  const sameLength = cookieToken.length === requestToken.length;
+  return bytesEqual && sameLength;
 }
 
 /**

--- a/packages/arcis-node/src/validation/schema.ts
+++ b/packages/arcis-node/src/validation/schema.ts
@@ -56,8 +56,16 @@ export function validate(
       return;
     }
 
-    // Replace with validated data (prevents mass assignment)
-    req[source] = validated as typeof req[typeof source];
+    // Replace with validated data (prevents mass assignment).
+    // SECURITY: Express 5 makes req.body/query/params read-only. Use
+    // defineProperty so this works on both Express 4 and 5; direct
+    // assignment crashes Express 5 with TypeError.
+    Object.defineProperty(req, source, {
+      value: validated,
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
     next();
   };
 }

--- a/packages/arcis-node/tests/middleware/csrf.test.ts
+++ b/packages/arcis-node/tests/middleware/csrf.test.ts
@@ -110,12 +110,25 @@ describe('validateCsrfToken', () => {
   });
 
   it('should use constant-time comparison (not short-circuit)', () => {
-    // Both should take similar time — we just verify correctness here
+    // Both should take similar time. Correctness check only here.
     const token = 'a'.repeat(64);
     const nearMatch = 'a'.repeat(63) + 'b';
     const farMatch = 'b'.repeat(64);
     expect(validateCsrfToken(token, nearMatch)).toBe(false);
     expect(validateCsrfToken(token, farMatch)).toBe(false);
+  });
+
+  it('should not throw and return false for length-mismatched tokens (regression)', () => {
+    // Regression: previous implementation returned false BEFORE
+    // timingSafeEqual on length mismatch, leaking length via timing.
+    // The current implementation pads both to a common reference length
+    // and ANDs the byte-equal result with a length-equality check.
+    expect(() => validateCsrfToken('a', 'a'.repeat(128))).not.toThrow();
+    expect(validateCsrfToken('a', 'a'.repeat(128))).toBe(false);
+    expect(validateCsrfToken('a'.repeat(128), 'a')).toBe(false);
+    // Padding byte attack: a token that, when padded with zeros, would
+    // accidentally equal a longer real token must still be rejected.
+    expect(validateCsrfToken('abc', 'abc\0\0')).toBe(false);
   });
 });
 

--- a/packages/arcis-python/arcis/data/threat-db.json
+++ b/packages/arcis-python/arcis/data/threat-db.json
@@ -116,18 +116,17 @@
       "vulnerable_ranges": [],
       "attack_vector": "Trojanized dependency plain-crypto-js@4.2.1 deploys a remote access trojan (RAT) via postinstall script.",
       "severity": "critical",
-      "cve": "CVE-2026-XXXX",
+      "cve": "no-cve-assigned",
       "disclosure_date": "2026-03-31",
       "source": "npm Security Advisory",
       "references": [
-        "https://github.com/axios/axios/security/advisories",
-        "https://github.com/advisories"
+        "https://github.com/axios/axios/security/advisories"
       ],
       "trojanized_deps": [
         "plain-crypto-js"
       ],
       "persistence_artifacts": [],
-      "remediation": "1. Run: npm uninstall axios && npm install axios@1.14.0\n2. Delete node_modules and reinstall: rm -rf node_modules && npm install\n3. Search for 'plain-crypto-js' in node_modules \u00e2\u20ac\u201d if present, your system may be compromised\n4. Rotate any credentials/tokens accessible from the affected machine"
+      "remediation": "1. Run: npm uninstall axios && npm install axios@1.14.0. 2. Delete node_modules and reinstall: rm -rf node_modules && npm install. 3. Search for 'plain-crypto-js' in node_modules. If present, your system may be compromised. 4. Rotate any credentials/tokens accessible from the affected machine."
     },
     {
       "ecosystem": "npm",
@@ -1506,7 +1505,7 @@
       "vulnerable_ranges": [],
       "attack_vector": "Credential harvester exfiltrates environment variables and API keys. Installs persistent .pth backdoor in site-packages that survives pip uninstall.",
       "severity": "critical",
-      "cve": "CVE-2026-XXXX",
+      "cve": "no-cve-assigned",
       "disclosure_date": "2026-03-24",
       "source": "PyPI Security Advisory",
       "references": [
@@ -1517,7 +1516,7 @@
       "persistence_artifacts": [
         "*.pth"
       ],
-      "remediation": "1. Run: pip uninstall litellm && pip install litellm==1.82.6\n2. Check site-packages for suspicious .pth files:\n   python -c \"import site; print(site.getsitepackages())\"\n   Look for .pth files you don't recognize \u00e2\u20ac\u201d the backdoor survives uninstall.\n3. Rotate ALL API keys, tokens, and credentials from environment variables.\n4. Check ~/.local/lib and conda envs for the same .pth artifacts."
+      "remediation": "1. Run: pip uninstall litellm && pip install litellm==1.82.6. 2. Check site-packages for suspicious .pth files: python -c \"import site; print(site.getsitepackages())\". Look for .pth files you don't recognize. The backdoor survives uninstall. 3. Rotate ALL API keys, tokens, and credentials from environment variables. 4. Check ~/.local/lib and conda envs for the same .pth artifacts."
     },
     {
       "ecosystem": "pypi",

--- a/packages/arcis-python/arcis/fastapi.py
+++ b/packages/arcis-python/arcis/fastapi.py
@@ -28,6 +28,7 @@ from .core.constants import DEFAULT_MAX_REQUESTS, DEFAULT_WINDOW_MS, DEFAULT_RAT
 from .telemetry.client import AsyncTelemetryClient
 from .telemetry.types import TelemetryOptions
 from .middleware.telemetry import telemetry_options_from_env as _telemetry_options_from_env
+from .utils.ip import detect_client_ip
 
 logger = logging.getLogger(__name__)
 
@@ -195,21 +196,21 @@ class AsyncRateLimiter:
         self._cleanup_lock: Optional[asyncio.Lock] = None
 
     def _default_key_func(self, request: Request) -> str:
-        """Default key function - uses client IP address."""
-        # FastAPI/Starlette
+        """Default key function. Uses the real client IP.
+
+        SECURITY: delegates to ``detect_client_ip`` which parses
+        ``X-Forwarded-For`` from the right (proxy-appended end) and prefers
+        platform-specific spoofproof headers (Cloudflare, Vercel, Fly.io,
+        etc.). Reading XFF from the left is spoofable: an attacker can
+        prepend an arbitrary value and be rate-limited under that key.
+        """
+        # FastAPI/Starlette: socket peer address is always trustworthy
         if hasattr(request, 'client') and request.client:
-            return request.client.host or "unknown"
-        
-        # Check forwarded headers
-        forwarded = request.headers.get('x-forwarded-for')
-        if forwarded:
-            return forwarded.split(',')[0].strip()
-        
-        real_ip = request.headers.get('x-real-ip')
-        if real_ip:
-            return real_ip
-        
-        return "unknown"
+            host = request.client.host
+            if host:
+                return host
+
+        return detect_client_ip(request) or "unknown"
     
     async def _start_cleanup(self) -> None:
         """Start background cleanup task for in-memory store.
@@ -272,6 +273,12 @@ class AsyncRateLimiter:
                 return {"allowed": True, "limit": self.max_requests, "remaining": self.max_requests, "reset": 0}
         
         key = self.key_func(request)
+        # Mirror the skip_func async-handling pattern: if the user passed
+        # an async key_func, await it. Without this, the returned coroutine
+        # would silently be used as the rate-limit key, breaking per-IP
+        # isolation entirely.
+        if asyncio.iscoroutine(key):
+            key = await key
         now = time.time()
 
         entry = await self.store.get(key)

--- a/packages/arcis-python/tests/integration/test_fastapi.py
+++ b/packages/arcis-python/tests/integration/test_fastapi.py
@@ -430,18 +430,76 @@ class TestAsyncRateLimiter:
         async def async_skip(request):
             await asyncio.sleep(0)  # Simulate async check
             return request.headers.get("x-admin") == "true"
-        
+
         limiter = AsyncRateLimiter(max_requests=1, window_ms=60000, skip_func=async_skip)
-        
+
         admin_request = MagicMock()
         admin_request.client = MagicMock()
         admin_request.client.host = "192.168.1.1"
         admin_request.headers = {"x-admin": "true"}
-        
+
         result = await limiter.check(admin_request)
         assert result["allowed"] is True
-        
+
         await limiter.close()
+
+    @pytest.mark.asyncio
+    async def test_async_key_function_is_awaited(self):
+        """Regression: an async key_func used to leak a coroutine object as the
+        rate-limit key, breaking per-key isolation silently. Now awaited like
+        skip_func.
+        """
+        async def async_key(request):
+            await asyncio.sleep(0)
+            return request.headers.get("x-tenant", "default")
+
+        limiter = AsyncRateLimiter(max_requests=2, window_ms=60000, key_func=async_key)
+
+        req_a = MagicMock()
+        req_a.client = MagicMock()
+        req_a.client.host = "1.1.1.1"
+        req_a.headers = {"x-tenant": "tenant-a"}
+
+        req_b = MagicMock()
+        req_b.client = MagicMock()
+        req_b.client.host = "1.1.1.1"
+        req_b.headers = {"x-tenant": "tenant-b"}
+
+        # Two requests under tenant-a, third must trip; meanwhile tenant-b
+        # has its own counter and stays allowed. If the coroutine were used
+        # as the key, all three would share a key and the test would behave
+        # incorrectly (or raise TypeError on dict lookup).
+        await limiter.check(req_a)
+        await limiter.check(req_a)
+        with pytest.raises(AsyncRateLimitExceeded):
+            await limiter.check(req_a)
+        result = await limiter.check(req_b)
+        assert result["allowed"] is True
+
+        await limiter.close()
+
+    def test_default_key_func_uses_xff_from_right(self):
+        """Regression: _default_key_func used to read X-Forwarded-For from the
+        left, allowing trivial IP spoofing via attacker-prepended values. It
+        now delegates to detect_client_ip which parses XFF from the right
+        (proxy-appended end) and prefers spoofproof platform headers.
+        """
+        from types import SimpleNamespace
+
+        limiter = AsyncRateLimiter(max_requests=10, window_ms=60000)
+
+        # Use SimpleNamespace so hasattr returns False for framework-specific
+        # attrs we did not set (META, remote_addr). MagicMock auto-creates
+        # those, sending detect_client_ip down the wrong branch.
+        request = SimpleNamespace(
+            client=None,  # No socket peer
+            headers={"x-forwarded-for": "spoofed.attacker, 203.0.113.50"},
+        )
+
+        key = limiter._default_key_func(request)
+        # Rightmost trusted IP must win, never the spoofed left value.
+        assert key != "spoofed.attacker"
+        assert "203.0.113.50" in key
     
     @pytest.mark.asyncio
     async def test_close_stops_limiter(self, mock_request):


### PR DESCRIPTION
## Summary

Internal security review pass on the full Arcis surface (Node + Python + Go SDKs, threat DB, README) flagged a batch of issues. This PR closes all critical and high severity items in the main repo. Examples are addressed in separate PRs against the example repos.

## Critical

- **threat-db.json**: replace 2 literal \`CVE-2026-XXXX\` placeholder entries (axios trojan, litellm trojan) with \`no-cve-assigned\`. Strip generic duplicate reference URLs. Decode mojibake em-dashes in remediation strings.
- **README.md**: bot corpus count was overclaimed as 646. Actual count in \`packages/core/well-known-bots.json\` is 635.
- **arcis-node csrf**: \`validateCsrfToken\` returned false on length mismatch BEFORE \`timingSafeEqual\`, leaking token length through timing. Now pads both buffers to a common reference length, runs \`timingSafeEqual\`, then ANDs with a constant-time length-equality check. Regression test added.
- **arcis-python fastapi**: \`AsyncRateLimiter._default_key_func\` read \`X-Forwarded-For\` from index \`[0]\`, allowing trivial IP spoofing via attacker-prepended values. Now delegates to \`detect_client_ip\` which reads XFF from the right and prefers spoofproof platform headers.
- **arcis-python fastapi**: \`AsyncRateLimiter.check\` did not check whether \`key_func\` returned a coroutine, silently using the coroutine object as a dict key when an async key_func was provided. Mirrors the existing \`skip_func\` async pattern. Regression tests added for both fixes.

## High

- **arcis-node validation/schema**: direct \`req[source] = validated\` crashes Express 5 because \`req.body/query/params\` are read-only. Use \`Object.defineProperty\` per CLAUDE.md Pattern 3.
- **arcis-go echo csrf**: accepted token from \`c.QueryParam\` fallback, leaking tokens to logs, Referer, browser history, CDN caches. Header-only now (matches the comment in core \`csrf.go\`).
- **arcis-go echo csrf**: \`buildEchoCsrfCookie\` concatenated cookie name, value, path, domain, and SameSite directly into a Set-Cookie header without CRLF stripping. All components now routed through \`sanitizers.SanitizeHeaderValue\`.

## Test plan

- [x] arcis-node: \`npm test\` (1610 pass, including new CSRF regression)
- [x] arcis-python: \`pytest\` (1198 pass / 2 skipped Redis-backed)
- [x] arcis-go: \`docker run ... go test ./echo/...\` (pass)

## Related

- Plan + full finding log: \`documents/plans/security-review-2026-05-07.md\` (local; not in repo)
- Medium findings (M1-M10) and low findings (L1-L5) parked for next batch
- FastAPI example fix: separate PR on \`getarcis/arcis-example-fastapi\`
- Bun example fix: separate PR on \`getarcis/arcis-example-bun\`