### PR TITLE
fix(security): close medium + low findings from internal review

### DIFF
--- a/packages/arcis-java/README.md
+++ b/packages/arcis-java/README.md
@@ -1,0 +1,31 @@
+# arcis-java
+
+> Pre-alpha. Do not deploy.
+
+This package is a skeleton for a future Java SDK of Arcis. It currently includes a single XSS sanitizer and configuration scaffold; framework adapters (Servlet filter, Spring Security, Jakarta middleware) are not yet implemented.
+
+For production use today, pick one of the SDKs that ship full coverage:
+
+- Node.js / TypeScript: [`@arcis/node`](https://www.npmjs.com/package/@arcis/node)
+- Python: [`arcis`](https://pypi.org/project/arcis/)
+- Go: [`github.com/GagancM/arcis`](https://pkg.go.dev/github.com/GagancM/arcis)
+
+## What is here
+
+- `Arcis.java` and `ArcisConfig.java`: builder-style config entry point.
+- `XssSanitizer.java`: single sanitizer with remove-then-encode order.
+- `SecurityThreatException.java`: exception type.
+- One test file (`XssSanitizerTest.java`).
+
+## What is not here
+
+- No middleware / filter integrations.
+- No CSRF, CORS, rate limit, headers, or input validation modules.
+- No supply-chain audit or static-analysis CLI.
+- No cross-SDK parity test coverage.
+
+When this package gains a working middleware layer it will be re-evaluated against the same `spec/TEST_VECTORS.json` contract that Node, Python, and Go pass today. Until then, prefer the production-ready SDKs above.
+
+## License
+
+MIT.

--- a/packages/arcis-mcp/src/server.ts
+++ b/packages/arcis-mcp/src/server.ts
@@ -167,8 +167,33 @@ function toolResult(text: string, structured?: unknown): CallToolResult {
   return structured !== undefined ? { content, structuredContent: structured as Record<string, unknown> } : { content };
 }
 
+/**
+ * Validate that a path argument exists and is a directory the server can read.
+ * Returns null on success or a human-readable error string on failure. We
+ * surface the error inline through the MCP tool result instead of letting
+ * the underlying CLI fail; failing earlier gives a clearer error to the
+ * MCP client and avoids spawning a subprocess for a path we know is bad.
+ */
+function validatePath(path: string): string | null {
+  try {
+    // Synchronous and cheap. Tool calls already cross a process boundary
+    // via spawn; this stat is a rounding error in comparison.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs') as typeof import('fs');
+    const stat = fs.statSync(path);
+    if (!stat.isDirectory()) {
+      return `path is not a directory: ${path}`;
+    }
+    return null;
+  } catch {
+    return `path does not exist or is not readable: ${path}`;
+  }
+}
+
 async function handleAudit(input: Record<string, unknown>): Promise<CallToolResult> {
   const path = typeof input.path === 'string' ? input.path : process.cwd();
+  const pathError = validatePath(path);
+  if (pathError) return toolResult(`arcis_audit: ${pathError}`);
   const args = ['audit', path];
   if (typeof input.language === 'string' && input.language !== 'auto') {
     args.push('--language', input.language);
@@ -186,6 +211,8 @@ async function handleAudit(input: Record<string, unknown>): Promise<CallToolResu
 
 async function handleSca(input: Record<string, unknown>): Promise<CallToolResult> {
   const path = typeof input.path === 'string' ? input.path : process.cwd();
+  const pathError = validatePath(path);
+  if (pathError) return toolResult(`arcis_sca: ${pathError}`);
   const args = ['sca', path];
   if (input.system === true) args.push('--system');
   const r = await runArcisCli(args);

--- a/packages/arcis-node/src/core/constants.ts
+++ b/packages/arcis-node/src/core/constants.ts
@@ -134,8 +134,8 @@ export const XSS_REMOVE_PATTERNS = [
   /** javascript: and vbscript: protocols (allow optional spaces before colon) */
   /javascript\s*:/gi,
   /vbscript\s*:/gi,
-  /** data: URIs with HTML/script content */
-  /data\s*:\s*text\/html[^>\s]*/gi,
+  /** data: URIs with HTML or SVG content (SVG can run JS via inline event handlers) */
+  /data\s*:\s*(?:text\/html|image\/svg)[^>\s]*/gi,
   /** form tag injection — phishing via action= redirection */
   /<form[\s>][^>]*/gi,
   /** meta tag injection — http-equiv refresh or CSP bypass */
@@ -300,10 +300,11 @@ export const VALIDATION = {
   EMAIL: /^[^\s@.][^\s@]*(?:\.[^\s@.][^\s@]*)*@[^\s@]+\.[^\s@]+$/,
   /**
    * URL regex pattern.
-   * Only allows http:// and https:// — explicitly rejects javascript:,
-   * data:, vbscript:, and other dangerous URI schemes.
+   * Only allows http:// and https:// (case-insensitive scheme per
+   * RFC 3986); explicitly rejects javascript:, data:, vbscript:, and
+   * other dangerous URI schemes.
    */
-  URL: /^https?:\/\/[^\s/$.?#][^\s]*$/,
+  URL: /^https?:\/\/[^\s/$.?#][^\s]*$/i,
   /** UUID regex pattern (v4) */
   UUID: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
 } as const;

--- a/packages/arcis-node/src/middleware/error-handler.ts
+++ b/packages/arcis-node/src/middleware/error-handler.ts
@@ -72,7 +72,14 @@ export function errorHandler(
   const customHandler = typeof options === 'object' ? options.customHandler : undefined;
 
   return (err: HttpError, req: Request, res: Response, _next: NextFunction) => {
-    const statusCode = err.statusCode || err.status || 500;
+    // Clamp to a valid HTTP error range. A thrown error with a bogus
+    // statusCode (negative, zero, or > 599) would otherwise be sent to
+    // the client and break proxies, browsers, or compliance scanners.
+    const rawStatus = err.statusCode ?? err.status ?? 500;
+    const statusCode =
+      Number.isFinite(rawStatus) && rawStatus >= 400 && rawStatus <= 599
+        ? Math.floor(rawStatus)
+        : 500;
 
     // Custom handler takes precedence
     if (customHandler) {

--- a/packages/arcis-node/src/middleware/rate-limit-sliding.ts
+++ b/packages/arcis-node/src/middleware/rate-limit-sliding.ts
@@ -69,6 +69,12 @@ export function createSlidingWindowLimiter(options: SlidingWindowOptions = {}): 
   const currentWindows = Object.create(null) as Record<string, WindowEntry>;
   const previousWindows = Object.create(null) as Record<string, WindowEntry>;
 
+  // Pin cleanup cadence to 30s regardless of windowMs. Scaling cleanup
+  // with windowMs causes churn on short windows (1s window cleans every
+  // second) and stale-entry buildup on long windows (1h window only
+  // cleans hourly). 30s bounds memory growth without burning CPU; the
+  // cutoff stays at `2 * windowMs` so legitimate active windows survive.
+  const CLEANUP_INTERVAL_MS = 30_000;
   const cleanupInterval = setInterval(() => {
     const now = Date.now();
     const cutoff = now - windowMs * 2; // Keep 2 windows worth
@@ -82,7 +88,7 @@ export function createSlidingWindowLimiter(options: SlidingWindowOptions = {}): 
         delete currentWindows[key];
       }
     }
-  }, windowMs);
+  }, CLEANUP_INTERVAL_MS);
 
   if (typeof cleanupInterval.unref === 'function') {
     cleanupInterval.unref();

--- a/packages/arcis-node/src/stores/redis.ts
+++ b/packages/arcis-node/src/stores/redis.ts
@@ -12,7 +12,17 @@ import { RATE_LIMIT } from '../core/constants';
 /** Generic Redis client interface (works with ioredis, redis, etc.) */
 export interface RedisClientLike {
   get(key: string): Promise<string | null>;
-  set(key: string, value: string, mode?: string, duration?: number): Promise<unknown>;
+  /**
+   * SET with optional flags. Supports both `set(key, value)` and
+   * `set(key, value, 'EX', seconds, 'NX')` shapes for atomic
+   * set-if-not-exists with TTL. Returns 'OK' on success; null when NX
+   * is supplied and the key already exists.
+   */
+  set(
+    key: string,
+    value: string,
+    ...args: Array<string | number>
+  ): Promise<string | null | unknown>;
   setex(key: string, seconds: number, value: string): Promise<unknown>;
   expire(key: string, seconds: number): Promise<unknown>;
   incr(key: string): Promise<number>;
@@ -98,18 +108,19 @@ export class RedisStore implements RateLimitStore {
 
   async increment(key: string): Promise<number> {
     const redisKey = this.getKey(key);
-    
-    // INCR creates key with value 1 if it doesn't exist
-    const count = await this.client.incr(redisKey);
 
-    // Set expiry only on first increment using EXPIRE, which sets the TTL
-    // without overwriting the value (unlike SET ... EX which would reset the
-    // counter if two requests increment concurrently before expiry is set).
-    if (count === 1) {
-      await this.client.expire(redisKey, this.windowSec);
+    // SECURITY / RELIABILITY: Atomic first-increment via SET ... EX ... NX.
+    // If the key did not exist, this single command creates it with value
+    // 1 and the window TTL atomically. If it existed, SET returns null
+    // and we fall through to INCR for the actual count. This eliminates
+    // the INCR-then-EXPIRE race where a connection drop between the two
+    // commands could leave a counter without a TTL, locking out the
+    // client until manual intervention.
+    const created = await this.client.set(redisKey, '1', 'EX', this.windowSec, 'NX');
+    if (created === 'OK' || created === true) {
+      return 1;
     }
-
-    return count;
+    return this.client.incr(redisKey);
   }
 
   async decrement(key: string): Promise<void> {

--- a/packages/arcis-node/src/validation/redirect.ts
+++ b/packages/arcis-node/src/validation/redirect.ts
@@ -122,14 +122,20 @@ export function validateRedirect(
     return { safe: false, reason: `disallowed protocol: ${parsed.protocol}` };
   }
 
-  // Check if host is in allowed list
+  // Check if host is in allowed list. Match against host:port form when
+  // a non-default port is present, falling back to hostname only when
+  // the URL uses a default port. parsed.port is "" for default ports
+  // (80 for http, 443 for https), so hostWithPort equals hostname in
+  // those cases. Non-default ports must be explicitly listed: a bare
+  // 'myapp.com' entry does NOT permit redirects to 'myapp.com:9999'.
   const hostname = parsed.hostname.toLowerCase();
+  const hostWithPort = parsed.port ? `${hostname}:${parsed.port}` : hostname;
   if (allowedHosts.length === 0) {
     return { safe: false, reason: 'absolute URL not in allowed hosts' };
   }
 
-  if (!allowedHosts.some(h => hostname === h.toLowerCase())) {
-    return { safe: false, reason: `host not allowed: ${hostname}` };
+  if (!allowedHosts.some(h => h.toLowerCase() === hostWithPort)) {
+    return { safe: false, reason: `host not allowed: ${hostWithPort}` };
   }
 
   return { safe: true };
@@ -147,10 +153,18 @@ export function isRedirectSafe(url: string, options: ValidateRedirectOptions = {
 }
 
 /**
- * Extract hostname from a protocol-relative URL.
+ * Extract host (with optional port) from a protocol-relative URL.
+ * Returns hostname for default ports, "hostname:port" for non-default.
+ * Optional userinfo (user:pass@) is stripped.
  */
 function extractHost(url: string): string | null {
-  // //hostname/path or //hostname:port/path
-  const match = url.match(/^\/\/([^/:?#]+)/);
-  return match ? match[1].toLowerCase() : null;
+  // //user:pass@hostname/path  ->  authority = "user:pass@hostname"
+  // //hostname:port/path       ->  authority = "hostname:port"
+  const match = url.match(/^\/\/([^/?#]+)/);
+  if (!match) return null;
+  // Strip userinfo if present
+  const authority = match[1].includes('@')
+    ? match[1].slice(match[1].indexOf('@') + 1)
+    : match[1];
+  return authority.toLowerCase();
 }

--- a/packages/arcis-node/tests/middleware/error-handler.test.ts
+++ b/packages/arcis-node/tests/middleware/error-handler.test.ts
@@ -65,6 +65,22 @@ describe('errorHandler', () => {
       expect(res.status).toHaveBeenCalledWith(403);
     });
 
+    it('should clamp out-of-range statusCode to 500 (regression)', () => {
+      // Regression: previously any err.statusCode passed through directly,
+      // so a thrown error with statusCode -1 or 99999 would set an invalid
+      // HTTP status on the response, breaking proxies and clients.
+      for (const bogus of [-1, 0, 99, 600, 9999, NaN, Infinity]) {
+        const req = mockRequest();
+        const res = mockResponse();
+        const next = vi.fn();
+        const handler = errorHandler(false);
+        const error: Error & { statusCode?: number } = new Error('boom');
+        error.statusCode = bogus;
+        handler(error, req as Request, res as Response, next as NextFunction);
+        expect(res.status).toHaveBeenCalledWith(500);
+      }
+    });
+
     it('should default to 500 status', () => {
       const req = mockRequest();
       const res = mockResponse();

--- a/packages/arcis-node/tests/validation/redirect.test.ts
+++ b/packages/arcis-node/tests/validation/redirect.test.ts
@@ -75,6 +75,41 @@ describe('validateRedirect', () => {
       expect(validateRedirect('https://cdn.myapp.com/img.png', opts).safe).toBe(true);
       expect(validateRedirect('https://evil.com', opts).safe).toBe(false);
     });
+
+    // Regression: a bare 'myapp.com' entry used to allow any port. An
+    // attacker could redirect to myapp.com:9999/admin or an internal
+    // service on a non-standard port and bypass the allowlist.
+    it('should reject non-default port when allowedHosts has only the bare hostname', () => {
+      const result = validateRedirect('https://myapp.com:9999/admin', {
+        allowedHosts: ['myapp.com'],
+      });
+      expect(result.safe).toBe(false);
+      expect(result.reason).toContain('host not allowed');
+    });
+
+    it('should accept default ports against bare-hostname allowlist entry', () => {
+      // Default ports omit parsed.port, so hostWithPort equals hostname.
+      expect(
+        validateRedirect('https://myapp.com:443/path', { allowedHosts: ['myapp.com'] }).safe,
+      ).toBe(true);
+      expect(
+        validateRedirect('http://myapp.com:80/path', { allowedHosts: ['myapp.com'] }).safe,
+      ).toBe(true);
+    });
+
+    it('should accept explicit non-default port when allowlist names it', () => {
+      const result = validateRedirect('https://myapp.com:9999/admin', {
+        allowedHosts: ['myapp.com:9999'],
+      });
+      expect(result.safe).toBe(true);
+    });
+
+    it('should reject port mismatch even when hostname is in allowlist', () => {
+      const result = validateRedirect('https://myapp.com:8443/admin', {
+        allowedHosts: ['myapp.com', 'myapp.com:9999'],
+      });
+      expect(result.safe).toBe(false);
+    });
   });
 
   describe('Protocol-Relative URLs', () => {

--- a/packages/arcis-python/arcis/fastapi.py
+++ b/packages/arcis-python/arcis/fastapi.py
@@ -277,16 +277,18 @@ class AsyncRateLimiter:
         entry = await self.store.get(key)
         
         if not entry or entry.reset_time < now:
-            # New window
+            # New window. Compute reset as the same `reset_time - now`
+            # delta that the subsequent-request branch uses so clients
+            # see a consistent representation across the whole window.
             reset_time = now + self.window_seconds
             await self.store.set(key, 1, reset_time)
             return {
                 "allowed": True,
                 "limit": self.max_requests,
                 "remaining": self.max_requests - 1,
-                "reset": int(self.window_seconds),
+                "reset": int(reset_time - now),
             }
-        
+
         count = await self.store.increment(key)
         remaining = max(0, self.max_requests - count)
         reset = int(entry.reset_time - now)

--- a/packages/arcis-rust/crates/arcis-engine/src/osv_cache.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/osv_cache.rs
@@ -98,7 +98,20 @@ impl OsvCache {
             fs::create_dir_all(parent)?;
         }
         let bytes = serde_json::to_vec_pretty(self).map_err(io::Error::other)?;
-        fs::write(path, bytes)
+        // Atomic write: serialize to a sibling temp file, then rename. A
+        // crash mid-write leaves either the old contents or the new
+        // contents, never a half-written file. The tmp path lives in the
+        // same directory so rename stays a same-filesystem operation.
+        let tmp = match path.file_name() {
+            Some(name) => {
+                let mut candidate = name.to_owned();
+                candidate.push(".tmp");
+                path.with_file_name(candidate)
+            }
+            None => path.with_extension("tmp"),
+        };
+        fs::write(&tmp, bytes)?;
+        fs::rename(&tmp, path)
     }
 
     /// Return cached vulns iff the entry exists AND is younger than


### PR DESCRIPTION
## Summary

Follows up #116 (critical + high). Closes 7 medium and 2 low items, plus documents 3 medium and 3 low as not-bugs or intentional design.

## Medium fixes

- **M2 osv_cache**: atomic write (temp + rename) so a crash mid-save cannot corrupt the cache.
- **M3 redis store**: replace INCR+EXPIRE with atomic \`SET ... EX ... NX\`. Old race could leave a counter without TTL, locking out the client permanently.
- **M4 sliding-window limiter**: pin cleanup interval to 30s instead of scaling with \`windowMs\`. Short windows churned, long windows leaked.
- **M5 redirect validator**: validate port alongside hostname. \`'myapp.com'\` allowlist no longer permits redirects to \`myapp.com:9999\`. Non-default ports must be explicit. Also strips userinfo from protocol-relative URLs. **4 new regression tests.**
- **M6 xss patterns**: broaden data: URI pattern to also catch \`data:image/svg+xml\` (SVG runs JS via inline event handlers).
- **M7 (re-scoped)**: the email-regex case-sensitivity claim was incorrect (the regex is case-permissive). The actual bug was in the **URL regex**, where \`HTTPS://...\` was rejected. Added \`/i\` flag.
- **M8 error-handler**: clamp \`statusCode\` to 400-599. \`statusCode: -1\` or \`99999\` used to ship to client. **1 new regression test covering 7 bogus values.**
- **M10 AsyncRateLimiter**: compute reset value the same way on first vs subsequent calls.

## Low fixes

- **L4 mcp server**: validate \`path\` argument to \`arcis_audit\` / \`arcis_sca\` before spawning the CLI. Returns a clear error inline if the path does not exist or is not a directory.
- **L5 arcis-java**: add README with explicit pre-alpha 'do not deploy' warning. Package is a 7-file skeleton with no middleware adapters yet.

## Skipped with rationale

- **M1**: em-dash in Rust audit rule messages is load-bearing. \`audit/render.rs:270\` splits on \` — \` to derive SARIF shortDescription. Changing it requires Python parity + render.rs split logic + ~30 test fixture updates. The no-em-dash rule targets prose; rule messages use em-dash as a documented structural delimiter.
- **M9**: the asymmetry the agent described doesn't apply. \`NewRateLimiter\` and \`NewRateLimiterWithStore\` are separate constructors with different signatures.
- **L1**: middleware \`close()\` being sync while \`MemoryStore.close()\` is async is harmless. \`await undefined\` resolves immediately.
- **L2** + **L3**: out of scope for a fix-pass; deserve their own design proposals.

## Test plan

- [x] arcis-node: \`npm test\` (1614 pass / was 1610 before this batch)
- [x] arcis-python: \`pytest tests/integration/test_fastapi.py::TestAsyncRateLimiter\` (10 pass)
- [x] arcis-rust: \`cargo test --package arcis-engine --lib osv\` (21 pass) and full workspace builds clean
- [x] arcis-mcp: \`npm run build\` (compiles)

## Related

- Plan + finding log: \`documents/plans/security-review-2026-05-07.md\` (local; not in repo)
- Critical + high PR: #116 (separate)

## Stacked on

This branch is based on \`nwl\`, not on the critical+high branch. If #116 lands first, this branch needs no rebase. If this lands first, #116 stays clean.