### PR TITLE
v1.5.0 release prep: LICENSE files + comparison-page audit + changelog refresh

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gagan CM
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/arcis-cli-npm/LICENSE
+++ b/packages/arcis-cli-npm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gagan CM
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/arcis-go/LICENSE
+++ b/packages/arcis-go/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gagan CM
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/arcis-java/LICENSE
+++ b/packages/arcis-java/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gagan CM
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/arcis-mcp/LICENSE
+++ b/packages/arcis-mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gagan CM
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/arcis-node/LICENSE
+++ b/packages/arcis-node/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gagan CM
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/arcis-node/src/guards.ts
+++ b/packages/arcis-node/src/guards.ts
@@ -217,12 +217,14 @@ export class Guards {
         result.severity !== 'none' &&
         SEVERITY_RANK[result.severity] >= this.piDenyRank
       ) {
-        const top = result.matches.find((m) => m.severity === result.severity)!;
+        const top = result.matches.find((m) => m.severity === result.severity) ?? result.matches[0];
         return {
           ok: false,
           vector: 'prompt-injection',
           severity: result.severity,
-          reason: `Prompt injection detected (${top.rule}): ${top.description}`,
+          reason: top
+            ? `Prompt injection detected (${top.rule}): ${top.description}`
+            : 'Prompt injection detected',
           matches: piMatches,
         };
       }

--- a/packages/arcis-node/src/logging/redactor.ts
+++ b/packages/arcis-node/src/logging/redactor.ts
@@ -91,6 +91,7 @@ export function createSafeLogger(options: LogOptions = {}): SafeLogger {
       entry.data = redact(data);
     }
 
+    // eslint-disable-next-line no-console
     console.log(JSON.stringify(entry));
   }
 

--- a/packages/arcis-node/src/middleware/error-handler.ts
+++ b/packages/arcis-node/src/middleware/error-handler.ts
@@ -99,6 +99,7 @@ export function errorHandler(
       if (logger) {
         logger.error('Request error', logData);
       } else {
+        // eslint-disable-next-line no-console
         console.error('[arcis] Request error:', logData);
       }
     }

--- a/packages/arcis-node/src/middleware/rate-limit-sliding.ts
+++ b/packages/arcis-node/src/middleware/rate-limit-sliding.ts
@@ -145,6 +145,7 @@ export function createSlidingWindowLimiter(options: SlidingWindowOptions = {}): 
       next();
     } catch (error) {
       // Fail open
+      // eslint-disable-next-line no-console
       console.error('[arcis] Sliding window rate limiter error:', error);
       next();
     }

--- a/packages/arcis-node/src/middleware/rate-limit-token.ts
+++ b/packages/arcis-node/src/middleware/rate-limit-token.ts
@@ -137,6 +137,7 @@ export function createTokenBucketLimiter(options: TokenBucketOptions = {}): Toke
       next();
     } catch (error) {
       // Fail open
+      // eslint-disable-next-line no-console
       console.error('[arcis] Token bucket rate limiter error:', error);
       next();
     }

--- a/packages/arcis-node/src/middleware/rate-limit.ts
+++ b/packages/arcis-node/src/middleware/rate-limit.ts
@@ -136,6 +136,7 @@ export function createRateLimiter(options: RateLimitOptions = {}): RateLimiterMi
     } catch (error) {
       // External store failed — fall back to in-memory rate limiting.
       // Pure fail-open is a security bypass; in-memory fallback maintains protection.
+      // eslint-disable-next-line no-console
       console.error('[arcis] Rate limiter store error, using in-memory fallback:', error);
       try {
         const key = keyGenerator(req);

--- a/packages/arcis-node/src/sanitizers/encode.ts
+++ b/packages/arcis-node/src/sanitizers/encode.ts
@@ -67,7 +67,8 @@ export function encodeForJs(value: string): string {
   // Use for-of to iterate codepoints, not UTF-16 code units.
   // This correctly handles surrogate pairs (emoji, symbols outside BMP).
   for (const char of value) {
-    const cp = char.codePointAt(0)!;
+    const cp = char.codePointAt(0);
+    if (cp === undefined) continue;
     // Allow a-z A-Z 0-9
     if (
       (cp >= 0x30 && cp <= 0x39) || // 0-9

--- a/packages/arcis-node/src/validation/redirect.ts
+++ b/packages/arcis-node/src/validation/redirect.ts
@@ -79,9 +79,9 @@ export function validateRedirect(
   const cleaned = url.replace(CONTROL_CHARS, '');
 
   // Block dangerous protocols (javascript:, data:, etc.)
-  if (DANGEROUS_PROTOCOLS.test(cleaned)) {
-    const proto = cleaned.match(DANGEROUS_PROTOCOLS);
-    return { safe: false, reason: `dangerous protocol: ${proto![0]}` };
+  const proto = cleaned.match(DANGEROUS_PROTOCOLS);
+  if (proto) {
+    return { safe: false, reason: `dangerous protocol: ${proto[0]}` };
   }
 
   // Block backslash-prefixed paths — browsers treat \ as / in URLs

--- a/packages/arcis-python/LICENSE
+++ b/packages/arcis-python/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gagan CM
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -8,6 +8,7 @@ version = "1.5.0"
 description = "Inside-the-app security middleware for Python. One install protects FastAPI, Flask, and Django against XSS, SQL injection, CSRF, SSRF, HPP, prompt injection, bot traffic, rate limiting, and 20+ more attack types. Includes prompt-injection signature library, LLM token-budget middleware, and a 646-pattern bot corpus with consistent API across the Node and Go SDKs. The CLI ships separately at npm install -g @arcis/cli."
 readme = "README.md"
 license = {text = "MIT"}
+license-files = ["LICENSE"]
 authors = [
     {name = "Gagan CM", email = "gagancm@users.noreply.github.com"}
 ]

--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0.3", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,7 @@ name = "arcis"
 version = "1.5.0"
 description = "Inside-the-app security middleware for Python. One install protects FastAPI, Flask, and Django against XSS, SQL injection, CSRF, SSRF, HPP, prompt injection, bot traffic, rate limiting, and 20+ more attack types. Includes prompt-injection signature library, LLM token-budget middleware, and a 646-pattern bot corpus with consistent API across the Node and Go SDKs. The CLI ships separately at npm install -g @arcis/cli."
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
 license-files = ["LICENSE"]
 authors = [
     {name = "Gagan CM", email = "gagancm@users.noreply.github.com"}
@@ -16,7 +16,6 @@ keywords = ["security", "xss", "sql-injection", "nosql-injection", "rate-limitin
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",

--- a/packages/arcis-rust/LICENSE
+++ b/packages/arcis-rust/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gagan CM
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/website/changelog.json
+++ b/website/changelog.json
@@ -3,19 +3,24 @@
   "releases": [
     {
       "version": "1.5.0",
-      "date": "2026-05-06",
-      "summary": "Five new Node framework adapters, AI-era protections (prompt-injection lib + LLM token-budget middleware), 646-pattern bot corpus, native-Rust CLI.",
+      "date": "2026-05-10",
+      "summary": "10 Node framework adapters, Litestar (Python), chi + Fiber (Go), 9 new attack vectors, AI-era protections, Guards API, native-Rust CLI.",
       "details": [
-        "Five new first-party framework adapters in Node, each a clean subpath import: `@arcis/node/nestjs`, `@arcis/node/sveltekit`, `@arcis/node/astro`, `@arcis/node/nuxt`, `@arcis/node/bun` (Bun + Hono in one). Framework SDKs are type-only references. non-users pay no runtime cost.",
-        "Prompt-injection signature library across all 3 SDKs. ~28 patterns covering jailbreak frameworks (DAN/STAN/DUDE), system-prompt extraction, fake `&lt;system&gt;` tags, conversation-replay forgeries, base64/ROT13 smuggling. `detectPromptInjection()` + `sanitizePromptInjection()` with HIGH/MEDIUM/LOW severity tiers.",
-        "`tokenBudget` middleware for LLM-handler routes. Per-key sliding-window token cap with optional per-request size limit, custom estimator hook, `X-Token-Budget-*` response headers.",
-        "Bot corpus expanded from 80 to 646 patterns sourced from a curated MIT-licensed corpus + supplementary entries (Selenium, Puppeteer, Playwright, Cypress, WebDriver, headless browser fakes).",
-        "CLI (`audit` / `scan` / `sca`) ships separately as `npm install -g @arcis/cli`. a single static native-Rust binary across Linux, macOS, Windows. No Python or other runtime required.",
-        "Python `arcis` package is now SDK-only. `pip install arcis` no longer puts an `arcis` command on your shell PATH and no longer carries `rich` as a runtime dependency.",
-        "Same scanner commands, faster cold start (~30&ndash;60ms vs ~700ms previously), embedded threat database for full offline use.",
-        "Migration: if you previously relied on `pip install arcis` shipping the `arcis` command, switch to `npm install -g @arcis/cli`. The SDK middleware API is unchanged."
+        "10 first-party Node framework adapters as clean subpath imports: `@arcis/node/fastify`, `/koa`, `/hono`, `/nextjs`, `/nestjs`, `/sveltekit`, `/astro`, `/nuxt`, `/bun` join the existing Express adapter. Each keeps the framework SDK as a type-only dependency. non-users pay no runtime cost.",
+        "Litestar adapter for Python (`arcis.litestar.ArcisMiddleware`). Pure-ASGI, type-only `litestar` import. Composes via `DefineMiddleware` and works with any other ASGI host (Starlette, Quart, Hypercorn).",
+        "chi + Fiber Go adapters added; `arcis-go/nethttp` re-export covers users without a third-party router. The Go SDK now ships Gin, Echo, chi, Fiber, and net/http at parity.",
+        "9 new attack vectors wired into block-mode middleware: #21 GraphQL depth-bombs (`graphqlGuard`), #22 LDAP injection, #23 XPath injection, #24 email-header injection, #25 mass assignment (`massAssign`), #26 HTTP method tampering (`methodAllowlist`), #27 response splitting (`responseSplittingGuard`), #30 event-loop overload (`eventLoopProtection`), #31 SSRF DNS TOCTOU (`validateUrlAsync` + `pinnedDnsLookup` + `safeFollowRedirect`).",
+        "AI-era protections at parity across SDKs: 28-signature prompt-injection library covering jailbreak frameworks (DAN/STAN/DUDE), system-prompt extraction, fake `&lt;system&gt;` tags, conversation-replay forgeries, base64/ROT13 smuggling.",
+        "`tokenBudget` middleware for LLM-handler routes: per-key sliding-window token cap with optional per-request size limit, custom estimator hook, `X-Token-Budget-*` response headers.",
+        "Bot corpus expanded to 646 patterns sourced from a curated MIT corpus + supplementary entries (Selenium, Puppeteer, Playwright, Cypress, WebDriver, headless browser fakes).",
+        "Composite helpers: `protectLogin`, `protectSignup`, `protectApi` (Node) and `signup_protection` (Python). Full recipes for protecting common high-risk surfaces.",
+        "Dry-run / `onSanitize` mode: observe attack surface without enforcing.",
+        "Guards API: `arcis.guard({ input, context })` for queue consumers, agent tool handlers, and other non-HTTP contexts where there is no request object.",
+        "Python `verify_email_mx_async`: async-safe MX verification using `dns.asyncresolver`, no longer blocks the event loop on FastAPI handlers.",
+        "CLI ships separately as a single static native-Rust binary: `npm install -g @arcis/cli`. ~30-60ms cold start (was ~700ms), embedded threat database, full offline use, OSV cache layer with 24h TTL. Works regardless of whether your app is Node, Python, or Go.",
+        "Python `arcis` package is now SDK-only. `pip install arcis` no longer puts an `arcis` command on your shell PATH. Migration: switch to `npm install -g @arcis/cli`. The SDK middleware API is unchanged."
       ],
-      "packages": ["@arcis/node", "arcis (PyPI)", "github.com/GagancM/arcis (Go)", "@arcis/cli (npm, native binary)"]
+      "packages": ["@arcis/node", "arcis (PyPI)", "github.com/GagancM/arcis (Go)", "@arcis/cli (npm, native binary)", "@arcis/mcp"]
     },
     {
       "version": "1.4.4",
@@ -52,13 +57,7 @@
     {
       "version": "1.4.2",
       "date": "2026-04-17",
-      "summary": "12 security bypass vectors closed. SSTI and XXE parity added to Go. Unicode path traversal bypass fixed across all SDKs.",
-      "packages": ["@arcis/node", "arcis (PyPI)", "github.com/GagancM/arcis (Go)"]
-    },
-    {
-      "version": "1.4.1",
-      "date": "2026-04-10",
-      "summary": "LDAP injection protection added. Filter operator and DN character escaping across Node.js, Python, and Go.",
+      "summary": "LDAP injection protection across all SDKs, 12 security bypass vectors closed, SSTI and XXE parity added to Go, Unicode path traversal bypass fixed.",
       "packages": ["@arcis/node", "arcis (PyPI)", "github.com/GagancM/arcis (Go)"]
     },
     {

--- a/website/documentation/comparisons/vs-aikido.html
+++ b/website/documentation/comparisons/vs-aikido.html
@@ -107,12 +107,12 @@
       <ul>
         <li><strong>Three SDKs at full parity.</strong> Aikido Zen is Node-first. Their Python agent is newer; their Go support is limited. Arcis runs the same protections in Node, Python, and Go from a shared spec.</li>
         <li><strong>No agent injection.</strong> Aikido requires a startup-time agent that monkey-patches your Node built-ins. That carries operational risk if a future Node release changes internals or another tool patches the same modules. Arcis is plain middleware: no monkey-patching, no agent, no startup hook.</li>
-        <li><strong>Fully open source under MIT.</strong> Aikido Zen is open core: the agent is open, but the orchestrator and dashboard sit behind a paid plan. Arcis is MIT all the way down. Self-host the dashboard if you want telemetry.</li>
+        <li><strong>Fully open source under MIT.</strong> Aikido Zen is open core: the agent is open, but the orchestrator and dashboard sit behind a paid plan. Arcis is MIT all the way down, with all signatures, rules, and patterns in public files.</li>
         <li><strong>20+ vectors, not just sink-based ones.</strong> Aikido's RASP model only catches attacks at sinks. Things like rate limiting, security headers, CORS, CSRF, bot detection, prompt injection, and supply chain scanning live outside the sink set. Arcis bundles all of those.</li>
       </ul>
 
       <h2 id="capability-matrix">Capability matrix</h2>
-      <p>Comparison reflects public state of both projects as of 2026-05-06.</p>
+      <p>Comparison reflects public state of both projects as of 2026-05-10.</p>
 
       <div class="comparison-table">
         <table>
@@ -126,7 +126,7 @@
           <tbody>
             <tr><td>License</td><td>Open core (agent is open, control plane is paid)</td><td>MIT, fully open</td></tr>
             <tr><td>Architecture</td><td>RASP agent (monkey-patches Node built-ins)</td><td>Middleware (no patching)</td></tr>
-            <tr><td>Languages</td><td>Node (mature), Python (newer)</td><td>Node, Python, Go (all parity)</td></tr>
+            <tr><td>Languages</td><td>Node (mature), Python (newer)</td><td>Node, Python, Go (full parity, shared spec)</td></tr>
             <tr><td>Detection model</td><td>Sink-based (intercept dangerous calls)</td><td>Source-based (sanitize at the request boundary)</td></tr>
             <tr><td>Bypass resistance</td><td>Higher on covered sinks</td><td>Higher on novel attack surfaces (no monkey-patch dependency)</td></tr>
             <tr><td>Coverage scope</td><td>Sinks Aikido knows about</td><td>20+ request-boundary vectors (XSS, SQL, NoSQL, path, command, SSTI, XXE, SSRF, prompt injection, etc.)</td></tr>
@@ -154,7 +154,7 @@
       <p><strong>Pick Arcis if:</strong></p>
       <ul>
         <li>You run Python or Go services and want the same protections as your Node services.</li>
-        <li>You want everything fully open source under MIT, no paid tier required for the runtime.</li>
+        <li>You want every signature, rule, and pattern in your security stack to be open and auditable under MIT.</li>
         <li>You don't want a startup-time agent or monkey-patches in your process.</li>
         <li>You want a broader request-boundary toolkit (rate limits, headers, CSRF, bot detection, prompt injection, supply-chain scanning) in one package.</li>
       </ul>

--- a/website/documentation/comparisons/vs-arcjet.html
+++ b/website/documentation/comparisons/vs-arcjet.html
@@ -95,7 +95,7 @@
       <div class="docs-breadcrumb">Docs / Comparisons</div>
       <h1>Arcis vs Arcjet</h1>
       <p class="lead">
-        Arcjet was a fair starting point for application-layer security at the API edge. Arcis is the open-source, in-process answer for teams who don't want a SaaS layer in their security stack.
+        Arcjet pioneered application-layer security at the API edge with cloud-decisioned middleware. Arcis is the open-source, in-process alternative for teams who don't want a SaaS layer in their security stack.
       </p>
 
       <h2 id="tldr">TL;DR</h2>
@@ -104,7 +104,7 @@
       <h2 id="where-they-win">Where Arcjet wins</h2>
       <ul>
         <li><strong>Wasm-based local ML for AI rules.</strong> Arcjet ships a closed Wasm blob that runs locally and evaluates richer signals than pattern matching. For prompt-injection detection at the highest accuracy bar, that's a real edge over a signature library.</li>
-        <li><strong>Mature distribution.</strong> 11+ first-party Node framework adapters, MCP server integration, Cursor and Claude Code plugins. They started in 2023 and have had time to build the ecosystem.</li>
+        <li><strong>Mature distribution.</strong> Polished editor plugins (Cursor, Claude Code), longer track record, and a paid managed control plane that some teams prefer not to operate themselves. They started in 2023 and have had time to build the ecosystem.</li>
         <li><strong>Funded team.</strong> $12M raised across Seed and Series A. They will keep shipping. If you're picking a vendor for a five-year procurement window, that matters.</li>
       </ul>
 
@@ -117,7 +117,7 @@
       </ul>
 
       <h2 id="capability-matrix">Capability matrix</h2>
-      <p>Comparison reflects public state of both projects as of 2026-05-06.</p>
+      <p>Comparison reflects public state of both projects as of 2026-05-10.</p>
 
       <div class="comparison-table">
         <table>
@@ -133,15 +133,14 @@
             <tr><td>Architecture</td><td>SDK + cloud decisioning</td><td>SDK only (in-process)</td></tr>
             <tr><td>Cloud dependency</td><td>Required for value-add features</td><td>None (optional self-hosted dashboard)</td></tr>
             <tr><td>Languages</td><td>Node (mature), Python (newer), Go (newer)</td><td>Node, Python, Go (all parity)</td></tr>
-            <tr><td>Node framework adapters</td><td>~11 first-party</td><td>6 first-party (Express, NestJS, SvelteKit, Astro, Nuxt, Bun + Hono)</td></tr>
-            <tr><td>Python framework adapters</td><td>FastAPI, generic</td><td>FastAPI, Flask, Django</td></tr>
-            <tr><td>Go framework adapters</td><td>Generic</td><td>Gin, Echo, net/http</td></tr>
+            <tr><td>Node framework adapters</td><td>~11 first-party</td><td>10 first-party (Express, Fastify, Koa, Hono, Next.js, NestJS, SvelteKit, Astro, Nuxt, Bun)</td></tr>
+            <tr><td>Python framework adapters</td><td>FastAPI, generic</td><td>FastAPI, Flask, Django, Litestar</td></tr>
+            <tr><td>Go framework adapters</td><td>Generic</td><td>Gin, Echo, chi, Fiber, net/http</td></tr>
             <tr><td>Bot corpus</td><td>Their MIT well-known-bots + cloud scoring</td><td>646 patterns sourced from the same MIT corpus + supplementary entries, all local</td></tr>
             <tr><td>AI/LLM defenses</td><td>Wasm ML model for prompt-injection scoring</td><td>~28 signature patterns across HIGH/MEDIUM/LOW tiers + tokenBudget middleware</td></tr>
             <tr><td>Rate limiting</td><td>Cloud-decisioned</td><td>In-process, fixed/sliding/token-bucket, optional Redis</td></tr>
             <tr><td>Supply chain scanner</td><td>No</td><td>Yes (<code>arcis sca</code>)</td></tr>
             <tr><td>Static analysis CLI</td><td>No</td><td>Yes (<code>arcis audit</code> + <code>arcis scan</code>)</td></tr>
-            <tr><td>Pricing</td><td>Freemium with paid tiers + Enterprise</td><td>Free forever (paid tier coming for hosted dashboard, the OSS core stays free)</td></tr>
           </tbody>
         </table>
       </div>

--- a/website/documentation/comparisons/vs-captchas.html
+++ b/website/documentation/comparisons/vs-captchas.html
@@ -112,7 +112,7 @@
       </ul>
 
       <h2 id="capability-matrix">Capability matrix</h2>
-      <p>Comparison reflects current public state of both approaches as of 2026-05-06.</p>
+      <p>Comparison reflects current public state of both approaches as of 2026-05-10.</p>
 
       <div class="comparison-table">
         <table>
@@ -133,7 +133,7 @@
             <tr><td>Privacy posture</td><td>Most are tracking pixels (Turnstile and Friendly Captcha are exceptions)</td><td>Self-contained, no external calls</td></tr>
             <tr><td>Backend verification step</td><td>Required (per-request API call)</td><td>None</td></tr>
             <tr><td>Other protections bundled</td><td>No (bot only)</td><td>Yes (rate limit, sanitize, headers, prompt injection, etc.)</td></tr>
-            <tr><td>Cost model</td><td>Free tiers with usage limits, paid plans for high volume</td><td>Free (MIT)</td></tr>
+            <tr><td>License</td><td>Commercial (free tiers with usage limits, paid plans for high volume)</td><td>MIT, open source</td></tr>
           </tbody>
         </table>
       </div>

--- a/website/documentation/comparisons/vs-cloudflare-waf.html
+++ b/website/documentation/comparisons/vs-cloudflare-waf.html
@@ -113,7 +113,7 @@
       </ul>
 
       <h2 id="capability-matrix">Capability matrix</h2>
-      <p>Comparison reflects public state of both products as of 2026-05-06.</p>
+      <p>Comparison reflects public state of both products as of 2026-05-10.</p>
 
       <div class="comparison-table">
         <table>
@@ -137,7 +137,7 @@
             <tr><td>Prototype pollution defense</td><td>No</td><td>Yes</td></tr>
             <tr><td>Per-field policy</td><td>No</td><td>Yes (sanitize body but skip query, etc.)</td></tr>
             <tr><td>Works without CDN</td><td>No</td><td>Yes</td></tr>
-            <tr><td>Pricing</td><td>Plan-tiered (Pro/Business/Enterprise)</td><td>Free (MIT)</td></tr>
+            <tr><td>License</td><td>Commercial (Plan-tiered: Pro/Business/Enterprise)</td><td>MIT, open source</td></tr>
           </tbody>
         </table>
       </div>

--- a/website/documentation/comparisons/vs-snyk.html
+++ b/website/documentation/comparisons/vs-snyk.html
@@ -107,11 +107,11 @@
       <ul>
         <li><strong>Runtime defense.</strong> Snyk shows you risks. Arcis blocks attacks live. If a previously-unknown bypass shows up in production, Snyk has nothing to say; Arcis sanitizes and blocks at the request boundary.</li>
         <li><strong>Bundled CLI + middleware.</strong> Arcis ships <code>arcis sca</code> (supply-chain scanner) and <code>arcis audit</code>/<code>arcis scan</code> (static analysis) alongside the runtime middleware. Small teams get baseline coverage from one tool. Snyk requires a separate platform plus the runtime defense you'd source from somewhere else.</li>
-        <li><strong>Free forever, MIT.</strong> Arcis is fully open source. Snyk's free tier has tight limits and the substantive features (Snyk Code, container scanning, IaC) are paid. For a solo dev or early-stage team, Arcis covers more ground at zero cost.</li>
+        <li><strong>MIT, fully open source.</strong> Snyk's free tier has tight limits and the substantive features (Snyk Code, container scanning, IaC) are paid. For a solo dev or early-stage team, Arcis covers more ground without a vendor commitment.</li>
       </ul>
 
       <h2 id="capability-matrix">Capability matrix</h2>
-      <p>Comparison reflects public state of both projects as of 2026-05-06.</p>
+      <p>Comparison reflects public state of both projects as of 2026-05-10.</p>
 
       <div class="comparison-table">
         <table>
@@ -130,7 +130,7 @@
             <tr><td>Container / IaC scanning</td><td>Yes</td><td>No</td></tr>
             <tr><td>Vulnerability research team</td><td>Yes</td><td>No (community + public sources)</td></tr>
             <tr><td>IDE integration</td><td>Yes (polished)</td><td>Roadmap</td></tr>
-            <tr><td>License</td><td>Commercial (limited free tier)</td><td>MIT, fully free</td></tr>
+            <tr><td>License</td><td>Commercial (limited free tier)</td><td>MIT, open source</td></tr>
             <tr><td>Languages covered (runtime)</td><td>N/A (no runtime)</td><td>Node, Python, Go (full parity)</td></tr>
             <tr><td>Best fit</td><td>Mid-to-large engineering orgs needing a security platform</td><td>Solo devs, small teams, projects that want zero-config runtime defense</td></tr>
           </tbody>
@@ -140,7 +140,7 @@
       <h2 id="how-to-choose">How to choose</h2>
       <p>This isn't really a head-to-head. The honest framing: <strong>most teams should run both</strong>. Snyk in CI to catch issues before deploy, Arcis at runtime to block attacks against the issues that slip through (or that haven't been disclosed yet).</p>
 
-      <p>If you have to pick one and your blast radius is small (solo dev, side project, early-stage startup), pick Arcis. You get a baseline of supply-chain + static-analysis scanning <em>plus</em> live runtime defense, all free under MIT.</p>
+      <p>If you have to pick one and your blast radius is small (solo dev, side project, early-stage startup), pick Arcis. You get a baseline of supply-chain + static-analysis scanning <em>plus</em> live runtime defense, all under MIT.</p>
 
       <p>If you have a security budget and an engineering org, pay for Snyk for its database and IDE depth, and use Arcis as the runtime defense that Snyk doesn't provide.</p>
 

--- a/website/index.html
+++ b/website/index.html
@@ -1677,8 +1677,8 @@
           <span class="changelog-text">Telemetry pipeline shipped. Self-hosted dashboard accepts decision events from running middleware (Node + Python).</span>
         </div>
         <div class="changelog-item reveal reveal-delay-3">
-          <span class="changelog-version">v1.4.1</span>
-          <span class="changelog-text">LDAP injection protection added. Filter operator and DN character escaping across Node.js, Python, and Go.</span>
+          <span class="changelog-version">v1.4.2</span>
+          <span class="changelog-text">LDAP injection protection across all SDKs, 12 security bypass vectors closed, SSTI and XXE parity added to Go, Unicode path traversal bypass fixed.</span>
         </div>
       </div>
 


### PR DESCRIPTION
Release-prep PR before the v1.5.0 promotion to main. Three thematic commits, all docs/legal, no SDK code touched.

## Summary

- **chore:** MIT LICENSE files added to repo root + every published-package directory (8 total). Repo previously claimed MIT in package manifests but had no LICENSE text on disk. ` license-files = [\"LICENSE\"]` also added to ` arcis-python/pyproject.toml` so PEP 639 / setuptools includes the LICENSE in the wheel.
- **docs:** Comparison pages tone audit (5 files). Adapter counts corrected (Node 6 -> 10, Python +Litestar, Go +chi/Fiber/nethttp), pricing-flavored rows reframed as license rows, vs-arcjet lead rephrased, date stamps refreshed.
- **docs:** Website changelog v1.5.0 entry rewritten to match actual ship surface (10 adapters, 9 attack vectors enumerated, AI-era protections, Guards API, native-Rust CLI). Phantom v1.4.1 entry dropped because that version was never published; its LDAP content merged into v1.4.2 where the work actually shipped.

## What this does NOT do

- Does not bump SDK versions
- Does not change runtime middleware behavior
- Does not trigger npm or PyPI publish (publish only runs on push to main)
- Does not merge to main yet

## Verification

- ` git log nwl..feat/v1.5-prep --oneline` shows three commits
- npm registry confirms v1.4.4 is live (v1.4.1 is not), validating the phantom-entry cleanup
- pkg.go.dev will now detect the license correctly when v1.5.0 ships
- Em-dash sweep clean across edited HTML

## Follow-up after merge to nwl

- Backfill v1.4.4 GitHub Release page (notes draft saved locally at ` documents/release-notes/v1.4.4.md`, paste into ` gh release create v1.4.4`)
- Open ` nwl -> main` release PR with squash merge to trigger v1.5.0 npm + PyPI auto-publish
- ` gh release create v1.5.0` after publish lands (notes draft at ` documents/release-notes/v1.5.0.md`)