### PR TITLE
feat(go): chi adapter — granular helpers + httptest + telemetry

### DIFF
--- a/packages/arcis-go/README.md
+++ b/packages/arcis-go/README.md
@@ -1,9 +1,11 @@
 # Arcis — Go SDK
 
-Zero-dependency security middleware for Go web applications. Adapters
-ship for Gin and Echo. Detects + sanitizes XSS, SQL injection, NoSQL
-injection, path traversal, command injection, prototype pollution,
-SSTI, XXE, and more across the same surface as the Node and Python SDKs.
+Zero-dependency security middleware for Go web applications. First-party
+adapters ship for Gin, Echo, and chi (works with any router that accepts
+stdlib `http.Handler` middleware via the chi adapter). Detects +
+sanitizes XSS, SQL injection, NoSQL injection, path traversal, command
+injection, prototype pollution, SSTI, XXE, and more across the same
+surface as the Node and Python SDKs.
 
 ```bash
 go get github.com/GagancM/arcis@latest
@@ -26,6 +28,31 @@ func main() {
     r.Run(":8080")
 }
 ```
+
+## Quick start (chi)
+
+```go
+import (
+    "net/http"
+
+    "github.com/go-chi/chi/v5"
+    arcischi "github.com/GagancM/arcis/chi"
+)
+
+func main() {
+    r := chi.NewRouter()
+    cfg := arcischi.DefaultConfig()
+    cfg.Block = true
+    r.Use(arcischi.MiddlewareWithConfig(cfg))
+    r.Get("/", handler)
+    http.ListenAndServe(":8080", r)
+}
+```
+
+The chi adapter is stdlib-only at runtime — `chi/v5` is only required
+in test builds. The adapter's middleware signature is the standard
+`func(next http.Handler) http.Handler`, so it composes with any router
+that accepts stdlib middleware (gorilla/mux, plain `net/http`, etc.).
 
 ## Quick start (Echo)
 
@@ -78,8 +105,8 @@ shipped in Go:
 
 ## Telemetry (v1.5.0+)
 
-Stream allow / deny decisions from the gin or echo middleware to a
-self-hosted Arcis dashboard. Stdlib only; opt-in (nil = zero overhead).
+Stream allow / deny decisions from the gin, echo, or chi middleware to
+a self-hosted Arcis dashboard. Stdlib only; opt-in (nil = zero overhead).
 
 ```go
 import "github.com/GagancM/arcis/telemetry"
@@ -94,9 +121,10 @@ cfg.Telemetry = tc
 r.Use(arcisgin.MiddlewareWithConfig(cfg))
 ```
 
-(Same shape for echo: `arcisecho.MiddlewareWithConfig(cfg)`.) Each
-request emits one `TelemetryEvent` matching `spec/API_SPEC.md` §9 — same
-wire shape Node and Python ship, batched and POSTed in the background.
+(Same shape for echo: `arcisecho.MiddlewareWithConfig(cfg)`, and for
+chi: `arcischi.MiddlewareWithConfig(cfg)`.) Each request emits one
+`TelemetryEvent` matching `spec/API_SPEC.md` §9 — same wire shape Node
+and Python ship, batched and POSTed in the background.
 
 For granular composition, the standalone `RateLimit` /
 `RateLimitWithStore` / `RateLimitWithSkip` helpers accept a
@@ -106,8 +134,10 @@ For granular composition, the standalone `RateLimit` /
 r.Use(arcisgin.RateLimit(100, time.Minute, arcisgin.WithTelemetry(tc)))
 ```
 
-Standalone helpers emit on deny only — composing several of them with
-the same client doesn't multiply per-request events.
+Same option shape on echo (`arcisecho.RateLimit(...)`) and chi
+(`arcischi.RateLimit(...)`). Standalone helpers emit on deny only —
+composing several of them with the same client doesn't multiply
+per-request events.
 
 ### No native SCA scanner
 

--- a/packages/arcis-go/chi/chi.go
+++ b/packages/arcis-go/chi/chi.go
@@ -69,6 +69,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -628,7 +630,14 @@ func RateLimitWithSkip(max int, window time.Duration, skip func(*http.Request) b
 // collisions with other packages.
 type ctxKey int
 
-const sanitizerCtxKey ctxKey = iota
+const (
+	sanitizerCtxKey ctxKey = iota
+	// validatedBodyCtxKey stashes the validated map produced by the
+	// Validate middleware so handlers can fetch the post-validation
+	// shape via GetValidatedBody(r). Mirrors gin's `validated_body`
+	// context key without colliding with user keys.
+	validatedBodyCtxKey
+)
 
 // GetSanitizer retrieves the Arcis sanitizer stashed in the request
 // context by MiddlewareWithConfig. Returns a default sanitizer when no
@@ -640,4 +649,257 @@ func GetSanitizer(r *http.Request) *arcis.Sanitizer {
 		}
 	}
 	return arcis.NewSanitizer(arcis.DefaultConfig())
+}
+
+// Headers returns a chi-compatible middleware that only sets security
+// headers. Pairs with arcis.NewSecurityHeaders + DefaultConfig.
+func Headers() func(http.Handler) http.Handler {
+	return HeadersWithConfig(DefaultConfig())
+}
+
+// HeadersWithConfig returns a security-headers middleware using the
+// supplied configuration. Mirrors gin/echo HeadersWithConfig.
+func HeadersWithConfig(config Config) func(http.Handler) http.Handler {
+	arcisConfig := arcis.Config{
+		CSP:               config.CSP,
+		FrameOptions:      config.FrameOptions,
+		HSTSMaxAge:        config.HSTSMaxAge,
+		HSTSSubdomains:    config.HSTSSubdomains,
+		ReferrerPolicy:    config.ReferrerPolicy,
+		PermissionsPolicy: config.PermissionsPolicy,
+		CacheControl:      config.CacheControl,
+		CacheControlValue: config.CacheControlValue,
+	}
+
+	headers := arcis.NewSecurityHeaders(arcisConfig)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			for key, value := range headers.GetHeaders() {
+				w.Header().Set(key, value)
+			}
+			next.ServeHTTP(w, r)
+			// Strip fingerprinting headers post-handler. Same caveat as
+			// MiddlewareWithConfig: this only mutates the in-memory map,
+			// effective when the handler hasn't flushed yet.
+			w.Header().Del("Server")
+			w.Header().Del("X-Powered-By")
+		})
+	}
+}
+
+// Sanitizer returns a chi-compatible middleware that exposes the Arcis
+// sanitizer to downstream handlers via the request context. Use
+// GetSanitizer(r), SanitizeJSON(r, data), or SanitizeString(r, value)
+// from the handler. Does not modify the request body — opt-in
+// sanitization, not auto-sanitization.
+func Sanitizer() func(http.Handler) http.Handler {
+	return SanitizerWithConfig(DefaultConfig())
+}
+
+// SanitizerWithConfig returns a sanitizer-only middleware using the
+// supplied configuration.
+func SanitizerWithConfig(config Config) func(http.Handler) http.Handler {
+	arcisConfig := arcis.Config{
+		SanitizeXSS:   config.SanitizeXSS,
+		SanitizeSQL:   config.SanitizeSQL,
+		SanitizeNoSQL: config.SanitizeNoSQL,
+		SanitizePath:  config.SanitizePath,
+		SanitizeCmd:   config.SanitizeCmd,
+		MaxInputSize:  config.MaxInputSize,
+	}
+
+	sanitizer := arcis.NewSanitizer(arcisConfig)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), sanitizerCtxKey, sanitizer)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// SanitizeJSON sanitizes JSON data using the sanitizer from request
+// context. Handlers call this after binding the body to a map so the
+// sanitized map is what reaches business logic.
+//
+// Example:
+//
+//	r.Use(arcischi.Sanitizer())
+//	r.Post("/items", func(w http.ResponseWriter, r *http.Request) {
+//	    var data map[string]interface{}
+//	    json.NewDecoder(r.Body).Decode(&data)
+//	    data = arcischi.SanitizeJSON(r, data)
+//	    // …use sanitized data
+//	})
+func SanitizeJSON(r *http.Request, data map[string]interface{}) map[string]interface{} {
+	return GetSanitizer(r).SanitizeMap(data)
+}
+
+// SanitizeString sanitizes a single string value using the sanitizer
+// from request context. Counterpart to SanitizeJSON for handlers that
+// pull individual query / path / header values.
+func SanitizeString(r *http.Request, value string) string {
+	return GetSanitizer(r).SanitizeString(value)
+}
+
+// Validate creates a JSON-body validation middleware. On parse / schema
+// failure responds 400 with a JSON `{"errors": [...]}` body and aborts.
+// On success stashes the validated map on the request context so
+// downstream handlers can fetch it via GetValidatedBody(r).
+//
+// The request body is read once and rebound (`io.NopCloser` over the
+// captured bytes) so a downstream handler that re-parses the body sees
+// the same wire input.
+func Validate(schema arcis.ValidationSchema) func(http.Handler) http.Handler {
+	validator := arcis.NewValidator(schema)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+					"errors": []string{"Failed to read request body"},
+				})
+				return
+			}
+			// Restore body for the next handler regardless of validation
+			// outcome — sanitizer or other downstream middleware may
+			// re-bind from r.Body.
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			r.ContentLength = int64(len(body))
+
+			var data map[string]interface{}
+			if len(body) > 0 {
+				if err := json.Unmarshal(body, &data); err != nil {
+					writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+						"errors": []string{"Invalid JSON"},
+					})
+					return
+				}
+			}
+
+			validated, validationErr := validator.Validate(data)
+			if validationErr != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+					"errors": validationErr.Errors,
+				})
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), validatedBodyCtxKey, validated)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// GetValidatedBody retrieves the validated request body stashed by the
+// Validate middleware. Returns nil when no Validate ran upstream — the
+// nil case mirrors gin's `c.Get("validated_body")` returning false on
+// missing.
+func GetValidatedBody(r *http.Request) map[string]interface{} {
+	if v := r.Context().Value(validatedBodyCtxKey); v != nil {
+		if m, ok := v.(map[string]interface{}); ok {
+			return m
+		}
+	}
+	return nil
+}
+
+// CsrfProtection returns a chi-compatible middleware for CSRF protection
+// using double-submit cookie. Unlike gin/echo, chi IS stdlib so we wrap
+// the underlying arcis.NewCsrfProtection().Handler directly — no
+// response-capture dance required. The native handler:
+//
+//   - validates the token on unsafe methods (POST, PUT, PATCH, DELETE)
+//   - emits a 403 with the same JSON shape as gin/echo on failure
+//   - issues a fresh cookie on safe methods (GET, HEAD, OPTIONS)
+//
+// matching the gin/echo wire format byte-for-byte.
+func CsrfProtection(opts arcis.CsrfOptions) func(http.Handler) http.Handler {
+	csrf := arcis.NewCsrfProtection(opts)
+	return csrf.Handler
+}
+
+// SecureCookies returns a chi-compatible middleware that enforces
+// secure-cookie defaults (Secure, HttpOnly, SameSite) on every
+// Set-Cookie header the handler produces.
+//
+// Same caveat as the headers strip in MiddlewareWithConfig: post-handler
+// header mutations only land on the wire when the handler hasn't
+// flushed yet. Handlers that defer the write benefit; handlers that
+// flush early lose the enforcement.
+func SecureCookies(opts arcis.SecureCookieOptions) func(http.Handler) http.Handler {
+	sc := arcis.NewSecureCookieDefaults(opts)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+			cookies := w.Header().Values("Set-Cookie")
+			if len(cookies) > 0 {
+				w.Header().Del("Set-Cookie")
+				for _, cookie := range cookies {
+					w.Header().Add("Set-Cookie", sc.Enforce(cookie))
+				}
+			}
+		})
+	}
+}
+
+// Cors returns a chi-compatible middleware for safe CORS handling.
+// Sets per-request CORS headers and short-circuits preflight OPTIONS
+// with a 204 when the origin is allowed. Mirrors gin/echo behavior.
+func Cors(opts arcis.CorsOptions) func(http.Handler) http.Handler {
+	cors := arcis.NewSafeCors(opts)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			headers := cors.GetHeaders(origin, r.Method)
+			for key, value := range headers {
+				w.Header().Set(key, value)
+			}
+			// Preflight short-circuit: only when both Origin is set AND
+			// the response includes Access-Control-Allow-Origin (i.e. the
+			// origin was admitted). Disallowed-origin OPTIONS falls
+			// through to the handler so the app can decide.
+			if r.Method == http.MethodOptions && origin != "" {
+				if _, ok := headers["Access-Control-Allow-Origin"]; ok {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// ErrorHandler returns a chi-compatible middleware that catches panics
+// from downstream handlers and renders them through Arcis's error
+// shaper. `isDev=true` includes the panic value in the response body;
+// `isDev=false` returns a generic 500.
+//
+// Closer in spirit to chi's middleware.Recoverer than gin's
+// post-handler `c.Errors` consumption — gin has a built-in error
+// channel, stdlib has only panic. Use the panic / recover pattern; it
+// covers both `panic("string")` and `panic(err)` shapes.
+func ErrorHandler(isDev bool) func(http.Handler) http.Handler {
+	handler := arcis.NewErrorHandler(isDev)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					var err error
+					switch x := rec.(type) {
+					case error:
+						err = x
+					case string:
+						err = errors.New(x)
+					default:
+						err = fmt.Errorf("%v", x)
+					}
+					handler.Handle(w, err, http.StatusInternalServerError)
+				}
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/packages/arcis-go/chi/chi.go
+++ b/packages/arcis-go/chi/chi.go
@@ -821,25 +821,67 @@ func CsrfProtection(opts arcis.CsrfOptions) func(http.Handler) http.Handler {
 	return csrf.Handler
 }
 
+// secureCookieWriter intercepts WriteHeader so SecureCookies can
+// transform Set-Cookie values BEFORE the response is committed to the
+// wire. Once http.ResponseWriter.WriteHeader has been called the header
+// map is no longer mutable (the bytes are en-route to the client), so a
+// pure post-handler approach silently no-ops on handlers that flush
+// eagerly via http.SetCookie + w.WriteHeader.
+type secureCookieWriter struct {
+	http.ResponseWriter
+	sc          *arcis.SecureCookieDefaults
+	wroteHeader bool
+}
+
+func (s *secureCookieWriter) enforce() {
+	cookies := s.ResponseWriter.Header().Values("Set-Cookie")
+	if len(cookies) == 0 {
+		return
+	}
+	s.ResponseWriter.Header().Del("Set-Cookie")
+	for _, cookie := range cookies {
+		s.ResponseWriter.Header().Add("Set-Cookie", s.sc.Enforce(cookie))
+	}
+}
+
+func (s *secureCookieWriter) WriteHeader(code int) {
+	if !s.wroteHeader {
+		s.wroteHeader = true
+		s.enforce()
+		s.ResponseWriter.WriteHeader(code)
+	}
+}
+
+func (s *secureCookieWriter) Write(b []byte) (int, error) {
+	if !s.wroteHeader {
+		// Implicit 200 path: net/http would call WriteHeader(200) for
+		// us; intercept so cookie enforcement still runs.
+		s.WriteHeader(http.StatusOK)
+	}
+	return s.ResponseWriter.Write(b)
+}
+
 // SecureCookies returns a chi-compatible middleware that enforces
 // secure-cookie defaults (Secure, HttpOnly, SameSite) on every
 // Set-Cookie header the handler produces.
 //
-// Same caveat as the headers strip in MiddlewareWithConfig: post-handler
-// header mutations only land on the wire when the handler hasn't
-// flushed yet. Handlers that defer the write benefit; handlers that
-// flush early lose the enforcement.
+// Wraps the response writer so cookies are transformed at WriteHeader
+// time, regardless of whether the handler flushes early or late. Edge
+// case: handlers that return without calling Write or WriteHeader (the
+// implicit-200 path with empty body) still benefit — net/http calls
+// WriteHeader(200) on the wrapped writer when the handler returns.
 func SecureCookies(opts arcis.SecureCookieOptions) func(http.Handler) http.Handler {
 	sc := arcis.NewSecureCookieDefaults(opts)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r)
-			cookies := w.Header().Values("Set-Cookie")
-			if len(cookies) > 0 {
-				w.Header().Del("Set-Cookie")
-				for _, cookie := range cookies {
-					w.Header().Add("Set-Cookie", sc.Enforce(cookie))
-				}
+			sw := &secureCookieWriter{ResponseWriter: w, sc: sc}
+			next.ServeHTTP(sw, r)
+			// Belt-and-braces: handler returned without ever calling
+			// Write or WriteHeader. Header map still mutable; do the
+			// enforcement now so a cookie set + return-without-flush
+			// still gets the secure attributes.
+			if !sw.wroteHeader {
+				sw.enforce()
 			}
 		})
 	}

--- a/packages/arcis-go/chi/chi_test.go
+++ b/packages/arcis-go/chi/chi_test.go
@@ -1,0 +1,515 @@
+// Package chi tests — bundle middleware + granular helpers driven via
+// a real chi.Router with httptest. The chi/v5 dep enters the module
+// here in commit 3 alongside the first file that needs it.
+//
+// Telemetry-shaped tests live in `telemetry_test.go` (commit 4).
+package chi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	chirouter "github.com/go-chi/chi/v5"
+
+	arcis "github.com/GagancM/arcis"
+)
+
+// newRouter is a small helper so each test gets a fresh chi router with
+// a single attached middleware (or stack). Keeps the per-test boilerplate
+// to one line and the setup intent obvious.
+func newRouter(mw ...func(http.Handler) http.Handler) *chirouter.Mux {
+	r := chirouter.NewRouter()
+	for _, m := range mw {
+		r.Use(m)
+	}
+	return r
+}
+
+// ── Middleware bundle ─────────────────────────────────────────────────
+
+func TestMiddleware_AllowPathSetsSecurityHeaders(t *testing.T) {
+	r := newRouter(Middleware())
+	r.Get("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("pong"))
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	t.Cleanup(Cleanup)
+
+	res, err := http.Get(srv.URL + "/ping")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if got := res.Header.Get("Content-Security-Policy"); got == "" {
+		t.Errorf("CSP header missing on allow path")
+	}
+	if got := res.Header.Get("X-Frame-Options"); got != "DENY" {
+		t.Errorf("X-Frame-Options = %q, want DENY", got)
+	}
+}
+
+func TestMiddleware_RateLimitReturns429AfterCap(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.RateLimitMax = 2
+	cfg.RateLimitWindow = time.Minute
+	cfg.Headers = false // Trim noise — we're only after the rate-limit branch.
+
+	r := newRouter(MiddlewareWithConfig(cfg))
+	r.Get("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	t.Cleanup(Cleanup)
+
+	// Two requests succeed, third blows the limiter.
+	for i := 0; i < 2; i++ {
+		res, err := http.Get(srv.URL + "/")
+		if err != nil {
+			t.Fatalf("req %d failed: %v", i, err)
+		}
+		_ = res.Body.Close()
+		if res.StatusCode != http.StatusOK {
+			t.Fatalf("req %d status = %d, want 200", i, res.StatusCode)
+		}
+	}
+	res, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("third request failed: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429", res.StatusCode)
+	}
+	// Retry-After surfaces the reset window so clients can back off.
+	if res.Header.Get("Retry-After") == "" {
+		t.Errorf("Retry-After header missing on 429")
+	}
+}
+
+func TestMiddleware_BlockModeReturns403OnAttack(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Block = true
+	cfg.RateLimit = false // Take rate-limit out of the picture for this assertion.
+	cfg.Headers = false
+
+	r := newRouter(MiddlewareWithConfig(cfg))
+	r.Post("/items", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	t.Cleanup(Cleanup)
+
+	body := strings.NewReader(`{"name": "<script>alert(1)</script>"}`)
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/items", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", res.StatusCode)
+	}
+}
+
+func TestMiddleware_StashesSanitizerOnContext(t *testing.T) {
+	r := newRouter(Middleware())
+	r.Get("/", func(w http.ResponseWriter, req *http.Request) {
+		s := GetSanitizer(req)
+		if s == nil {
+			t.Fatal("GetSanitizer returned nil under bundle middleware")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	t.Cleanup(Cleanup)
+
+	res, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_ = res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+}
+
+// ── Headers helper ────────────────────────────────────────────────────
+
+func TestHeaders_SetsHeadersWithoutRateLimit(t *testing.T) {
+	r := newRouter(Headers())
+	r.Get("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	// Hammer the endpoint past any rate limit — Headers helper must NOT
+	// engage the limiter, so all 5 stay 200.
+	for i := 0; i < 5; i++ {
+		res, err := http.Get(srv.URL + "/")
+		if err != nil {
+			t.Fatalf("req %d failed: %v", i, err)
+		}
+		_ = res.Body.Close()
+		if res.StatusCode != http.StatusOK {
+			t.Fatalf("req %d status = %d, want 200", i, res.StatusCode)
+		}
+		if got := res.Header.Get("Content-Security-Policy"); got == "" {
+			t.Errorf("req %d: CSP header missing", i)
+		}
+	}
+}
+
+// ── Sanitizer / SanitizeJSON / SanitizeString ─────────────────────────
+
+func TestSanitizer_StashesSanitizerOnContext(t *testing.T) {
+	r := newRouter(Sanitizer())
+	r.Get("/", func(w http.ResponseWriter, req *http.Request) {
+		if GetSanitizer(req) == nil {
+			t.Fatal("GetSanitizer returned nil under Sanitizer() middleware")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	res, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_ = res.Body.Close()
+}
+
+func TestSanitizeJSON_StripsScript(t *testing.T) {
+	r := newRouter(Sanitizer())
+	r.Post("/echo", func(w http.ResponseWriter, req *http.Request) {
+		var data map[string]interface{}
+		_ = json.NewDecoder(req.Body).Decode(&data)
+		clean := SanitizeJSON(req, data)
+		writeJSON(w, http.StatusOK, clean)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	body := bytes.NewReader([]byte(`{"name":"<script>alert(1)</script>hi"}`))
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/echo", body)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	var out map[string]interface{}
+	_ = json.NewDecoder(res.Body).Decode(&out)
+	name, _ := out["name"].(string)
+	if strings.Contains(name, "<script>") {
+		t.Errorf("name still contains <script>: %q", name)
+	}
+}
+
+func TestSanitizeString_StripsScript(t *testing.T) {
+	r := newRouter(Sanitizer())
+	r.Get("/", func(w http.ResponseWriter, req *http.Request) {
+		out := SanitizeString(req, req.URL.Query().Get("q"))
+		_, _ = w.Write([]byte(out))
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	res, err := http.Get(srv.URL + "/?q=" + "%3Cscript%3Ehi%3C%2Fscript%3E")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	if strings.Contains(string(body), "<script>") {
+		t.Errorf("response still contains <script>: %q", string(body))
+	}
+}
+
+// ── Validate / GetValidatedBody ──────────────────────────────────────
+
+func TestValidate_400OnInvalidJSON(t *testing.T) {
+	schema := arcis.ValidationSchema{
+		"name": {Type: arcis.TypeString, Required: true},
+	}
+	r := newRouter(Validate(schema))
+	r.Post("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	res, err := http.Post(srv.URL+"/", "application/json", strings.NewReader("not json"))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", res.StatusCode)
+	}
+}
+
+func TestValidate_400OnSchemaFail(t *testing.T) {
+	schema := arcis.ValidationSchema{
+		"name": {Type: arcis.TypeString, Required: true},
+	}
+	r := newRouter(Validate(schema))
+	r.Post("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	// Empty object — required field missing.
+	res, err := http.Post(srv.URL+"/", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", res.StatusCode)
+	}
+	var out map[string]interface{}
+	_ = json.NewDecoder(res.Body).Decode(&out)
+	if _, ok := out["errors"]; !ok {
+		t.Errorf(`response missing "errors" key: %v`, out)
+	}
+}
+
+func TestValidate_200AndStashesValidatedBody(t *testing.T) {
+	schema := arcis.ValidationSchema{
+		"name": {Type: arcis.TypeString, Required: true},
+	}
+	var seen map[string]interface{}
+	r := newRouter(Validate(schema))
+	r.Post("/", func(w http.ResponseWriter, req *http.Request) {
+		seen = GetValidatedBody(req)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	res, err := http.Post(srv.URL+"/", "application/json", strings.NewReader(`{"name":"alice"}`))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_ = res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", res.StatusCode)
+	}
+	if seen == nil {
+		t.Fatal("GetValidatedBody returned nil after Validate succeeded")
+	}
+	if seen["name"] != "alice" {
+		t.Errorf("validated body name = %v, want alice", seen["name"])
+	}
+}
+
+func TestGetValidatedBody_NilWithoutMiddleware(t *testing.T) {
+	// No Validate middleware in the stack — GetValidatedBody must not
+	// panic and must return nil (no key in context).
+	r := newRouter()
+	r.Get("/", func(w http.ResponseWriter, req *http.Request) {
+		if GetValidatedBody(req) != nil {
+			t.Errorf("GetValidatedBody = non-nil without Validate middleware")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	res, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_ = res.Body.Close()
+}
+
+// ── CsrfProtection ────────────────────────────────────────────────────
+
+func TestCsrfProtection_PostWithoutTokenIs403(t *testing.T) {
+	r := newRouter(CsrfProtection(arcis.CsrfOptions{}))
+	r.Post("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	res, err := http.Post(srv.URL+"/", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", res.StatusCode)
+	}
+}
+
+func TestCsrfProtection_GetIssuesCookie(t *testing.T) {
+	r := newRouter(CsrfProtection(arcis.CsrfOptions{}))
+	r.Get("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	res, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+	cookies := res.Cookies()
+	if len(cookies) == 0 {
+		t.Errorf("CSRF middleware did not set a cookie on safe method GET")
+	}
+}
+
+// ── SecureCookies ────────────────────────────────────────────────────
+
+func TestSecureCookies_AddsSecureAttribute(t *testing.T) {
+	r := newRouter(SecureCookies(arcis.SecureCookieOptions{}))
+	r.Get("/", func(w http.ResponseWriter, _ *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "sid", Value: "abc"})
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	res, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+	cookieRaw := res.Header.Get("Set-Cookie")
+	if cookieRaw == "" {
+		t.Fatal("no Set-Cookie header on response")
+	}
+	if !strings.Contains(cookieRaw, "Secure") {
+		t.Errorf("Set-Cookie missing Secure attribute: %q", cookieRaw)
+	}
+	if !strings.Contains(cookieRaw, "HttpOnly") {
+		t.Errorf("Set-Cookie missing HttpOnly attribute: %q", cookieRaw)
+	}
+}
+
+// ── Cors ──────────────────────────────────────────────────────────────
+
+func TestCors_PreflightShortCircuits204(t *testing.T) {
+	r := newRouter(Cors(arcis.CorsOptions{
+		Origin: "https://app.example.com",
+	}))
+	r.Get("/", func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("preflight should not reach the handler")
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodOptions, srv.URL+"/", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", res.StatusCode)
+	}
+	if got := res.Header.Get("Access-Control-Allow-Origin"); got == "" {
+		t.Errorf("Access-Control-Allow-Origin missing on preflight response")
+	}
+}
+
+func TestCors_NormalRequestGetsHeaders(t *testing.T) {
+	r := newRouter(Cors(arcis.CorsOptions{
+		Origin: "https://app.example.com",
+	}))
+	r.Get("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", res.StatusCode)
+	}
+	if got := res.Header.Get("Access-Control-Allow-Origin"); got == "" {
+		t.Errorf("Access-Control-Allow-Origin missing on normal response")
+	}
+}
+
+// ── ErrorHandler ──────────────────────────────────────────────────────
+
+func TestErrorHandler_RecoversFromPanicError(t *testing.T) {
+	r := newRouter(ErrorHandler(false))
+	r.Get("/", func(_ http.ResponseWriter, _ *http.Request) {
+		panic(errors.New("boom"))
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	res, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", res.StatusCode)
+	}
+}
+
+func TestErrorHandler_RecoversFromPanicString(t *testing.T) {
+	// `panic("string")` is a separate code path through the type
+	// switch — pin it explicitly so a future refactor can't drop the
+	// string arm without test failure.
+	r := newRouter(ErrorHandler(false))
+	r.Get("/", func(_ http.ResponseWriter, _ *http.Request) {
+		panic("kaboom")
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	res, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", res.StatusCode)
+	}
+}

--- a/packages/arcis-go/chi/telemetry_test.go
+++ b/packages/arcis-go/chi/telemetry_test.go
@@ -1,0 +1,275 @@
+// Telemetry-shaped chi adapter tests. Mirrors gin/telemetry_test.go and
+// echo/telemetry_test.go file-by-file:
+//
+//   - allow path: bundle MiddlewareWithConfig with Telemetry set, single
+//     event with empty vector/rule/severity, 200 status.
+//   - bundle deny path: Block=true + XSS payload, single event with
+//     vector="xss" / rule="xss/match" / severity="high" / status=403.
+//   - standalone RateLimit deny: variadic WithTelemetry option, 429 emits
+//     vector="rate-limit" / rule="rate-limit/exceeded" / severity="medium"
+//     and the preceding allow does NOT emit (Phase 2b deny-only semantic).
+//
+// `recordingServer` here is the FOURTH copy in the repo (gin, echo,
+// telemetry/client_test). Extracting it to a shared `telemetrytest`
+// helper conflicts with the file-ownership boundary; deferred to a
+// janitor session that can touch all four files at once.
+package chi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	chirouter "github.com/go-chi/chi/v5"
+
+	"github.com/GagancM/arcis/telemetry"
+)
+
+func recordingServer(t *testing.T) (string, <-chan []byte) {
+	t.Helper()
+	ch := make(chan []byte, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		ch <- body
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, ch
+}
+
+func decodeFirstEvent(t *testing.T, body []byte) telemetry.Event {
+	t.Helper()
+	var env struct {
+		Events []telemetry.Event `json:"events"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode batch: %v (body=%q)", err, body)
+	}
+	if len(env.Events) != 1 {
+		t.Fatalf("got %d events, want 1", len(env.Events))
+	}
+	return env.Events[0]
+}
+
+func mustReceiveBody(t *testing.T, ch <-chan []byte, deadline time.Duration) []byte {
+	t.Helper()
+	select {
+	case b := <-ch:
+		return b
+	case <-time.After(deadline):
+		t.Fatal("timeout waiting for telemetry POST")
+		return nil
+	}
+}
+
+func TestChiTelemetry_AllowPath(t *testing.T) {
+	url, reqs := recordingServer(t)
+	tc, err := telemetry.NewClient(telemetry.Options{
+		Endpoint:      url,
+		BatchSize:     1, // flush per-event for deterministic tests
+		FlushInterval: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.RateLimit = false // isolate from rate-limit interference
+	cfg.Block = false
+	cfg.Telemetry = tc
+
+	r := chirouter.NewRouter()
+	r.Use(MiddlewareWithConfig(cfg))
+	r.Get("/ok", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+	t.Cleanup(Cleanup)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ok", nil)
+	req.Header.Set("User-Agent", "test-ua-allow")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("response code = %d, want 200", w.Code)
+	}
+
+	if err := tc.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	evt := decodeFirstEvent(t, mustReceiveBody(t, reqs, time.Second))
+
+	if evt.Decision != telemetry.DecisionAllow {
+		t.Errorf("Decision = %q, want allow", evt.Decision)
+	}
+	if evt.Vector != "" {
+		t.Errorf("Vector = %q, want empty", evt.Vector)
+	}
+	if evt.Rule != "" {
+		t.Errorf("Rule = %q, want empty", evt.Rule)
+	}
+	if evt.Severity != "" {
+		t.Errorf("Severity = %q, want empty", evt.Severity)
+	}
+	if evt.Status != http.StatusOK {
+		t.Errorf("Status = %d, want 200", evt.Status)
+	}
+	if evt.Method != http.MethodGet {
+		t.Errorf("Method = %q, want GET", evt.Method)
+	}
+	if evt.Path != "/ok" {
+		t.Errorf("Path = %q, want /ok", evt.Path)
+	}
+	if evt.UserAgent != "test-ua-allow" {
+		t.Errorf("UserAgent = %q, want test-ua-allow", evt.UserAgent)
+	}
+	if evt.LatencyMs < 0 {
+		t.Errorf("LatencyMs = %v, want >= 0", evt.LatencyMs)
+	}
+	if evt.Ts == "" {
+		t.Errorf("Ts is empty, want RFC3339 timestamp")
+	}
+}
+
+func TestChiTelemetry_BlockDenyPath(t *testing.T) {
+	url, reqs := recordingServer(t)
+	tc, err := telemetry.NewClient(telemetry.Options{
+		Endpoint:      url,
+		BatchSize:     1,
+		FlushInterval: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.RateLimit = false
+	cfg.Block = true
+	cfg.Telemetry = tc
+
+	r := chirouter.NewRouter()
+	r.Use(MiddlewareWithConfig(cfg))
+	r.Post("/api", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("should-not-reach"))
+	})
+	t.Cleanup(Cleanup)
+
+	body := `{"q":"<script>alert(1)</script>"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "test-ua-deny")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("response code = %d, want 403", w.Code)
+	}
+
+	if err := tc.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	evt := decodeFirstEvent(t, mustReceiveBody(t, reqs, time.Second))
+
+	if evt.Decision != telemetry.DecisionDeny {
+		t.Errorf("Decision = %q, want deny", evt.Decision)
+	}
+	if evt.Vector != "xss" {
+		t.Errorf("Vector = %q, want xss", evt.Vector)
+	}
+	if evt.Rule != "xss/match" {
+		t.Errorf("Rule = %q, want xss/match", evt.Rule)
+	}
+	if evt.Severity != telemetry.SeverityHigh {
+		t.Errorf("Severity = %q, want high", evt.Severity)
+	}
+	if evt.MatchedPattern == "" {
+		t.Errorf("MatchedPattern is empty, want a sample of the attack string")
+	}
+	if evt.Reason != "Detected xss pattern" {
+		t.Errorf("Reason = %q, want Detected xss pattern", evt.Reason)
+	}
+	if evt.Status != http.StatusForbidden {
+		t.Errorf("Status = %d, want 403", evt.Status)
+	}
+	if evt.Path != "/api" {
+		t.Errorf("Path = %q, want /api", evt.Path)
+	}
+}
+
+// TestChiTelemetry_StandaloneRateLimitDeny pins the Phase 2b semantic:
+// standalone RateLimit + WithTelemetry emits on deny only. Two requests
+// (allow then deny) must produce exactly ONE telemetry POST with the
+// 429-shaped event — no duplicates from composing RateLimit with other
+// middleware.
+func TestChiTelemetry_StandaloneRateLimitDeny(t *testing.T) {
+	url, reqs := recordingServer(t)
+	tc, err := telemetry.NewClient(telemetry.Options{
+		Endpoint:      url,
+		BatchSize:     1,
+		FlushInterval: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := chirouter.NewRouter()
+	r.Use(RateLimit(1, time.Minute, WithTelemetry(tc)))
+	r.Get("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("pong"))
+	})
+	t.Cleanup(Cleanup)
+
+	// Same RemoteAddr → same rate-limit key. First passes, second 429s.
+	hit := func() int {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+		req.RemoteAddr = "10.0.0.1:5555"
+		req.Header.Set("User-Agent", "test-ua-rl")
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+	if got := hit(); got != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", got)
+	}
+	if got := hit(); got != http.StatusTooManyRequests {
+		t.Fatalf("second request status = %d, want 429", got)
+	}
+
+	if err := tc.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Deny-only emit: two requests, one deny = exactly one telemetry POST.
+	evt := decodeFirstEvent(t, mustReceiveBody(t, reqs, time.Second))
+	select {
+	case extra := <-reqs:
+		t.Fatalf("unexpected second telemetry POST (allow should not emit): body=%q", extra)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	if evt.Decision != telemetry.DecisionDeny {
+		t.Errorf("Decision = %q, want deny", evt.Decision)
+	}
+	if evt.Vector != "rate-limit" {
+		t.Errorf("Vector = %q, want rate-limit", evt.Vector)
+	}
+	if evt.Rule != "rate-limit/exceeded" {
+		t.Errorf("Rule = %q, want rate-limit/exceeded", evt.Rule)
+	}
+	if evt.Severity != telemetry.SeverityMedium {
+		t.Errorf("Severity = %q, want medium", evt.Severity)
+	}
+	if evt.Status != http.StatusTooManyRequests {
+		t.Errorf("Status = %d, want 429", evt.Status)
+	}
+	if evt.Reason != "Rate limit exceeded" {
+		t.Errorf("Reason = %q, want Rate limit exceeded", evt.Reason)
+	}
+}

--- a/packages/arcis-go/go.mod
+++ b/packages/arcis-go/go.mod
@@ -4,7 +4,9 @@ go 1.25.0
 
 require (
 	github.com/gin-gonic/gin v1.12.0
+	github.com/go-chi/chi/v5 v5.2.5
 	github.com/labstack/echo/v4 v4.15.1
+	golang.org/x/text v0.34.0
 )
 
 require (
@@ -39,6 +41,5 @@ require (
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
-	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 )

--- a/packages/arcis-go/go.sum
+++ b/packages/arcis-go/go.sum
@@ -15,6 +15,8 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.12.0 h1:b3YAbrZtnf8N//yjKeU2+MQsh2mY5htkZidOM7O0wG8=
 github.com/gin-gonic/gin v1.12.0/go.mod h1:VxccKfsSllpKshkBWgVgRniFFAzFb9csfngsqANjnLc=
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=


### PR DESCRIPTION
Closes the chi-adapter granular helpers + tests + README that didn't make PR #106's first commit.

## Summary
- Granular helpers: Headers / Sanitizer / Validate / Csrf / SecureCookies / Cors / ErrorHandler
- chi router httptest suite + SecureCookies WriteHeader-interceptor fix
- telemetry allow + bundle-deny + standalone-deny tests
- README quick-start + telemetry parallel section

## Test plan
- [ ] go test ./chi/... -race (Docker)
- [x] 22 tests across chi_test.go + telemetry_test.go pass locally