### PR TITLE
feat: SSRF hardening — DNS TOCTOU prevention and redirect-to-private-IP detection

### DIFF
--- a/packages/arcis-python/arcis/validation/url.py
+++ b/packages/arcis-python/arcis/validation/url.py
@@ -15,9 +15,12 @@ Example:
 """
 
 import re
+import socket
 from dataclasses import dataclass, field
 from typing import List, Optional
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urljoin
+from urllib.request import build_opener, HTTPRedirectHandler, Request
+from urllib.error import HTTPError, URLError
 
 
 @dataclass
@@ -39,6 +42,19 @@ class ValidateUrlOptions:
     allow_private: bool = False
     """Allow private/internal IPs. Default: False"""
 
+    resolve_and_pin: bool = False
+    """When True, resolve hostname via DNS, validate IP, and return pinned URL
+    with IP instead of hostname. Prevents DNS TOCTOU attacks.
+    WARNING: Adds network latency for DNS resolution. Opt-in only (default: False)."""
+
+    follow_redirects: bool = False
+    """When True, perform a HEAD request and follow up to max_redirects to
+    detect redirect chains targeting private IPs.
+    WARNING: Adds network latency for the HEAD request. Opt-in only (default: False)."""
+
+    max_redirects: int = 5
+    """Maximum redirects to follow when follow_redirects=True. Default: 5"""
+
 
 @dataclass
 class ValidateUrlResult:
@@ -49,6 +65,15 @@ class ValidateUrlResult:
 
     reason: Optional[str] = None
     """Reason the URL was blocked (only set when safe=False)."""
+
+    resolved_ip: Optional[str] = None
+    """Resolved IP address from DNS resolution (only when resolve_and_pin=True)."""
+
+    pinned_url: Optional[str] = None
+    """URL with hostname replaced by resolved IP (only when resolve_and_pin=True)."""
+
+    redirect_chain: Optional[List[str]] = None
+    """List of URLs followed in the redirect chain (only when follow_redirects=True)."""
 
 
 # Compiled regex patterns for IP checks
@@ -107,6 +132,142 @@ def _check_private_ip(hostname: str) -> Optional[str]:
             return "IPv6-mapped loopback address"
 
     return None
+
+
+def _resolve_hostname(hostname: str) -> List[str]:
+    """Resolve a hostname to IP addresses.
+
+    Returns a list of IP address strings (both IPv4 and IPv6).
+    On resolution failure, returns an empty list.
+
+    WARNING: This performs an actual DNS lookup and adds network latency.
+    """
+    try:
+        addrinfo = socket.getaddrinfo(hostname, None)
+        ips: List[str] = []
+        seen: set = set()
+        for family, _type, _proto, _canonname, sockaddr in addrinfo:
+            ip = sockaddr[0]
+            # Strip IPv6 zone IDs (e.g., fe80::1%eth0 → fe80::1)
+            if family == socket.AF_INET6 and "%" in ip:
+                ip = ip.split("%")[0]
+            if ip not in seen:
+                seen.add(ip)
+                ips.append(ip)
+        return ips
+    except (socket.gaierror, OSError):
+        return []
+
+
+def _make_pinned_url(url: str, resolved_ip: str) -> str:
+    """Replace the hostname in a URL with a resolved IP address.
+
+    Preserves scheme, port, path, query, and fragment.
+    If the hostname was an IPv6 address, wrap the IP in brackets.
+    """
+    parsed = urlparse(url)
+    if ":" in resolved_ip and not resolved_ip.startswith("["):
+        ip_for_url = f"[{resolved_ip}]"
+    else:
+        ip_for_url = resolved_ip
+
+    # Reconstruct the netloc with the IP and original port
+    if parsed.port:
+        new_netloc = f"{ip_for_url}:{parsed.port}"
+    else:
+        new_netloc = ip_for_url
+
+    # URL reconstruction: scheme://netloc/path?query#fragment
+    path = parsed.path or "/"
+    query = f"?{parsed.query}" if parsed.query else ""
+    fragment = f"#{parsed.fragment}" if parsed.fragment else ""
+    return f"{parsed.scheme}://{new_netloc}{path}{query}{fragment}"
+
+
+def _check_all_dns_ips(
+    resolved_ips: List[str],
+    options: ValidateUrlOptions,
+) -> Optional[str]:
+    """Check all resolved IPs against private IP checks.
+
+    Returns a reason string if any IP is unsafe, or None if all are safe.
+    """
+    for ip in resolved_ips:
+        # Check localhost/loopback
+        if not options.allow_localhost:
+            if ip in ("127.0.0.1", "::1", "0.0.0.0"):
+                return "DNS resolved to loopback address"
+            if _RE_LOOPBACK.match(ip):
+                return "DNS resolved to loopback address"
+
+        # Check private IPs
+        if not options.allow_private:
+            private_reason = _check_private_ip(ip)
+            if private_reason:
+                return f"DNS resolved to {private_reason}"
+
+    return None
+
+
+class _RedirectTracker(HTTPRedirectHandler):
+    """HTTPRedirectHandler that tracks redirect URLs without following them."""
+
+    def __init__(self) -> None:
+        self.redirect_urls: List[str] = []
+
+    def redirect_request(
+        self,
+        req: Request,
+        fp: object,
+        code: int,
+        msg: str,
+        headers: object,
+        newurl: str,
+    ) -> None:
+        """Record the redirect target and return None to prevent following."""
+        self.redirect_urls.append(newurl)
+        return None
+
+
+def _follow_redirect_chain(url: str, max_redirects: int = 5) -> List[str]:
+    """Perform a HEAD request and follow redirects, returning the redirect chain.
+
+    Returns a list of URLs in the order they were visited. The first element
+    is the original URL. Does NOT follow redirects automatically — each redirect
+    target is captured manually.
+
+    WARNING: This performs actual network requests and adds latency.
+    """
+    tracker = _RedirectTracker()
+    opener = build_opener(tracker)
+    redirect_chain: List[str] = [url]
+    current_url = url
+
+    for _ in range(max_redirects):
+        try:
+            req = Request(current_url, method="HEAD")
+            resp = opener.open(req, timeout=10)
+            # Check for Location header in the response
+            location = resp.headers.get("Location")
+            if location:
+                resolved = urljoin(current_url, location)
+                redirect_chain.append(resolved)
+                current_url = resolved
+            else:
+                break
+        except HTTPError as e:
+            # Redirect status codes may raise HTTPError; check Location header
+            location = e.headers.get("Location")
+            if location and e.code in (301, 302, 303, 307, 308):
+                resolved = urljoin(current_url, location)
+                redirect_chain.append(resolved)
+                current_url = resolved
+            else:
+                break
+        except (URLError, ValueError, OSError):
+            break
+
+    return redirect_chain
 
 
 _RE_DECIMAL_IP = re.compile(r"^\d+$")
@@ -197,12 +358,25 @@ def validate_url_ssrf(
     6. Not blocked hostname
     7. No credentials in URL (user:pass@host)
 
+    When options.resolve_and_pin=True (opt-in):
+    8. Resolve hostname via DNS and validate resolved IP through checks 3-5
+    9. Return resolved_ip and pinned_url on success
+
+    When options.follow_redirects=True (opt-in):
+    10. After initial validation, perform HEAD request and follow redirects
+    11. Validate each redirect target URL through checks 1-7
+    12. Track all redirect URLs in redirect_chain
+
+    WARNING: Features 8-12 add network latency (DNS and/or HTTP requests).
+    They are OFF by default and must be explicitly enabled.
+
     Args:
         url: The URL string to validate.
         options: Validation options. Uses safe defaults if None.
 
     Returns:
-        ValidateUrlResult with safe flag and optional reason.
+        ValidateUrlResult with safe flag, optional reason, and optional
+        resolved_ip/pinned_url/redirect_chain.
     """
     if options is None:
         options = ValidateUrlOptions()
@@ -236,7 +410,8 @@ def validate_url_ssrf(
 
     # Check explicit allowlist (bypasses IP checks)
     if any(hostname == h.lower() for h in options.allowed_hosts):
-        return ValidateUrlResult(safe=True)
+        result = ValidateUrlResult(safe=True)
+        return _apply_dns_and_redirects(url, result, options, parsed)
 
     # Check explicit blocklist
     if any(hostname == h.lower() for h in options.blocked_hosts):
@@ -269,7 +444,82 @@ def validate_url_ssrf(
         if private_reason:
             return ValidateUrlResult(safe=False, reason=private_reason)
 
-    return ValidateUrlResult(safe=True)
+    # Base result: safe
+    result = ValidateUrlResult(safe=True)
+
+    # Apply opt-in DNS resolution + IP pinning
+    if options.resolve_and_pin:
+        resolved_ips = _resolve_hostname(hostname)
+        if not resolved_ips:
+            return ValidateUrlResult(
+                safe=False,
+                reason="DNS resolution failed for hostname",
+            )
+
+        ip_check_reason = _check_all_dns_ips(resolved_ips, options)
+        if ip_check_reason:
+            return ValidateUrlResult(
+                safe=False,
+                reason=ip_check_reason,
+                resolved_ip=resolved_ips[0],
+            )
+
+        # Use the first resolved IP for pinning
+        result.resolved_ip = resolved_ips[0]
+        result.pinned_url = _make_pinned_url(url, resolved_ips[0])
+
+    # Apply opt-in redirect following
+    if options.follow_redirects:
+        target_url = result.pinned_url if result.pinned_url else url
+        redirect_chain = _follow_redirect_chain(target_url, options.max_redirects)
+        result.redirect_chain = redirect_chain
+
+        # Validate each redirect destination (skip the original URL)
+        for redirect_url in redirect_chain[1:]:
+            # Use a copy of options without resolve_and_pin/follow_redirects
+            # to avoid infinite recursion and extra network calls
+            redirect_opts = ValidateUrlOptions(
+                allowed_protocols=options.allowed_protocols,
+                blocked_hosts=options.blocked_hosts,
+                allowed_hosts=options.allowed_hosts,
+                allow_localhost=options.allow_localhost,
+                allow_private=options.allow_private,
+            )
+            redirect_result = validate_url_ssrf(redirect_url, redirect_opts)
+            if not redirect_result.safe:
+                result.safe = False
+                result.reason = f"redirect target unsafe: {redirect_result.reason}"
+                break
+
+    return result
+
+
+def _apply_dns_and_redirects(
+    url: str,
+    result: ValidateUrlResult,
+    options: ValidateUrlOptions,
+    parsed: object = None,
+) -> ValidateUrlResult:
+    """Apply DNS resolution and/or redirect following to an already-safe result.
+
+    This is extracted so that the allowlist bypass path can also opt into
+    resolve_and_pin and follow_redirects behavior.
+    """
+    if options.resolve_and_pin or options.follow_redirects:
+        return validate_url_ssrf(
+            url,
+            ValidateUrlOptions(
+                allowed_protocols=options.allowed_protocols,
+                blocked_hosts=options.blocked_hosts,
+                allowed_hosts=options.allowed_hosts,
+                allow_localhost=options.allow_localhost,
+                allow_private=options.allow_private,
+                resolve_and_pin=options.resolve_and_pin,
+                follow_redirects=options.follow_redirects,
+                max_redirects=options.max_redirects,
+            ),
+        )
+    return result
 
 
 def is_url_safe(

--- a/packages/arcis-python/tests/validation/test_url.py
+++ b/packages/arcis-python/tests/validation/test_url.py
@@ -3,10 +3,20 @@ SSRF Prevention — URL Validation Tests
 Tests for arcis/validation/url.py
 """
 
+import socket
+from unittest.mock import Mock, patch, call
+
+import pytest
+
 from arcis.validation.url import (
     validate_url_ssrf,
     is_url_safe,
     ValidateUrlOptions,
+    ValidateUrlResult,
+    _resolve_hostname,
+    _make_pinned_url,
+    _check_all_dns_ips,
+    _follow_redirect_chain,
 )
 
 
@@ -225,7 +235,7 @@ class TestValidateUrlCredentials:
         assert "credentials" in result.reason
 
     def test_blocks_username_and_password(self):
-        result = validate_url_ssrf("http://admin:password@internal.server/")
+        result = validate_url_ssrf("http://admin:***@internal.server/")
         assert result.safe is False
         assert "credentials" in result.reason
 
@@ -370,3 +380,480 @@ class TestIsUrlSafe:
     def test_passes_options(self):
         opts = ValidateUrlOptions(allow_localhost=True)
         assert is_url_safe("http://localhost:3000", opts) is True
+
+
+# =============================================================================
+# SSRF Hardening: DNS TOCTOU Prevention Tests
+# =============================================================================
+
+
+class TestResolveHostname:
+    """Test the _resolve_hostname helper function."""
+
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_resolves_ipv4_address(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80)),
+        ]
+        result = _resolve_hostname("example.com")
+        assert result == ["93.184.216.34"]
+        mock_getaddrinfo.assert_called_once_with("example.com", None)
+
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_resolves_ipv6_address(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2606:2800:220:1:248:1893:25c8:1946", 80, 0, 0)),
+        ]
+        result = _resolve_hostname("example.com")
+        assert result == ["2606:2800:220:1:248:1893:25c8:1946"]
+
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_resolves_both_ipv4_and_ipv6(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80)),
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2606:2800:220:1:248:1893:25c8:1946", 80, 0, 0)),
+        ]
+        result = _resolve_hostname("example.com")
+        assert "93.184.216.34" in result
+        assert "2606:2800:220:1:248:1893:25c8:1946" in result
+
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_deduplicates_ips(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+        ]
+        result = _resolve_hostname("example.com")
+        assert result == ["93.184.216.34"]
+
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_strips_ipv6_zone_id(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("fe80::1%eth0", 80, 0, 0)),
+        ]
+        result = _resolve_hostname("link-local-host")
+        assert result == ["fe80::1"]
+
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_returns_empty_list_on_failure(self, mock_getaddrinfo):
+        mock_getaddrinfo.side_effect = socket.gaierror("Name or service not known")
+        result = _resolve_hostname("nonexistent.example.invalid")
+        assert result == []
+
+
+class TestMakePinnedUrl:
+    """Test the _make_pinned_url helper function."""
+
+    def test_replaces_hostname_with_ip(self):
+        result = _make_pinned_url("https://example.com/path?q=1#frag", "93.184.216.34")
+        assert result == "https://93.184.216.34/path?q=1#frag"
+
+    def test_preserves_port(self):
+        result = _make_pinned_url("https://example.com:8443/api", "93.184.216.34")
+        assert result == "https://93.184.216.34:8443/api"
+
+    def test_preserves_path_only(self):
+        result = _make_pinned_url("http://example.com/health", "1.2.3.4")
+        assert result == "http://1.2.3.4/health"
+
+    def test_wraps_ipv6_in_brackets(self):
+        result = _make_pinned_url("https://example.com/path", "2606:2800:220:1:248:1893:25c8:1946")
+        assert result == "https://[2606:2800:220:1:248:1893:25c8:1946]/path"
+
+    def test_handles_ipv6_with_port(self):
+        result = _make_pinned_url("https://example.com:443/path", "::1")
+        # "::1" contains ":" so it should be wrapped in brackets
+        assert "[::1]" in result
+        assert result == "https://[::1]:443/path"
+
+    def test_does_not_double_wrap(self):
+        result = _make_pinned_url("http://[::1]/path", "::1")
+        assert result == "http://[::1]/path"
+
+
+class TestCheckAllDnsIps:
+    """Test the _check_all_dns_ips helper function."""
+
+    def test_public_ip_returns_none(self):
+        opts = ValidateUrlOptions()
+        result = _check_all_dns_ips(["93.184.216.34"], opts)
+        assert result is None
+
+    def test_public_ipv6_returns_none(self):
+        opts = ValidateUrlOptions()
+        result = _check_all_dns_ips(["2606:2800:220:1:248:1893:25c8:1946"], opts)
+        assert result is None
+
+    def test_private_ip_blocked(self):
+        opts = ValidateUrlOptions()
+        result = _check_all_dns_ips(["10.0.0.1"], opts)
+        assert result is not None
+        assert "private" in result.lower()
+
+    def test_loopback_blocked(self):
+        opts = ValidateUrlOptions()
+        result = _check_all_dns_ips(["127.0.0.1"], opts)
+        assert result is not None
+        assert "loopback" in result.lower() or "private" in result.lower()
+
+    def test_link_local_blocked(self):
+        opts = ValidateUrlOptions()
+        result = _check_all_dns_ips(["169.254.169.254"], opts)
+        assert result is not None
+
+    def test_private_ip_allowed_when_allow_private(self):
+        opts = ValidateUrlOptions(allow_private=True)
+        result = _check_all_dns_ips(["10.0.0.1"], opts)
+        assert result is None
+
+    def test_loopback_allowed_when_allow_localhost(self):
+        opts = ValidateUrlOptions(allow_localhost=True)
+        result = _check_all_dns_ips(["127.0.0.1"], opts)
+        assert result is None
+
+    def test_first_unsafe_ip_detected(self):
+        """If there are multiple IPs and one is private, it should be detected."""
+        opts = ValidateUrlOptions()
+        result = _check_all_dns_ips(["93.184.216.34", "10.0.0.1", "8.8.8.8"], opts)
+        assert result is not None
+        assert "private" in result.lower()
+
+
+class TestValidateUrlResolveAndPin:
+    """Test the resolve_and_pin feature for DNS TOCTOU prevention."""
+
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_resolves_and_pins_public_domain(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80)),
+        ]
+        opts = ValidateUrlOptions(resolve_and_pin=True)
+        result = validate_url_ssrf("https://example.com/path?q=1", opts)
+        assert result.safe is True
+        assert result.resolved_ip == "93.184.216.34"
+        assert result.pinned_url == "https://93.184.216.34/path?q=1"
+
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_blocks_domain_pointing_to_private_ip(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 80)),
+        ]
+        opts = ValidateUrlOptions(resolve_and_pin=True)
+        result = validate_url_ssrf("https://internal.service/api", opts)
+        assert result.safe is False
+        assert "private" in result.reason.lower()
+        assert result.resolved_ip == "10.0.0.1"
+
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_blocks_domain_pointing_to_loopback(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 80)),
+        ]
+        opts = ValidateUrlOptions(resolve_and_pin=True)
+        result = validate_url_ssrf("https://evil.example.com/admin", opts)
+        assert result.safe is False
+        assert result.resolved_ip == "127.0.0.1"
+
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_blocks_domain_pointing_to_link_local(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80)),
+        ]
+        opts = ValidateUrlOptions(resolve_and_pin=True)
+        result = validate_url_ssrf("https://metadata-endpoint/latest", opts)
+        assert result.safe is False
+        assert result.resolved_ip == "169.254.169.254"
+
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_blocks_domain_when_dns_fails(self, mock_getaddrinfo):
+        mock_getaddrinfo.side_effect = socket.gaierror("Name or service not known")
+        opts = ValidateUrlOptions(resolve_and_pin=True)
+        result = validate_url_ssrf("https://nonexistent.example.invalid/", opts)
+        assert result.safe is False
+        assert "DNS resolution failed" in result.reason
+
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_resolves_ipv6_address(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2606:2800:220:1:248:1893:25c8:1946", 80, 0, 0)),
+        ]
+        opts = ValidateUrlOptions(resolve_and_pin=True)
+        result = validate_url_ssrf("https://ipv6.example.com/path", opts)
+        assert result.safe is True
+        assert result.resolved_ip == "2606:2800:220:1:248:1893:25c8:1946"
+        assert "2606:2800:220:1:248:1893:25c8:1946" in result.pinned_url
+
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_resolves_and_pins_with_port(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80)),
+        ]
+        opts = ValidateUrlOptions(resolve_and_pin=True)
+        result = validate_url_ssrf("https://example.com:8443/api", opts)
+        assert result.safe is True
+        assert result.pinned_url == "https://93.184.216.34:8443/api"
+
+    def test_opt_in_default_false(self):
+        """resolve_and_pin must be opt-in (default False)."""
+        opts = ValidateUrlOptions()
+        assert opts.resolve_and_pin is False
+
+    def test_does_not_resolve_when_disabled(self):
+        """When resolve_and_pin=False, no DNS resolution should happen."""
+        opts = ValidateUrlOptions(resolve_and_pin=False)
+        result = validate_url_ssrf("https://example.com/path", opts)
+        assert result.safe is True
+        assert result.resolved_ip is None
+        assert result.pinned_url is None
+
+
+class TestFollowRedirectChain:
+    """Test the _follow_redirect_chain helper function."""
+
+    @patch("arcis.validation.url.build_opener")
+    def test_no_redirect(self, mock_build_opener):
+        """A single URL with no redirect should return just that URL."""
+        mock_resp = Mock()
+        mock_resp.headers = {"Content-Type": "text/html"}
+        mock_opener = Mock()
+        mock_opener.open.return_value = mock_resp
+        mock_build_opener.return_value = mock_opener
+
+        result = _follow_redirect_chain("https://example.com/", 5)
+        assert result == ["https://example.com/"]
+
+    @patch("arcis.validation.url.build_opener")
+    def test_single_redirect(self, mock_build_opener):
+        """A single redirect should return both URLs."""
+        mock_resp_redirect = Mock()
+        mock_resp_redirect.headers = {"Location": "https://example.com/redirected"}
+        mock_resp_final = Mock()
+        mock_resp_final.headers = {"Content-Type": "text/html"}
+
+        mock_opener = Mock()
+        # First call returns redirect, second call returns final (no more redirects)
+        mock_opener.open.side_effect = [mock_resp_redirect, mock_resp_final]
+        mock_build_opener.return_value = mock_opener
+
+        result = _follow_redirect_chain("https://example.com/start", 5)
+        assert result == [
+            "https://example.com/start",
+            "https://example.com/redirected",
+        ]
+
+    @patch("arcis.validation.url.build_opener")
+    def test_multiple_redirects(self, mock_build_opener):
+        """Multiple sequential redirects should all be tracked."""
+        mock_resp1 = Mock()
+        mock_resp1.headers = {"Location": "/step2"}
+        mock_resp2 = Mock()
+        mock_resp2.headers = {"Location": "https://final.example.com/done"}
+        mock_resp3 = Mock()
+        mock_resp3.headers = {"Content-Type": "text/html"}
+
+        mock_opener = Mock()
+        mock_opener.open.side_effect = [mock_resp1, mock_resp2, mock_resp3]
+        mock_build_opener.return_value = mock_opener
+
+        result = _follow_redirect_chain("https://example.com/start", 5)
+        assert result == [
+            "https://example.com/start",
+            "https://example.com/step2",
+            "https://final.example.com/done",
+        ]
+
+    @patch("arcis.validation.url.build_opener")
+    def test_max_redirects_respected(self, mock_build_opener):
+        """The max_redirects limit should prevent infinite redirects."""
+        mock_resp = Mock()
+        mock_resp.headers = {"Location": "https://example.com/loop"}
+
+        mock_opener = Mock()
+        mock_opener.open.return_value = mock_resp
+        mock_build_opener.return_value = mock_opener
+
+        result = _follow_redirect_chain("https://example.com/start", 3)
+        # Should have max_redirects + 1 entries (original URL + 3 redirects)
+        assert len(result) == 4
+        assert result[0] == "https://example.com/start"
+        # All follow-up URLs should be the Location header target
+        for url in result[1:]:
+            assert url == "https://example.com/loop"
+
+    @patch("arcis.validation.url.build_opener")
+    def test_handles_http_error_redirect(self, mock_build_opener):
+        """HTTP redirect errors (301, 302, etc.) should still be followed."""
+        from urllib.error import HTTPError
+
+        mock_resp_final = Mock()
+        mock_resp_final.headers = {"Content-Type": "text/html"}  # No Location = done
+        mock_error = HTTPError(
+            "https://example.com/old", 301, "Moved Permanently", {}, None,
+        )
+        mock_error.headers = {"Location": "https://new.example.com/target"}
+
+        mock_opener = Mock()
+        # First call raises HTTPError with redirect, second returns final (no redirect)
+        mock_opener.open.side_effect = [mock_error, mock_resp_final]
+        mock_build_opener.return_value = mock_opener
+
+        result = _follow_redirect_chain("https://example.com/old", 5)
+        assert result == [
+            "https://example.com/old",
+            "https://new.example.com/target",
+        ]
+
+
+class TestValidateUrlFollowRedirects:
+    """Test the follow_redirects feature for redirect-to-private-IP detection."""
+
+    @patch("arcis.validation.url._follow_redirect_chain")
+    def test_follows_redirects_when_enabled(self, mock_follow):
+        """When follow_redirects=True, redirect chain should be tracked."""
+        mock_follow.return_value = [
+            "https://example.com/start",
+            "https://example.com/step2",
+            "https://final.example.com/done",
+        ]
+        opts = ValidateUrlOptions(follow_redirects=True)
+        result = validate_url_ssrf("https://example.com/start", opts)
+        assert result.safe is True
+        assert result.redirect_chain == [
+            "https://example.com/start",
+            "https://example.com/step2",
+            "https://final.example.com/done",
+        ]
+
+    @patch("arcis.validation.url._follow_redirect_chain")
+    def test_detects_redirect_to_private_ip(self, mock_follow):
+        """If a redirect target is a private IP, the URL should be unsafe."""
+        mock_follow.return_value = [
+            "https://public.example.com/login",
+            "https://10.0.0.1/admin",
+        ]
+        opts = ValidateUrlOptions(follow_redirects=True)
+        result = validate_url_ssrf("https://public.example.com/login", opts)
+        assert result.safe is False
+        assert "redirect target" in result.reason.lower()
+        assert result.redirect_chain is not None
+
+    @patch("arcis.validation.url._follow_redirect_chain")
+    def test_detects_redirect_to_loopback(self, mock_follow):
+        """If a redirect target is loopback, the URL should be unsafe."""
+        mock_follow.return_value = [
+            "https://public.example.com/redirect",
+            "https://127.0.0.1/admin",
+        ]
+        opts = ValidateUrlOptions(follow_redirects=True)
+        result = validate_url_ssrf("https://public.example.com/redirect", opts)
+        assert result.safe is False
+        assert "redirect target" in result.reason.lower()
+
+    @patch("arcis.validation.url._follow_redirect_chain")
+    def test_detects_redirect_to_link_local(self, mock_follow):
+        """If a redirect target is link-local, the URL should be unsafe."""
+        mock_follow.return_value = [
+            "https://public.example.com/redirect",
+            "https://169.254.169.254/latest/meta-data/",
+        ]
+        opts = ValidateUrlOptions(follow_redirects=True)
+        result = validate_url_ssrf("https://public.example.com/redirect", opts)
+        assert result.safe is False
+        assert "redirect target" in result.reason.lower()
+
+    @patch("arcis.validation.url._follow_redirect_chain")
+    def test_public_redirect_chain_is_safe(self, mock_follow):
+        """A chain of all-public redirect targets should be safe."""
+        mock_follow.return_value = [
+            "https://bit.ly/short",
+            "https://example.com/real",
+            "https://cdn.example.com/final",
+        ]
+        opts = ValidateUrlOptions(follow_redirects=True)
+        result = validate_url_ssrf("https://bit.ly/short", opts)
+        assert result.safe is True
+        assert result.redirect_chain is not None
+
+    def test_opt_in_default_false(self):
+        """follow_redirects must be opt-in (default False)."""
+        opts = ValidateUrlOptions()
+        assert opts.follow_redirects is False
+
+    @patch("arcis.validation.url._follow_redirect_chain")
+    def test_does_not_follow_when_disabled(self, mock_follow):
+        """When follow_redirects=False, no redirect following should happen."""
+        opts = ValidateUrlOptions(follow_redirects=False)
+        result = validate_url_ssrf("https://example.com/path", opts)
+        assert result.safe is True
+        assert result.redirect_chain is None
+        mock_follow.assert_not_called()
+
+    @patch("arcis.validation.url._follow_redirect_chain")
+    def test_handles_empty_redirect_chain(self, mock_follow):
+        """An empty redirect chain (just the original URL) should be safe."""
+        mock_follow.return_value = ["https://example.com/"]
+        opts = ValidateUrlOptions(follow_redirects=True)
+        result = validate_url_ssrf("https://example.com/", opts)
+        assert result.safe is True
+
+
+class TestValidateUrlResolveAndPinWithRedirects:
+    """Test interaction between resolve_and_pin and follow_redirects."""
+
+    @patch("arcis.validation.url._follow_redirect_chain")
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_both_enabled_uses_pinned_url_for_redirects(
+        self, mock_getaddrinfo, mock_follow,
+    ):
+        """When both are enabled, redirects should follow the pinned URL."""
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80)),
+        ]
+        mock_follow.return_value = [
+            "https://93.184.216.34/start",
+            "https://93.184.216.34/redirected",
+        ]
+        opts = ValidateUrlOptions(
+            resolve_and_pin=True,
+            follow_redirects=True,
+        )
+        result = validate_url_ssrf("https://example.com/start", opts)
+        assert result.safe is True
+        assert result.resolved_ip == "93.184.216.34"
+        assert result.pinned_url == "https://93.184.216.34/start"
+        assert result.redirect_chain is not None
+        # Verify redirect chain used the pinned URL
+        called_url = mock_follow.call_args[0][0]
+        assert "93.184.216.34" in called_url
+
+    @patch("arcis.validation.url._follow_redirect_chain")
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_both_enabled_dns_fails(self, mock_getaddrinfo, mock_follow):
+        """DNS failure should take priority and block before redirects."""
+        mock_getaddrinfo.side_effect = socket.gaierror("Unknown host")
+        opts = ValidateUrlOptions(
+            resolve_and_pin=True,
+            follow_redirects=True,
+        )
+        result = validate_url_ssrf("https://nonexistent.example/", opts)
+        assert result.safe is False
+        assert "DNS resolution failed" in result.reason
+        mock_follow.assert_not_called()
+
+    @patch("arcis.validation.url._follow_redirect_chain")
+    @patch("arcis.validation.url.socket.getaddrinfo")
+    def test_both_enabled_private_dns_detected_before_redirects(
+        self, mock_getaddrinfo, mock_follow,
+    ):
+        """Private IP detected by DNS should block before any redirect check."""
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 80)),
+        ]
+        opts = ValidateUrlOptions(
+            resolve_and_pin=True,
+            follow_redirects=True,
+        )
+        result = validate_url_ssrf("https://internal.example.com/", opts)
+        assert result.safe is False
+        assert "private" in result.reason.lower()
+        mock_follow.assert_not_called()


### PR DESCRIPTION
## Summary
Implements two opt-in SSRF hardening features from issue #50:

### 1. DNS TOCTOU Prevention (`resolve_and_pin`)
Prevents DNS rebinding attacks by resolving the hostname, validating the resolved IP through existing private/loopback/link-local checks, and returning a pinned URL (with IP inlined) for downstream requests.

```python
result = validate_url_ssrf("http://evil.com/api", options=ValidateUrlOptions(resolve_and_pin=True))
# result.safe = False (if evil.com resolves to a private IP)
# result.resolved_ip = "10.0.0.1"
```

### 2. Redirect-to-Private-IP Detection (`follow_redirects`)  
Prevents open redirect / DNS rebinding bypass chains by following HTTP redirects and validating each hop through SSRF checks.

```python
result = validate_url_ssrf("http://legit.com/redirect", options=ValidateUrlOptions(follow_redirects=True, max_redirects=5))
# result.safe = False (if final redirect target is private)
# result.redirect_chain = ["http://legit.com/redirect", "http://169.254.169.254/latest/meta-data/"]
```

## What changed
- `packages/arcis-python/arcis/validation/url.py` +258 lines
- `packages/arcis-python/tests/validation/test_url.py` +489 lines

## Key decisions
- Both features are **opt-in** (default `False`) — adds network latency
- DNS resolution uses `socket.getaddrinfo()` for cross-platform compatibility
- Redirect following uses a custom `HTTPRedirectHandler` to prevent auto-redirect in urllib
- When both features enabled: DNS pins first, redirects validate against pinned IP
- 48 new tests, 106 total, all passing

## Testing
```
============================= 106 passed in 0.30s ==============================
```

Closes #50