### PR TITLE
feat(rust-audit): bounded-concurrency parallel scan (cli-audit.md item 11)

### DIFF
--- a/packages/arcis-rust/crates/arcis-cli/src/audit.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/audit.rs
@@ -15,12 +15,18 @@ use std::time::Instant;
 
 use arcis_engine::audit::{
     assign_ids, classify_baseline, collect_files_with_options, detect_language, render_json,
-    render_sarif, rules as compiled_rules, scan_file_with_suppression, Baseline, BaselineEntry,
+    render_sarif, rules as compiled_rules, scan_files_parallel, Baseline, BaselineEntry,
     BaselineError, BaselineSummary, Finding, IgnoreOptions, JsonReport, Language, SarifReport,
     Severity,
 };
 
 const TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Default worker count when `--jobs` is not given. cli-audit.md item 11
+/// pins this at 8: enough to hit the 4–8× speedup target on 1k-file
+/// monorepos without oversubscribing typical dev machines. Users on
+/// tiny CI runners or beefy 16-core boxes override via `--jobs N`.
+const DEFAULT_JOBS: usize = 8;
 
 #[derive(Debug)]
 struct Args {
@@ -51,6 +57,10 @@ struct Args {
     /// `<path>.tmp` rename). Always exits 0 — recording IS success by
     /// definition. Mutually exclusive with [`Self::baseline`].
     baseline_write: Option<PathBuf>,
+    /// `--jobs N` / `-j N`: worker thread count for parallel file
+    /// scanning. cli-audit.md item 11. `None` falls back to
+    /// [`DEFAULT_JOBS`] (8). Zero is rejected at parse time.
+    jobs: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -75,6 +85,7 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
     let mut no_gitignore = false;
     let mut baseline: Option<PathBuf> = None;
     let mut baseline_write: Option<PathBuf> = None;
+    let mut jobs: Option<usize> = None;
 
     let mut iter = argv.iter().enumerate();
     while let Some((_, arg)) = iter.next() {
@@ -142,6 +153,22 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
                     );
                 }
             },
+            "--jobs" | "-j" => match iter.next() {
+                Some((_, v)) => match v.parse::<usize>() {
+                    Ok(0) => {
+                        return ParseOutcome::Err("arcis audit: --jobs must be at least 1".into());
+                    }
+                    Ok(n) => jobs = Some(n),
+                    Err(_) => {
+                        return ParseOutcome::Err(format!(
+                            "arcis audit: invalid --jobs value: {v} (expected a positive integer)"
+                        ));
+                    }
+                },
+                None => {
+                    return ParseOutcome::Err("arcis audit: --jobs requires an argument".into());
+                }
+            },
             "--severity" | "-s" => match iter.next() {
                 Some((_, v)) => match Severity::parse(v) {
                     Some(s) => severity = Some(s),
@@ -184,6 +211,7 @@ fn parse_args(argv: &[String]) -> ParseOutcome {
         no_gitignore,
         baseline,
         baseline_write,
+        jobs,
     })
 }
 
@@ -285,6 +313,10 @@ fn print_help<W: Write>(out: &mut W) -> io::Result<()> {
     writeln!(
         out,
         "                       will surface the lower-severity entries as resolved."
+    )?;
+    writeln!(
+        out,
+        "  -j, --jobs N         Worker threads for parallel file scanning (default 8)."
     )?;
     writeln!(out, "  -h, --help           Show this message and exit.")?;
     Ok(())
@@ -468,15 +500,15 @@ pub fn run(argv: &[String]) -> ExitCode {
         None => compiled_rules().len(),
     };
 
-    // Run scan. Time only the scan phase, like Python.
+    // Run scan. Time only the scan phase, like Python. Worker pool
+    // (cli-audit.md item 11) processes files concurrently; the engine
+    // clamps `jobs` to `[1, files.len()]` and falls through to the
+    // serial path on a single-core CI runner without thread overhead.
+    let jobs = args.jobs.unwrap_or(DEFAULT_JOBS);
     let start = Instant::now();
-    let mut findings: Vec<Finding> = Vec::new();
-    let mut suppressed_total: usize = 0;
-    for f in &files {
-        let r = scan_file_with_suppression(f);
-        findings.extend(r.findings);
-        suppressed_total += r.suppressed;
-    }
+    let scan_result = scan_files_parallel(&files, jobs);
+    let mut findings: Vec<Finding> = scan_result.findings;
+    let suppressed_total: usize = scan_result.suppressed;
     let duration_ms = start.elapsed().as_millis() as u64;
 
     // Severity filter — keep findings whose severity rank <= threshold.
@@ -1238,6 +1270,84 @@ mod tests {
     fn parse_args_baseline_write_without_path_errors() {
         let r = parse_args(&[".".to_string(), "--baseline-write".to_string()]);
         assert!(matches!(r, ParseOutcome::Err(msg) if msg.contains("requires a path")));
+    }
+
+    // ── --jobs flag (cli-audit.md item 11) ─────────────────────────────
+
+    #[test]
+    fn parse_args_jobs_long_flag() {
+        match parse_args(&[".".to_string(), "--jobs".to_string(), "4".to_string()]) {
+            ParseOutcome::Args(a) => assert_eq!(a.jobs, Some(4)),
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_jobs_short_flag() {
+        match parse_args(&[".".to_string(), "-j".to_string(), "16".to_string()]) {
+            ParseOutcome::Args(a) => assert_eq!(a.jobs, Some(16)),
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_jobs_default_is_none() {
+        // Caller fills in DEFAULT_JOBS (8) — parser stays neutral so the
+        // explicit-flag-vs-default distinction stays visible if we ever
+        // need to log it.
+        match parse_args(&[".".to_string()]) {
+            ParseOutcome::Args(a) => assert!(a.jobs.is_none()),
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_args_jobs_zero_errors() {
+        // Zero workers would never make progress. Reject at parse time
+        // so the user gets a clear message instead of a silent hang.
+        let r = parse_args(&[".".to_string(), "--jobs".to_string(), "0".to_string()]);
+        assert!(matches!(r, ParseOutcome::Err(msg) if msg.contains("at least 1")));
+    }
+
+    #[test]
+    fn parse_args_jobs_non_numeric_errors() {
+        let r = parse_args(&[".".to_string(), "--jobs".to_string(), "many".to_string()]);
+        assert!(matches!(r, ParseOutcome::Err(msg) if msg.contains("invalid --jobs")));
+    }
+
+    #[test]
+    fn parse_args_jobs_negative_errors() {
+        // `-4`.parse::<usize>() rejects the leading minus — covered by
+        // the same path as the non-numeric case but pin it explicitly so
+        // a future move to a signed type doesn't silently accept it.
+        let r = parse_args(&[".".to_string(), "--jobs".to_string(), "-4".to_string()]);
+        assert!(matches!(r, ParseOutcome::Err(msg) if msg.contains("invalid --jobs")));
+    }
+
+    #[test]
+    fn parse_args_jobs_without_value_errors() {
+        let r = parse_args(&[".".to_string(), "--jobs".to_string()]);
+        assert!(matches!(r, ParseOutcome::Err(msg) if msg.contains("requires an argument")));
+    }
+
+    #[test]
+    fn help_text_documents_jobs_flag() {
+        // Refinement #3 mirror: pin --jobs in the help text. Both forms
+        // appear, the default (8) is named, and the purpose ("parallel"
+        // / "worker") is surfaced so users know what they're tuning.
+        let mut buf: Vec<u8> = Vec::new();
+        print_help(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("--jobs"), "help must mention --jobs");
+        assert!(out.contains("-j"), "help must mention -j short form");
+        assert!(
+            out.contains("8"),
+            "help must surface the default worker count: {out}"
+        );
+        assert!(
+            out.to_lowercase().contains("worker") || out.to_lowercase().contains("parallel"),
+            "help must explain --jobs is about parallelism: {out}"
+        );
     }
 
     #[test]

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/engine.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/engine.rs
@@ -6,7 +6,10 @@
 //! lives in `arcis-cli` next to the clap glue.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::thread;
 
 use super::finding_id;
 use super::rules::{rules as compiled_rules, Language, Rule, Severity};
@@ -170,6 +173,80 @@ pub fn scan_file_with_suppression(path: &Path) -> FileResult {
     FileResult {
         findings,
         suppressed,
+    }
+}
+
+/// Scan multiple files in parallel using `jobs` worker threads.
+///
+/// cli-audit.md item 11. Returns the combined per-file
+/// [`FileResult`]s — findings concatenated (unordered; caller sorts)
+/// and suppression counts summed. Bounded concurrency: at most `jobs`
+/// files in flight at once. Memory stays flat regardless of total file
+/// count because each worker only holds one file's content at a time.
+///
+/// Workers steal indices from a shared atomic cursor — no per-file
+/// channel, no `Arc<Vec>` clones, just a counter and a results mutex.
+/// Output ordering is non-deterministic by design; callers that need
+/// a stable order sort by `(severity, file, line)` after collection
+/// (which the CLI already does for byte-equal JSON / SARIF parity).
+///
+/// `jobs == 0` falls through to the serial path (treated as 1). Passing
+/// more workers than files spawns at most one worker per file.
+pub fn scan_files_parallel(paths: &[PathBuf], jobs: usize) -> FileResult {
+    if paths.is_empty() {
+        return FileResult::default();
+    }
+
+    // Serial fast path: avoids thread + sync overhead for tiny scans
+    // and gives us a single code path for `jobs in {0, 1}`.
+    let effective = jobs.max(1).min(paths.len());
+    if effective == 1 {
+        let mut findings = Vec::new();
+        let mut suppressed = 0usize;
+        for p in paths {
+            let r = scan_file_with_suppression(p);
+            findings.extend(r.findings);
+            suppressed += r.suppressed;
+        }
+        return FileResult {
+            findings,
+            suppressed,
+        };
+    }
+
+    let cursor = AtomicUsize::new(0);
+    let findings: Mutex<Vec<Finding>> = Mutex::new(Vec::new());
+    let suppressed = AtomicUsize::new(0);
+
+    thread::scope(|s| {
+        for _ in 0..effective {
+            s.spawn(|| loop {
+                let i = cursor.fetch_add(1, Ordering::Relaxed);
+                if i >= paths.len() {
+                    break;
+                }
+                let r = scan_file_with_suppression(&paths[i]);
+                if !r.findings.is_empty() {
+                    // Lock only when we have something to push — common
+                    // scan path is "file has no findings" so contention
+                    // stays low even at high `jobs`.
+                    findings
+                        .lock()
+                        .expect("audit findings mutex poisoned")
+                        .extend(r.findings);
+                }
+                if r.suppressed > 0 {
+                    suppressed.fetch_add(r.suppressed, Ordering::Relaxed);
+                }
+            });
+        }
+    });
+
+    FileResult {
+        findings: findings
+            .into_inner()
+            .expect("audit findings mutex poisoned"),
+        suppressed: suppressed.load(Ordering::Relaxed),
     }
 }
 
@@ -612,6 +689,135 @@ mod tests {
         let findings = scan_directory(td.path(), None, None);
         assert_eq!(findings.len(), 1);
         assert!(findings[0].file.contains("main.py"));
+    }
+
+    // ── parallel scan (cli-audit.md item 11) ───────────────────────────
+
+    #[test]
+    fn scan_files_parallel_empty_returns_empty() {
+        let r = scan_files_parallel(&[], 8);
+        assert!(r.findings.is_empty());
+        assert_eq!(r.suppressed, 0);
+    }
+
+    #[test]
+    fn scan_files_parallel_jobs_zero_treated_as_one() {
+        // Robustness: --jobs 0 from the CLI shouldn't divide-by-zero
+        // or hang; the engine clamps to a serial scan.
+        let td = TempDir::new().unwrap();
+        let f = write(&td, "a.py", "yaml.load(f)\n");
+        let r = scan_files_parallel(&[f], 0);
+        assert_eq!(r.findings.len(), 1);
+        assert_eq!(r.findings[0].rule_id, "YAML-UNSAFE");
+    }
+
+    #[test]
+    fn scan_files_parallel_serial_path_when_jobs_one() {
+        // jobs=1 hits the no-thread fast path. Validates the same code
+        // path that serves as the single-core CI fallback.
+        let td = TempDir::new().unwrap();
+        let a = write(&td, "a.py", "yaml.load(f)\n");
+        let b = write(&td, "b.py", "pickle.loads(b'x')\n");
+        let r = scan_files_parallel(&[a, b], 1);
+        assert_eq!(r.findings.len(), 2);
+    }
+
+    #[test]
+    fn scan_files_parallel_jobs_more_than_files_clamps() {
+        // jobs=64 over 2 files should not spawn 64 idle workers; the
+        // engine clamps to `files.len()`. Just check correctness — we
+        // don't probe the worker count externally, only the result.
+        let td = TempDir::new().unwrap();
+        let a = write(&td, "a.py", "yaml.load(f)\n");
+        let b = write(&td, "b.py", "pickle.loads(b'x')\n");
+        let r = scan_files_parallel(&[a, b], 64);
+        assert_eq!(r.findings.len(), 2);
+    }
+
+    #[test]
+    fn scan_files_parallel_findings_match_serial_after_sort() {
+        // Semantic equivalence: parallel scan must produce the same
+        // findings as the serial path (same fields, same count) once
+        // sorted by (severity, file, line). This is the load-bearing
+        // correctness gate — if it ever fails, parity is broken.
+        let td = TempDir::new().unwrap();
+        let mut paths = Vec::new();
+        for i in 0..40 {
+            let p = write(
+                &td,
+                &format!("f{i}.py"),
+                "yaml.load(f)\npickle.loads(b'x')\neval(z)\n",
+            );
+            paths.push(p);
+        }
+
+        // Serial baseline.
+        let mut serial = FileResult::default();
+        for p in &paths {
+            let r = scan_file_with_suppression(p);
+            serial.findings.extend(r.findings);
+            serial.suppressed += r.suppressed;
+        }
+        serial.findings.sort_by(|a, b| {
+            a.severity
+                .cmp(&b.severity)
+                .then_with(|| a.file.cmp(&b.file))
+                .then_with(|| a.line.cmp(&b.line))
+        });
+
+        // Parallel result with 8 workers — same files, same findings.
+        let mut parallel = scan_files_parallel(&paths, 8);
+        parallel.findings.sort_by(|a, b| {
+            a.severity
+                .cmp(&b.severity)
+                .then_with(|| a.file.cmp(&b.file))
+                .then_with(|| a.line.cmp(&b.line))
+        });
+
+        assert_eq!(parallel.findings, serial.findings);
+        assert_eq!(parallel.suppressed, serial.suppressed);
+    }
+
+    #[test]
+    fn scan_files_parallel_suppression_count_aggregates() {
+        // Suppression count summed across files when each suppresses
+        // some findings. Validates the AtomicUsize aggregation path.
+        let td = TempDir::new().unwrap();
+        let mut paths = Vec::new();
+        for i in 0..10 {
+            let p = write(
+                &td,
+                &format!("f{i}.py"),
+                "yaml.load(f)  # arcis-audit: ignore\npickle.loads(b'x')\n",
+            );
+            paths.push(p);
+        }
+        let r = scan_files_parallel(&paths, 4);
+        // 10 files × 1 suppression each = 10. Pickle line still fires.
+        assert_eq!(r.suppressed, 10);
+        assert_eq!(r.findings.len(), 10);
+        assert!(r.findings.iter().all(|f| f.rule_id == "PICKLE-LOAD"));
+    }
+
+    #[test]
+    fn scan_files_parallel_no_lost_findings_under_pressure() {
+        // Stress: many small files + high jobs count. The atomic
+        // cursor must hand each file to exactly one worker — no
+        // duplicates, no skips. Total findings = files × per-file count.
+        let td = TempDir::new().unwrap();
+        let mut paths = Vec::new();
+        const N: usize = 200;
+        for i in 0..N {
+            let p = write(&td, &format!("a{i}.py"), "yaml.load(f)\n");
+            paths.push(p);
+        }
+        let r = scan_files_parallel(&paths, 16);
+        assert_eq!(
+            r.findings.len(),
+            N,
+            "expected exactly {N} findings (one per file), got {}",
+            r.findings.len()
+        );
     }
 
     #[test]

--- a/packages/arcis-rust/crates/arcis-engine/src/audit/mod.rs
+++ b/packages/arcis-rust/crates/arcis-engine/src/audit/mod.rs
@@ -29,7 +29,7 @@ pub use baseline::{
 };
 pub use engine::{
     scan_directory, scan_directory_with_suppression, scan_file, scan_file_with_suppression,
-    FileResult, Finding,
+    scan_files_parallel, FileResult, Finding,
 };
 pub use finding_id::{assign_ids, compute as compute_finding_id, normalize_relpath};
 pub use render::{render_json, render_sarif, JsonReport, SarifReport};


### PR DESCRIPTION
Closes Phase B ergonomics — last item.

## Summary
- New `arcis_engine::audit::scan_files_parallel(paths, jobs)` is stdlib-only (`thread::scope` + `AtomicUsize` cursor + `Mutex<Vec<Finding>>`); no new workspace deps.
- CLI gains `-j` / `--jobs N` (default 8); `--jobs 0` rejected at parse time.
- Determinism preserved: parallel scan returns findings unordered; existing `(severity, file, line)` sort + `assign_ids` runs after collection so JSON / SARIF output stays byte-equal.

## Test plan
- [x] 15 new tests (7 engine + 8 CLI), workspace 482 → 497 passing locally
- [ ] CI green on this PR