### PR TITLE
fix(node): unblock npm 1.5.0 publish (drop dangling CLI refs)

### DIFF
--- a/packages/arcis-node/package.json
+++ b/packages/arcis-node/package.json
@@ -101,9 +101,6 @@
     "dist",
     "scripts/postinstall.cjs"
   ],
-  "bin": {
-    "arcis": "./dist/cli/arcis.mjs"
-  },
   "scripts": {
     "build": "tsup && tsc --emitDeclarationOnly --declaration --declarationMap",
     "dev": "tsup --watch",

--- a/packages/arcis-node/scripts/postinstall.cjs
+++ b/packages/arcis-node/scripts/postinstall.cjs
@@ -1,10 +1,10 @@
 /* eslint-disable */
 // Postinstall notice for @arcis/node.
 //
-// Surface the fact that the Arcis CLI (audit / scan / sca) ships in the
-// Python package only. Without this message, users who installed the Node
-// SDK type `arcis` in their shell, get "command not found", and assume
-// the package is broken.
+// Surface the fact that the Arcis CLI (audit / scan / sca) ships as a
+// separate native binary. Without this message, users who installed the
+// Node SDK type `arcis` in their shell, get "command not found", and
+// assume the package is broken.
 //
 // Skip in CI / non-TTY / when npm asks us not to log.
 if (process.env.CI || process.env.ARCIS_SKIP_NOTICE) return;
@@ -16,8 +16,8 @@ const lines = [
   '',
   c('  Arcis Node SDK installed.', '1;36'),
   '',
-  c('  The CLI (audit / scan / sca) ships separately in Python:', '2'),
-  c('    pip install arcis', '32'),
+  c('  The CLI (audit / scan / sca) ships separately as a native binary:', '2'),
+  c('    npm install -g @arcis/cli', '32'),
   '',
   c('  This package is the SDK / middleware. It does not put a CLI on', '2'),
   c('  your shell PATH. Docs: https://gagancm.github.io/arcis/documentation/cli.html', '2'),

--- a/packages/arcis-node/tsup.config.ts
+++ b/packages/arcis-node/tsup.config.ts
@@ -19,10 +19,6 @@ export default defineConfig({
     'logging/index': 'src/logging/index.ts',
     'stores/index': 'src/stores/index.ts',
     'utils/index': 'src/utils/index.ts',
-    // Node CLI binary. package.json's "bin" points at ./dist/cli/arcis.mjs
-    // so the ESM build is the canonical entry. Shebang prepended via
-    // banner below so the file is executable when npm symlinks it.
-    'cli/arcis': 'src/cli/arcis.ts',
   },
   format: ['cjs', 'esm'],
   dts: false,


### PR DESCRIPTION
## What broke

Run [25647820982](https://github.com/Gagancm/arcis/actions/runs/25647820982) — \`Publish Node.js\` job failed at \`npm run build\`:

\`\`\`
Cannot find cli/arcis: src/cli/arcis.ts
\`\`\`

PyPI 1.5.0 shipped fine. Only npm needs a re-run.

## Root cause

The v1.5.0 release prep removed \`src/cli/arcis.ts\` when the Node CLI shim was cut over to the standalone \`@arcis/cli\` Rust binary. When I merged \`main\` (which still held the v1.4.4 squash) back into \`nwl\` to absorb the topology divergence, the auto-merge for \`tsup.config.ts\` and \`package.json\` re-introduced the CLI build entry and \`bin\` field. The file itself stayed deleted, so tsup tried to compile a missing entry.

## Fix

- \`tsup.config.ts\`: drop the \`'cli/arcis': 'src/cli/arcis.ts'\` entry.
- \`package.json\`: drop the \`bin\` field that pointed at the missing \`dist/cli/arcis.mjs\`.
- \`scripts/postinstall.cjs\`: update the on-install hint from the now-defunct \`pip install arcis\` (Python CLI was removed in 1.5.0) to \`npm install -g @arcis/cli\` (the actual v1.5.0 install path).

Build verified locally: tsup completes clean across all 18 entry points (ESM + CJS + sourcemaps).

## After merge

\`publish.yml\` re-fires on the squash to \`main\`:
- Python: \`skip-if-exists\` because PyPI 1.5.0 is already live.
- Node: builds clean, publishes \`@arcis/node@1.5.0\`.

No version bump needed — npm registry has no record of 1.5.0 yet (verified 404 on registry).