### PR TITLE
docs: honest-claims marketing rewrite + Go nethttp adapter (sdk-vectors G4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Response sent to client
 | Principle | What It Means |
 |-----------|--------------|
 | **Contract-First** | Specification before code. `API_SPEC.md` → `TEST_VECTORS.json` → implementation. |
-| **Zero Dependencies** | Self-contained. No transitive dependencies. Zero supply chain risk. |
+| **Lean Dependencies** | Node + Python SDKs ship with zero runtime dependencies. Go SDK has a stdlib-only core; framework adapters (Gin, Echo) are imported on demand. |
 | **Fail Open** | If infrastructure (Redis) fails, allow requests through. Availability > denial. |
 | **Defensive Defaults** | Secure out of the box. Users opt OUT of protection, not in. |
 | **Remove Then Encode** | Strip dangerous patterns before encoding. Encoding first hides them from pattern matching. |
@@ -465,7 +465,7 @@ The script is stripped. The rest of the comment is saved normally.
 | Input validation | Yes | No | No | No | No | No |
 | SSRF prevention | Yes | No | No | No | No | Yes |
 | Multi-language | 3 SDKs | Node only | Browser only | Node only | 4 SDKs | Node + Python |
-| Zero dependencies | Yes | Yes | No | No | No | No |
+| Lean core dependencies | Yes | Yes | No | No | No | No |
 | Open Source | Yes | Yes | Yes | Yes | Freemium | Paid |
 | CLI scanner | Yes | No | No | No | No | Yes |
 
@@ -523,7 +523,7 @@ Arcis is a strong defense layer, but it is not a silver bullet:
 
 ### Sanitization Approach
 
-Arcis uses regex-based pattern matching for attack detection. This is a deliberate trade-off: zero dependencies and minimal overhead, at the cost of not having a full HTML/SQL parser.
+Arcis uses regex-based pattern matching for attack detection. This is a deliberate trade-off: lean dependency footprint and minimal overhead, at the cost of not having a full HTML/SQL parser.
 
 **SQL injection specifically:** Arcis strips known SQL attack patterns from user input as a defense-in-depth layer. This is **not a replacement for parameterized queries**. It is an additional barrier. Your database layer should always use parameterized queries or a safe ORM.
 

--- a/packages/arcis-go/README.md
+++ b/packages/arcis-go/README.md
@@ -46,6 +46,34 @@ func main() {
 }
 ```
 
+## Quick start (plain net/http)
+
+For users without a third-party router, the `nethttp` subpackage exposes
+the same middleware shape as a `func(http.Handler) http.Handler`
+decorator. No router dependency.
+
+```go
+import (
+    "net/http"
+    archttp "github.com/GagancM/arcis/nethttp"
+)
+
+func main() {
+    mux := http.NewServeMux()
+    mux.HandleFunc("/", handler)
+
+    cfg := archttp.DefaultConfig()
+    cfg.Block = true
+    var h http.Handler = mux
+    h = archttp.MiddlewareWithConfig(cfg)(h)
+
+    http.ListenAndServe(":8080", h)
+}
+```
+
+Composes with any router that accepts stdlib middleware (chi, gorilla/mux,
+or hand-rolled).
+
 ## Block mode (v1.4.4+)
 
 Setting `Config.Block = true` flips the middleware from "silently sanitize

--- a/packages/arcis-go/README.md
+++ b/packages/arcis-go/README.md
@@ -1,9 +1,10 @@
 # Arcis — Go SDK
 
-Zero-dependency security middleware for Go web applications. Adapters
-ship for Gin and Echo. Detects + sanitizes XSS, SQL injection, NoSQL
-injection, path traversal, command injection, prototype pollution,
-SSTI, XXE, and more across the same surface as the Node and Python SDKs.
+Security middleware for Go web applications. The core is stdlib-only;
+Gin and Echo adapters import their respective router. Detects +
+sanitizes XSS, SQL injection, NoSQL injection, path traversal, command
+injection, prototype pollution, SSTI, XXE, and more across the same
+surface as the Node and Python SDKs.
 
 ```bash
 go get github.com/GagancM/arcis@latest

--- a/packages/arcis-go/nethttp/nethttp.go
+++ b/packages/arcis-go/nethttp/nethttp.go
@@ -1,0 +1,153 @@
+/*
+Package nethttp provides Arcis middleware adapters for plain net/http
+servers (no third-party router required).
+
+The implementation reuses the chi adapter (which is itself stdlib-only —
+it never imports chi/v5 in code, only mentions it in its docstrings).
+This package is a thin re-export so users who do not use chi can
+discover the same middleware under an obvious import path.
+
+Usage:
+
+	import (
+		"net/http"
+		archttp "github.com/GagancM/arcis/nethttp"
+	)
+
+	func main() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", handler)
+
+		// Full protection with defaults
+		var h http.Handler = mux
+		h = archttp.Middleware()(h)
+
+		http.ListenAndServe(":8080", h)
+	}
+
+	// Or with custom config
+	h = archttp.MiddlewareWithConfig(archttp.Config{
+		RateLimitMax:    50,
+		RateLimitWindow: time.Minute,
+		CSP:             "default-src 'self'",
+	})(h)
+
+	// Granular rate-limit middleware with optional telemetry
+	h = archttp.RateLimit(100, time.Minute, archttp.WithTelemetry(tc))(h)
+
+# Resource Cleanup
+
+Arcis's rate limiter runs a background goroutine for cleanup. Call
+Cleanup() when your application shuts down to stop this goroutine and
+release resources:
+
+	import (
+		"context"
+		"net/http"
+		"os/signal"
+		"syscall"
+		archttp "github.com/GagancM/arcis/nethttp"
+	)
+
+	func main() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", handler)
+
+		var h http.Handler = mux
+		h = archttp.Middleware()(h)
+
+		srv := &http.Server{Addr: ":8080", Handler: h}
+
+		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
+
+		go srv.ListenAndServe()
+
+		<-ctx.Done()
+		_ = srv.Shutdown(context.Background())
+		archttp.Cleanup()
+	}
+*/
+package nethttp
+
+import (
+	"net/http"
+	"time"
+
+	arcis "github.com/GagancM/arcis"
+	arcischi "github.com/GagancM/arcis/chi"
+	"github.com/GagancM/arcis/telemetry"
+)
+
+// Config holds Arcis middleware configuration. Aliased to the chi
+// package so the two adapters share one source of truth.
+type Config = arcischi.Config
+
+// RateLimitOption configures a standalone rate-limit middleware. Use
+// WithTelemetry to attach a telemetry client.
+type RateLimitOption = arcischi.RateLimitOption
+
+// DefaultConfig returns the default Arcis configuration.
+func DefaultConfig() Config { return arcischi.DefaultConfig() }
+
+// Cleanup closes all active Arcis middleware instances and releases
+// resources. Stops background goroutines used by rate limiters for
+// expired-entry cleanup. Call Cleanup() at application shutdown to
+// prevent goroutine leaks.
+//
+// Cleanup is shared with the chi adapter — calling either flushes
+// rate-limit instances created by either package.
+func Cleanup() { arcischi.Cleanup() }
+
+// WithTelemetry attaches a telemetry client to a standalone
+// rate-limit middleware. On 429, one TelemetryEvent is emitted with
+// vector="rate-limit", rule="rate-limit/exceeded", severity="medium".
+//
+// Standalone helpers emit only on deny. Allow events come from
+// MiddlewareWithConfig; emitting them here would duplicate when
+// composing RateLimit + Sanitizer + Validate with telemetry on each.
+func WithTelemetry(tc *telemetry.Client) RateLimitOption {
+	return arcischi.WithTelemetry(tc)
+}
+
+// Middleware returns the default Arcis middleware: rate limiting,
+// security headers, server-fingerprint stripping. Composes with any
+// router that accepts stdlib middleware (`func(http.Handler) http.Handler`).
+func Middleware() func(http.Handler) http.Handler {
+	return arcischi.Middleware()
+}
+
+// MiddlewareWithConfig returns Arcis middleware honoring the supplied
+// config. When `Block` is true, scans the request body, query, and URL
+// path for attack patterns and responds 403 instead of running the
+// handler. When a Telemetry client is configured, emits one event per
+// request (allow + deny) with the standard wire format.
+func MiddlewareWithConfig(config Config) func(http.Handler) http.Handler {
+	return arcischi.MiddlewareWithConfig(config)
+}
+
+// RateLimit returns a standalone rate-limit middleware. Optional
+// WithTelemetry attaches a telemetry client that emits on 429.
+func RateLimit(max int, window time.Duration, opts ...RateLimitOption) func(http.Handler) http.Handler {
+	return arcischi.RateLimit(max, window, opts...)
+}
+
+// RateLimitWithStore returns a rate-limit middleware backed by an
+// external store (Redis, etc.).
+func RateLimitWithStore(max int, window time.Duration, store arcis.RateLimitStore, opts ...RateLimitOption) func(http.Handler) http.Handler {
+	return arcischi.RateLimitWithStore(max, window, store, opts...)
+}
+
+// RateLimitWithSkip returns a rate-limit middleware that skips
+// counting requests for which `skip(r)` returns true (e.g. internal
+// health checks).
+func RateLimitWithSkip(max int, window time.Duration, skip func(*http.Request) bool, opts ...RateLimitOption) func(http.Handler) http.Handler {
+	return arcischi.RateLimitWithSkip(max, window, skip, opts...)
+}
+
+// GetSanitizer retrieves the per-request Sanitizer that
+// MiddlewareWithConfig stashes on the request context. Returns nil if
+// the middleware was not in the chain or sanitization was disabled.
+func GetSanitizer(r *http.Request) *arcis.Sanitizer {
+	return arcischi.GetSanitizer(r)
+}

--- a/packages/arcis-go/nethttp/nethttp_test.go
+++ b/packages/arcis-go/nethttp/nethttp_test.go
@@ -1,0 +1,228 @@
+package nethttp_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	archttp "github.com/GagancM/arcis/nethttp"
+)
+
+func helloHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+}
+
+func TestMiddleware_AllowsCleanRequest(t *testing.T) {
+	h := archttp.Middleware()(helloHandler())
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	defer archttp.Cleanup()
+
+	res, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", res.StatusCode)
+	}
+	if got := res.Header.Get("X-Frame-Options"); got != "DENY" {
+		t.Fatalf("X-Frame-Options: got %q want DENY", got)
+	}
+	if res.Header.Get("Server") != "" {
+		t.Fatalf("Server header should be stripped, got %q", res.Header.Get("Server"))
+	}
+}
+
+func TestMiddlewareWithConfig_BlockMode_RejectsXSS(t *testing.T) {
+	cfg := archttp.DefaultConfig()
+	cfg.Block = true
+	h := archttp.MiddlewareWithConfig(cfg)(helloHandler())
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	defer archttp.Cleanup()
+
+	body := strings.NewReader(`{"q":"<script>alert(1)</script>"}`)
+	req, _ := http.NewRequest("POST", srv.URL+"/", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403", res.StatusCode)
+	}
+	var payload struct {
+		Error string `json:"error"`
+	}
+	raw, _ := io.ReadAll(res.Body)
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("body decode: %v", err)
+	}
+	if payload.Error == "" {
+		t.Fatalf("expected error string in body, got %s", string(raw))
+	}
+}
+
+func TestMiddlewareWithConfig_BlockMode_AllowsCleanBody(t *testing.T) {
+	cfg := archttp.DefaultConfig()
+	cfg.Block = true
+	h := archttp.MiddlewareWithConfig(cfg)(helloHandler())
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	defer archttp.Cleanup()
+
+	body := strings.NewReader(`{"name":"Gagan"}`)
+	req, _ := http.NewRequest("POST", srv.URL+"/", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", res.StatusCode)
+	}
+}
+
+func TestRateLimit_StandaloneRejectsAfterCap(t *testing.T) {
+	limit := archttp.RateLimit(2, time.Minute)
+	h := limit(helloHandler())
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	defer archttp.Cleanup()
+
+	for i := 0; i < 2; i++ {
+		res, err := http.Get(srv.URL + "/")
+		if err != nil {
+			t.Fatalf("get %d: %v", i, err)
+		}
+		_ = res.Body.Close()
+		if res.StatusCode != http.StatusOK {
+			t.Fatalf("call %d: got %d want 200", i, res.StatusCode)
+		}
+	}
+
+	res, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("third get: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("third call: got %d want 429", res.StatusCode)
+	}
+	if res.Header.Get("Retry-After") == "" {
+		t.Fatalf("expected Retry-After header on 429")
+	}
+}
+
+func TestRateLimit_SkipsHealthcheck(t *testing.T) {
+	skip := func(r *http.Request) bool {
+		return r.URL.Path == "/healthz"
+	}
+	limit := archttp.RateLimitWithSkip(1, time.Minute, skip)
+	h := limit(helloHandler())
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	defer archttp.Cleanup()
+
+	for i := 0; i < 5; i++ {
+		res, err := http.Get(srv.URL + "/healthz")
+		if err != nil {
+			t.Fatalf("healthz %d: %v", i, err)
+		}
+		_ = res.Body.Close()
+		if res.StatusCode != http.StatusOK {
+			t.Fatalf("healthz call %d should be exempt: got %d", i, res.StatusCode)
+		}
+	}
+
+	// First non-exempt call should pass.
+	res, _ := http.Get(srv.URL + "/api")
+	_ = res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("first /api call: got %d want 200", res.StatusCode)
+	}
+	// Second non-exempt call hits the limit of 1.
+	res, _ = http.Get(srv.URL + "/api")
+	_ = res.Body.Close()
+	if res.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("second /api call: got %d want 429", res.StatusCode)
+	}
+}
+
+func TestMiddlewareWithConfig_HeadersOnlyMode(t *testing.T) {
+	cfg := Config{
+		Headers:        true,
+		FrameOptions:   "SAMEORIGIN",
+		ReferrerPolicy: "no-referrer",
+		HSTSMaxAge:     63072000,
+		HSTSSubdomains: true,
+		CSP:            "default-src 'none'",
+	}
+	h := archttp.MiddlewareWithConfig(cfg)(helloHandler())
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	defer archttp.Cleanup()
+
+	res, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer res.Body.Close()
+
+	if got := res.Header.Get("X-Frame-Options"); got != "SAMEORIGIN" {
+		t.Fatalf("X-Frame-Options: got %q want SAMEORIGIN", got)
+	}
+	if got := res.Header.Get("Referrer-Policy"); got != "no-referrer" {
+		t.Fatalf("Referrer-Policy: got %q want no-referrer", got)
+	}
+	if got := res.Header.Get("Content-Security-Policy"); got != "default-src 'none'" {
+		t.Fatalf("CSP: got %q", got)
+	}
+	hsts := res.Header.Get("Strict-Transport-Security")
+	if !strings.Contains(hsts, "max-age=63072000") || !strings.Contains(hsts, "includeSubDomains") {
+		t.Fatalf("HSTS: got %q", hsts)
+	}
+}
+
+func TestGetSanitizer_ReturnsInstance(t *testing.T) {
+	cfg := archttp.DefaultConfig()
+	var got bool
+	h := archttp.MiddlewareWithConfig(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s := archttp.GetSanitizer(r)
+		if s != nil {
+			got = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	defer archttp.Cleanup()
+
+	res, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	_ = res.Body.Close()
+
+	if !got {
+		t.Fatalf("expected GetSanitizer to return a non-nil Sanitizer when middleware is in the chain")
+	}
+}
+
+// Type alias so the test file can spell `Config` without re-importing.
+type Config = archttp.Config

--- a/packages/arcis-java/pom.xml
+++ b/packages/arcis-java/pom.xml
@@ -10,7 +10,7 @@
     <packaging>jar</packaging>
 
     <name>Arcis</name>
-    <description>Security middleware for Java web applications. Protects against 42+ security flaws with zero dependencies.</description>
+    <description>Security middleware for Java web applications. Protects against 42+ security flaws with a lean dependency footprint.</description>
     <url>https://github.com/GagancM/arcis</url>
 
     <licenses>

--- a/packages/arcis-rust/crates/arcis-cli/src/catalog.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/catalog.rs
@@ -53,10 +53,7 @@ fn ljust(s: &str, width: usize) -> String {
 pub fn print<W: Write>(w: &mut W, version: &str, verbose: bool) -> io::Result<()> {
     writeln!(w)?;
     writeln!(w, "  Arcis  v{version}")?;
-    writeln!(
-        w,
-        "  Security middleware + scanners for Node, Python, Go."
-    )?;
+    writeln!(w, "  Security middleware + scanners for Node, Python, Go.")?;
     writeln!(w)?;
     writeln!(w, "  Commands")?;
     for row in COMMANDS {

--- a/packages/arcis-rust/crates/arcis-cli/src/catalog.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/catalog.rs
@@ -55,7 +55,7 @@ pub fn print<W: Write>(w: &mut W, version: &str, verbose: bool) -> io::Result<()
     writeln!(w, "  Arcis  v{version}")?;
     writeln!(
         w,
-        "  Zero-dep security middleware + scanners for Node, Python, Go."
+        "  Security middleware + scanners for Node, Python, Go."
     )?;
     writeln!(w)?;
     writeln!(w, "  Commands")?;

--- a/website/changelog.html
+++ b/website/changelog.html
@@ -471,7 +471,7 @@
       <div class="footer-inner">
         <div class="footer-brand">
           <div class="footer-logo">Arcis<span>.</span></div>
-          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, lean dependency footprint.</p>
           <div class="footer-badges">
             <span class="footer-badge">
               <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>

--- a/website/documentation/api-reference.html
+++ b/website/documentation/api-reference.html
@@ -218,7 +218,7 @@ validateUrl<span class="p">(</span><span class="s">'https://api.example.com/'</s
       <div class="footer-inner">
         <div class="footer-brand">
           <div class="footer-logo">Arcis<span>.</span></div>
-          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, lean dependency footprint.</p>
           <div class="footer-badges">
             <span class="footer-badge">
               <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>

--- a/website/documentation/attack-vectors.html
+++ b/website/documentation/attack-vectors.html
@@ -183,7 +183,7 @@
       <div class="footer-inner">
         <div class="footer-brand">
           <div class="footer-logo">Arcis<span>.</span></div>
-          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, lean dependency footprint.</p>
           <div class="footer-badges">
             <span class="footer-badge">
               <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>

--- a/website/documentation/cli.html
+++ b/website/documentation/cli.html
@@ -277,7 +277,7 @@ arcis scan http://localhost:8000 --route POST:/echo --field q --thorough</code><
       <div class="footer-inner">
         <div class="footer-brand">
           <div class="footer-logo">Arcis<span>.</span></div>
-          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, lean dependency footprint.</p>
           <div class="footer-badges">
             <span class="footer-badge">
               <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>

--- a/website/documentation/configuration.html
+++ b/website/documentation/configuration.html
@@ -207,7 +207,7 @@ app.<span class="f">use</span><span class="p">(</span><span class="f">csrfProtec
       <div class="footer-inner">
         <div class="footer-brand">
           <div class="footer-logo">Arcis<span>.</span></div>
-          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, lean dependency footprint.</p>
           <div class="footer-badges">
             <span class="footer-badge">
               <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>

--- a/website/documentation/frameworks.html
+++ b/website/documentation/frameworks.html
@@ -296,7 +296,7 @@ app = <span class="f">Flask</span><span class="p">(</span>__name__<span class="p
       <div class="footer-inner">
         <div class="footer-brand">
           <div class="footer-logo">Arcis<span>.</span></div>
-          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, lean dependency footprint.</p>
           <div class="footer-badges">
             <span class="footer-badge">
               <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>

--- a/website/documentation/getting-started.html
+++ b/website/documentation/getting-started.html
@@ -411,7 +411,7 @@ curl <span class="s">'http://localhost:3000/?q=&lt;script&gt;alert(1)&lt;/script
       <div class="footer-inner">
         <div class="footer-brand">
           <div class="footer-logo">Arcis<span>.</span></div>
-          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, lean dependency footprint.</p>
           <div class="footer-badges">
             <span class="footer-badge">
               <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>

--- a/website/documentation/index.html
+++ b/website/documentation/index.html
@@ -222,7 +222,7 @@ go get github.com/GagancM/arcis
       <div class="footer-inner">
         <div class="footer-brand">
           <div class="footer-logo">Arcis<span>.</span></div>
-          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, lean dependency footprint.</p>
           <div class="footer-badges">
             <span class="footer-badge">
               <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>

--- a/website/index.html
+++ b/website/index.html
@@ -14,9 +14,9 @@
   </script>
 
   <title>Arcis: Security Middleware for Every Backend</title>
-  <meta name="description" content="One line of code protects your app against 20+ attack vectors. Zero dependencies. Works with Node.js, Python, and Go.">
+  <meta name="description" content="One line of code protects your app against 20+ attack vectors. Lean dependency footprint. Works with Node.js, Python, and Go.">
   <meta property="og:title" content="Arcis. Security Middleware for Every Backend">
-  <meta property="og:description" content="One line of code. 20+ attack vectors handled. Zero dependencies. Node.js, Python, Go.">
+  <meta property="og:description" content="One line of code. 20+ attack vectors handled. Three languages: Node.js, Python, Go.">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -1395,7 +1395,7 @@
           <ul>
             <li>One package, one line: <code>app.use(arcis({ block: true }))</code></li>
             <li>20+ attack vectors covered instantly.</li>
-            <li>Zero dependencies. Zero configuration.</li>
+            <li>Lean dependencies. Zero configuration.</li>
           </ul>
         </div>
       </div>
@@ -1610,7 +1610,7 @@
             <tr><td>SSRF prevention</td><td class="arcis-col"><span class="check">&#10003;</span></td><td><span class="cross">&#10005;</span></td><td><span class="cross">&#10005;</span></td><td><span class="cross">&#10005;</span></td><td><span class="cross">&#10005;</span></td><td><span class="check">&#10003;</span></td></tr>
             <tr><td>Supply chain scanner</td><td class="arcis-col"><span class="check">&#10003;</span></td><td><span class="cross">&#10005;</span></td><td><span class="cross">&#10005;</span></td><td><span class="cross">&#10005;</span></td><td><span class="cross">&#10005;</span></td><td><span class="cross">&#10005;</span></td></tr>
             <tr><td>Multi-language</td><td class="arcis-col"><span class="check">3 SDKs</span></td><td>Node only</td><td>Browser</td><td>Node only</td><td>3 SDKs</td><td>Node + Py</td></tr>
-            <tr><td>Zero dependencies</td><td class="arcis-col"><span class="check">&#10003;</span></td><td><span class="check">&#10003;</span></td><td><span class="cross">&#10005;</span></td><td><span class="cross">&#10005;</span></td><td><span class="cross">&#10005;</span></td><td><span class="cross">&#10005;</span></td></tr>
+            <tr><td>Lean core dependencies</td><td class="arcis-col"><span class="check">&#10003;</span></td><td><span class="check">&#10003;</span></td><td><span class="cross">&#10005;</span></td><td><span class="cross">&#10005;</span></td><td><span class="cross">&#10005;</span></td><td><span class="cross">&#10005;</span></td></tr>
             <tr><td>Open source</td><td class="arcis-col"><span class="check">&#10003;</span></td><td><span class="check">&#10003;</span></td><td><span class="check">&#10003;</span></td><td><span class="check">&#10003;</span></td><td>Freemium</td><td>Paid</td></tr>
           </tbody>
         </table>
@@ -1859,7 +1859,7 @@
       <div class="footer-inner">
         <div class="footer-brand">
           <div class="footer-logo">Arcis<span>.</span></div>
-          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, zero dependencies.</p>
+          <p class="footer-tagline">Security middleware for every backend. One line of code, 20+ attack vectors handled, lean dependency footprint.</p>
           <div class="footer-badges">
             <span class="footer-badge">
               <svg width="12" height="12" viewBox="0 0 16 16" fill="rgba(255,255,255,0.5)"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>


### PR DESCRIPTION
## Summary
- 'Zero dependencies' marketing rewritten to per-SDK accurate (Node + Python core: zero runtime deps; Go: stdlib-only core with optional Gin/Echo adapters). 13 files: README, arcis-go/README, arcis-java/pom.xml, arcis-rust catalog.rs, website index.html + 8 doc pages.
- Go nethttp adapter (issue #45 / sdk-vectors G4) — pure re-export of the stdlib-only chi adapter so users without chi can find it. 8 tests using only stdlib net/http + httptest.

## Test plan
- [x] Marketing copy reads accurately per SDK
- [ ] go test ./nethttp/... -race (Docker)