### PR TITLE
v1.5.2 + cli-v1.0.1: arcis-on-PATH after pip install + welcome screen

### DIFF
--- a/packages/arcis-cli-npm/package.json
+++ b/packages/arcis-cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Arcis security CLI — scan running apps, audit source, and check dependencies. Native Rust binary distributed via npm.",
   "keywords": [
     "security",

--- a/packages/arcis-node/package.json
+++ b/packages/arcis-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/node",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Inside-the-app security middleware for Node.js. One install protects Express, NestJS, SvelteKit, Astro, Nuxt, Bun + Hono against XSS, SQL injection, CSRF, SSRF, HPP, prompt injection, bot traffic, rate limiting, and 20+ more attack types. Includes prompt-injection signature library, LLM token-budget middleware, 646-pattern bot corpus, and the @arcis/cli supply-chain scanner.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/arcis-python/arcis/__init__.py
+++ b/packages/arcis-python/arcis/__init__.py
@@ -183,7 +183,7 @@ try:
 except ImportError:
     _HAS_ASYNC = False
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 __all__ = [
     # Main class
     "Arcis",

--- a/packages/arcis-python/arcis/cli_shim.py
+++ b/packages/arcis-python/arcis/cli_shim.py
@@ -1,0 +1,304 @@
+"""
+arcis CLI shim.
+
+`pip install arcis` registers this module as the `arcis` console script.
+It is intentionally minimal: the heavyweight scan/audit/sca commands
+live in the Rust binary distributed via `npm install -g @arcis/cli`.
+
+This shim does two things:
+
+1. Detect whether the real Rust CLI is installed somewhere on the
+   system. If yes, exec passthrough so users can type `arcis ...`
+   anywhere and the real binary handles it.
+
+2. Otherwise, print a friendly welcome screen with the version of the
+   Python SDK that's installed, instructions for getting the full CLI,
+   and a couple of SDK-level operations that work without the binary
+   (`arcis --version`, `arcis check '<payload>'`).
+
+Why this shim exists: v1.4.x shipped a full Python CLI as part of the
+SDK. v1.5.0 stripped `[project.scripts]` on the assumption that
+`@arcis/cli` was already on npm. It wasn't, until 2026-05-21. Users who
+ran `pip install arcis` between 2026-05-11 and that publish got the
+SDK with no `arcis` command on PATH, which produced a confusing
+"command not found" error. This shim closes that gap.
+
+Self-recursion guard: when the shim is on PATH first (typical for
+Python's `Scripts/` directory on Windows ahead of npm's global bin),
+`shutil.which("arcis")` would return the shim itself, infinitely
+recursing. We resolve the absolute path of `sys.argv[0]` and reject
+any candidate that matches.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from typing import List, Optional
+
+
+# Version of the SDK shipping this shim. Kept in sync with
+# arcis/__init__.py:__version__ — both should bump together.
+SDK_VERSION = "1.5.2"
+
+
+# Locations where npm install -g writes binaries. We check these in
+# order; the first hit that's not us wins.
+def _candidate_paths() -> List[str]:
+    """Probe likely install locations for the real `arcis` binary."""
+    candidates: List[str] = []
+
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA", "")
+        if appdata:
+            # npm-global default on Windows
+            for name in ("arcis.cmd", "arcis.exe", "arcis.ps1", "arcis"):
+                candidates.append(os.path.join(appdata, "npm", name))
+        # Some Windows users have npm under USERPROFILE\AppData\Roaming\npm
+        userprofile = os.environ.get("USERPROFILE", "")
+        if userprofile:
+            for name in ("arcis.cmd", "arcis.exe"):
+                candidates.append(
+                    os.path.join(userprofile, "AppData", "Roaming", "npm", name)
+                )
+    else:
+        for prefix in (
+            "/usr/local/bin",
+            "/opt/homebrew/bin",
+            os.path.expanduser("~/.npm-global/bin"),
+            os.path.expanduser("~/.volta/bin"),
+            "/usr/bin",
+        ):
+            candidates.append(os.path.join(prefix, "arcis"))
+
+    # As a last attempt, ask npm itself where its global prefix is.
+    try:
+        result = subprocess.run(
+            ["npm", "config", "get", "prefix"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode == 0:
+            prefix = result.stdout.strip()
+            if prefix:
+                if sys.platform == "win32":
+                    candidates.append(os.path.join(prefix, "arcis.cmd"))
+                    candidates.append(os.path.join(prefix, "arcis.exe"))
+                else:
+                    candidates.append(os.path.join(prefix, "bin", "arcis"))
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        # npm not installed, or hung. Don't block on it.
+        pass
+
+    return candidates
+
+
+def _is_python_entry_point(path: str) -> bool:
+    """Heuristic: does this path look like a Python `console_scripts` entry
+    point rather than the real Rust CLI? Used as the recursion guard.
+
+    Strong signals:
+      - Path contains `\\Scripts\\` (Windows pip install)
+      - Path contains `/bin/` AND we're inside a virtualenv (sys.prefix)
+      - Path is under sys.exec_prefix (the Python install root)
+
+    The Rust CLI from `@arcis/cli` lives under `npm`'s prefix, which is
+    almost never under Python's install root. False positives are
+    acceptable here: worst case we miss a real CLI install and fall
+    back to the welcome screen. False negatives (treating the Python
+    shim as the real CLI) cause infinite recursion, which we MUST
+    avoid.
+    """
+    normalized = path.replace("\\", "/").lower()
+
+    # Windows pip console_scripts go into <PythonRoot>/Scripts/
+    if "/scripts/" in normalized:
+        return True
+
+    # Inside a Python install / virtualenv layout
+    try:
+        py_root = os.path.realpath(sys.exec_prefix).replace("\\", "/").lower()
+        if py_root and normalized.startswith(py_root):
+            return True
+    except (TypeError, ValueError, OSError):
+        pass
+
+    # Editable install: pip + setuptools/uv put a shim entry point in a
+    # Python bin/ dir that ALSO contains `python` or `python.exe`. Check
+    # for a sibling python interpreter.
+    parent = os.path.dirname(path)
+    if parent:
+        for python_name in ("python", "python.exe", "python3", "python3.exe"):
+            if os.path.isfile(os.path.join(parent, python_name)):
+                return True
+
+    return False
+
+
+def _find_real_cli() -> Optional[str]:
+    """Return the path to the real @arcis/cli binary, or None.
+
+    Recursion guard: filters out Python entry points (the shim itself).
+    Without this guard, the shim would call itself in a subprocess
+    loop on systems where Python's Scripts/ dir comes before npm's
+    global bin on PATH (common on Windows).
+    """
+    # Check PATH first; fast path when the npm bin is ahead of Python's
+    # Scripts/.
+    found = shutil.which("arcis")
+    if found and not _is_python_entry_point(found):
+        return found
+
+    # Probe well-known npm install locations.
+    for candidate in _candidate_paths():
+        if not os.path.isfile(candidate):
+            continue
+        if _is_python_entry_point(candidate):
+            continue
+        return candidate
+
+    return None
+
+
+def _print_welcome() -> None:
+    """Friendly help when the real CLI isn't installed.
+
+    Two sections: how to get the full CLI, and what works without it.
+    The SDK-only operations exercise the real Python detection code so
+    users can verify the install before reaching for npm.
+    """
+    bar = "=" * 64
+    print(bar)
+    print(f"  Arcis Python SDK v{SDK_VERSION}")
+    print(bar)
+    print()
+    print("  You have the Python SDK installed. The scan/audit/sca CLI")
+    print("  ships separately as a native binary via npm.")
+    print()
+    print("  Install the full CLI:")
+    print("      npm install -g @arcis/cli")
+    print()
+    print("  After installing, you'll get:")
+    print("      arcis scan <url>      Probe a running endpoint for vulnerabilities")
+    print("      arcis audit <path>    Static analysis on a source tree")
+    print("      arcis sca <path>      Supply-chain scan of dependencies")
+    print()
+    print("  Without the CLI, you can still use the Python SDK in code:")
+    print("      from arcis import sanitize_string")
+    print("      from arcis.sanitizers.sanitize import scan_threats")
+    print()
+    print("  Quick SDK self-test from this shim:")
+    print("      arcis check '<script>alert(1)</script>'")
+    print("      arcis --version")
+    print()
+    print("  Docs:  https://github.com/Gagancm/arcis")
+    print()
+
+
+def _sdk_self_test(payload: str) -> int:
+    """Run a payload through the Python SDK's scan_threats and print
+    the result. Exists so users can verify the SDK works without the
+    full CLI binary."""
+    try:
+        from .sanitizers.sanitize import scan_threats
+    except Exception as exc:
+        print(f"arcis: failed to load SDK: {exc}", file=sys.stderr)
+        return 2
+
+    result = scan_threats(payload)
+    if result is None:
+        print(f"clean: no threat detected in input ({len(payload)} chars)")
+        return 0
+
+    vector, rule, matched = result
+    print(f"THREAT detected")
+    print(f"  vector:  {vector}")
+    print(f"  rule:    {rule}")
+    print(f"  matched: {matched[:80]}")
+    return 1
+
+
+def main() -> int:
+    """Entry point registered as `arcis` in pyproject.toml.
+
+    Behavior:
+      - With no args or `--help` or `-h`: print welcome screen.
+      - With `--version` or `-V`: print SDK version + tell user about
+        the separate CLI binary.
+      - With `check <payload>`: run scan_threats on the payload (SDK
+        self-test).
+      - With any other args: try to passthrough to the real CLI; if
+        not installed, print welcome screen.
+    """
+    args = sys.argv[1:]
+
+    # Fast path for self-help / version. Don't probe for the CLI
+    # binary on these because the Python SDK can answer them honestly.
+    if not args or args[0] in ("-h", "--help"):
+        # If the real CLI is on the system, defer to its help rather
+        # than printing the shim's welcome.
+        real_cli = _find_real_cli()
+        if real_cli and args:
+            try:
+                os.execv(real_cli, [real_cli] + args)
+            except OSError:
+                pass
+        _print_welcome()
+        return 0
+
+    if args[0] in ("-V", "--version"):
+        print(f"arcis SDK {SDK_VERSION} (Python)")
+        real_cli = _find_real_cli()
+        if real_cli:
+            print(f"  CLI binary available at: {real_cli}")
+            # Also print the CLI's own version
+            try:
+                result = subprocess.run(
+                    [real_cli, "--version"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                cli_ver = (result.stdout or "").strip()
+                if cli_ver:
+                    print(f"  CLI version: {cli_ver}")
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+        else:
+            print("  CLI binary: not installed. Get it: npm install -g @arcis/cli")
+        return 0
+
+    if args[0] == "check":
+        if len(args) < 2:
+            print("usage: arcis check '<payload>'", file=sys.stderr)
+            return 2
+        return _sdk_self_test(args[1])
+
+    # Any other subcommand: passthrough to the real CLI if installed.
+    real_cli = _find_real_cli()
+    if real_cli:
+        try:
+            os.execv(real_cli, [real_cli] + args)
+        except OSError as exc:
+            print(f"arcis: failed to launch real CLI ({real_cli}): {exc}", file=sys.stderr)
+            return 2
+
+    # Real CLI not installed. Be helpful instead of cryptic.
+    print(
+        f"arcis: '{args[0]}' requires the full CLI binary, which isn't "
+        "installed on this system.",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    print("  Install:  npm install -g @arcis/cli", file=sys.stderr)
+    print("  Then:     arcis " + " ".join(args), file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Or run 'arcis --help' for SDK-only options.", file=sys.stderr)
+    return 127
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/arcis-python/arcis/cli_shim.py
+++ b/packages/arcis-python/arcis/cli_shim.py
@@ -214,7 +214,7 @@ def _sdk_self_test(payload: str) -> int:
         return 0
 
     vector, rule, matched = result
-    print(f"THREAT detected")
+    print("THREAT detected")
     print(f"  vector:  {vector}")
     print(f"  rule:    {rule}")
     print(f"  matched: {matched[:80]}")

--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arcis"
-version = "1.5.1"
+version = "1.5.2"
 description = "Inside-the-app security middleware for Python. One install protects FastAPI, Flask, and Django against XSS, SQL injection, CSRF, SSRF, HPP, prompt injection, bot traffic, rate limiting, and 20+ more attack types. Includes prompt-injection signature library, LLM token-budget middleware, and a 646-pattern bot corpus with consistent API across the Node and Go SDKs. The CLI ships separately at npm install -g @arcis/cli."
 readme = "README.md"
 license = "MIT"
@@ -50,6 +50,13 @@ dev = [
     "fastapi>=0.68.0",
     "httpx>=0.24.0",
 ]
+
+[project.scripts]
+# Re-introduce `arcis` on PATH after the v1.5.0 strip. This is a thin
+# shim that either delegates to the real Rust CLI (when @arcis/cli is
+# installed via npm) or prints a friendly install hint + SDK self-test.
+# See arcis/cli_shim.py for the rationale.
+arcis = "arcis.cli_shim:main"
 
 [project.urls]
 Homepage = "https://github.com/GagancM/arcis"

--- a/packages/arcis-rust/Cargo.lock
+++ b/packages/arcis-rust/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arcis-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "arcis-data",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "arcis-data"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "arcis-engine"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arcis-data",
  "dirs",

--- a/packages/arcis-rust/Cargo.toml
+++ b/packages/arcis-rust/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT"
 authors = ["Gagan CM <cm.g@northeastern.edu>"]
@@ -24,8 +24,8 @@ description = "Native Rust CLI for Arcis security middleware"
 rust-version = "1.75"
 
 [workspace.dependencies]
-arcis-engine = { path = "crates/arcis-engine", version = "1.0.0" }
-arcis-data = { path = "crates/arcis-data", version = "1.0.0" }
+arcis-engine = { path = "crates/arcis-engine", version = "1.0.1" }
+arcis-data = { path = "crates/arcis-data", version = "1.0.1" }
 
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/packages/arcis-rust/crates/arcis-cli/src/main.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/main.rs
@@ -14,7 +14,7 @@
 //! Plain text is what the parity harness compares against, byte-for-byte
 //! with the legacy Python CLI's non-TTY output.
 
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::process::ExitCode;
 
 mod audit;
@@ -22,8 +22,25 @@ mod catalog;
 mod sca;
 mod scan;
 mod stub;
+mod welcome;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Best-effort terminal column count without adding a dep.
+///
+/// Reads `$COLUMNS` if exported (most shells set this on interactive
+/// sessions); otherwise returns 120 as a reasonable default that's
+/// wider than the welcome panel's minimum. If the welcome screen
+/// renders wider than the real terminal, lines wrap and the user sees
+/// a slightly mangled box. That's acceptable; the catalog fallback
+/// only triggers below 80 cols and we trust users to have a normal
+/// terminal width.
+fn terminal_cols() -> usize {
+    std::env::var("COLUMNS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(120)
+}
 
 fn main() -> ExitCode {
     // Eager schema check so a build with a stale embedded threat DB fails
@@ -39,11 +56,23 @@ fn main() -> ExitCode {
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
 
-    // No args: print catalog (matches Python's len(sys.argv) < 2 path on
-    // non-TTY, plus the dispatcher in arcis/cli/__init__.py).
+    // No args: pick welcome screen (TTY) or plain catalog (pipe/CI).
+    // Welcome screen requires a wide-enough terminal; we use the
+    // catalog as a graceful fallback when the user has a narrow window
+    // or has piped stdout. This keeps byte-equal parity with the
+    // Python CLI on non-TTY paths, where parity tests run.
     if argv.len() < 2 {
-        let _ = catalog::print(&mut out, VERSION, /* verbose = */ false);
-        let _ = writeln!(out);
+        let stdout_is_tty = std::io::stdout().is_terminal();
+        let cols = terminal_cols();
+        if stdout_is_tty && !welcome::too_narrow(cols) {
+            let cwd = std::env::current_dir()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| String::from("."));
+            let _ = welcome::print(&mut out, VERSION, &cwd);
+        } else {
+            let _ = catalog::print(&mut out, VERSION, /* verbose = */ false);
+            let _ = writeln!(out);
+        }
         return ExitCode::from(0);
     }
 

--- a/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
@@ -125,35 +125,30 @@ fn build_left(version: &str, cwd: &str) -> Vec<String> {
     rows.push(String::new());
     rows.push(center("Welcome to Arcis", LEFT_INNER));
     rows.push(String::new());
-    // Arcis burst mascot. Three rows of radial spokes around a center
-    // star, inspired by the burst SVGs in `cladue desing/exports/`.
-    // The center glyph U+2738 (heavy 8-pointed star) renders as a
-    // single column on every Unicode terminal we've tested.
+    // Arcis burst mascot. Five rows of radial spokes around a dense
+    // center mass, approximating the 7-petal sunburst from
+    // `cladue desing/exports/arcis-burst-emerald.svg`. Uses U+2572 ╲
+    // and U+2571 ╱ (heavy box-drawing diagonals) for the petals so
+    // they read as broad rays rather than thin slashes. U+25CF ● is
+    // the center where all 7 ellipses overlap in the SVG.
     rows.push(center(
-        &format!(
-            "{EMERALD}\\  {V}  /{RESET}",
-            EMERALD = EMERALD,
-            V = V,
-            RESET = RESET
-        ),
+        &format!("{EMERALD}\u{2572} \u{2572}\u{2502}\u{2571} \u{2571}{RESET}"),
         LEFT_INNER,
     ));
     rows.push(center(
-        &format!(
-            "{EMERALD}{H}{H} \u{2738} {H}{H}{RESET}",
-            EMERALD = EMERALD,
-            H = H,
-            RESET = RESET
-        ),
+        &format!("{EMERALD} \u{2572}\u{2572}\u{2502}\u{2571}\u{2571} {RESET}"),
         LEFT_INNER,
     ));
     rows.push(center(
-        &format!(
-            "{EMERALD}/  {V}  \\{RESET}",
-            EMERALD = EMERALD,
-            V = V,
-            RESET = RESET
-        ),
+        &format!("{EMERALD}{H}{H}{H}\u{25CF}{H}{H}{H}{RESET}"),
+        LEFT_INNER,
+    ));
+    rows.push(center(
+        &format!("{EMERALD} \u{2571}\u{2571}\u{2502}\u{2572}\u{2572} {RESET}"),
+        LEFT_INNER,
+    ));
+    rows.push(center(
+        &format!("{EMERALD}\u{2571} \u{2571}\u{2502}\u{2572} \u{2572}{RESET}"),
         LEFT_INNER,
     ));
     rows.push(String::new());
@@ -173,17 +168,18 @@ fn build_right() -> Vec<String> {
     let mut rows = Vec::new();
     rows.push(String::new());
     rows.push(format!("{EMERALD}Tips for getting started{RESET}"));
-    rows.push("Run 'arcis audit .' to scan your code for unsafe patterns".to_string());
-    rows.push("Run 'arcis sca .' to match deps against the threat database".to_string());
-    rows.push("Run 'arcis scan <url>' to probe a live endpoint".to_string());
+    rows.push("  Run 'arcis audit .' to scan your code for unsafe patterns".to_string());
+    rows.push("  Run 'arcis sca .' to match deps against the threat database".to_string());
+    rows.push("  Run 'arcis scan <url>' to probe a live endpoint".to_string());
     rows.push(String::new());
-    rows.push(format!("{EMERALD}What's new{RESET}"));
-    rows.push("Two-panel welcome screen on 'arcis' with no arguments".to_string());
-    rows.push("Python SDK shim restored: 'pip install arcis' exposes 'arcis' again".to_string());
-    rows.push("Daily cli-install-smoke workflow catches publish-channel breakage".to_string());
-    rows.push("Auto-published on every nwl to main release via publish.yml".to_string());
+    rows.push(format!("{EMERALD}More commands{RESET}"));
+    rows.push("  arcis --help      Per-command help and full flag reference".to_string());
+    rows.push("  arcis --version   Print installed CLI version".to_string());
+    rows.push("  arcis --list      Verbose catalog with examples per command".to_string());
+    rows.push("  arcis update      Check for a newer Arcis release".to_string());
+    rows.push(String::new());
     rows.push(format!(
-        "{DIM}arcis --help for the full command reference{RESET}"
+        "{DIM}  Upgrade:  npm install -g @arcis/cli@latest{RESET}"
     ));
     rows.push(String::new());
     rows
@@ -277,7 +273,7 @@ mod tests {
     fn right_panel_carries_section_titles() {
         let out = render("1.0.1", "/tmp/proj");
         assert!(out.contains("Tips for getting started"));
-        assert!(out.contains("What's new"));
+        assert!(out.contains("More commands"));
     }
 
     #[test]
@@ -286,6 +282,17 @@ mod tests {
         assert!(out.contains("arcis audit ."));
         assert!(out.contains("arcis sca ."));
         assert!(out.contains("arcis scan"));
+    }
+
+    #[test]
+    fn right_panel_lists_meta_commands() {
+        let out = render("1.0.1", "/tmp/proj");
+        assert!(out.contains("--help"));
+        assert!(out.contains("--version"));
+        assert!(out.contains("--list"));
+        assert!(out.contains("arcis update"));
+        assert!(out.contains("Upgrade:"));
+        assert!(out.contains("npm install -g @arcis/cli"));
     }
 
     #[test]

--- a/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
@@ -1,0 +1,296 @@
+//! Two-panel welcome screen for `arcis` no-args on TTY.
+//!
+//! Shows on `arcis` (no arguments) when stdout is a TTY. Inspired by
+//! Claude Code's first-screen layout: left panel for identity (version,
+//! cwd), right panel for tips + commands + "what's new". Non-TTY (pipes,
+//! CI) and `--help` / `--list` continue to use the plain catalog in
+//! `catalog.rs` so byte-equal parity with the Python harness holds.
+//!
+//! Width: the panels target ~120 columns total. If the terminal is
+//! narrower than 80 columns, fall back to the plain catalog. Wider than
+//! 120 means we just leave extra blank on the right; we don't stretch
+//! panels because hand-stretched panels look worse than fixed-width ones.
+
+use std::io::{self, Write};
+
+/// Bullet entries shown in the right-side "Tips" panel. Kept short so
+/// they fit in ~70 columns minus padding.
+struct Tip {
+    cmd: &'static str,
+    note: &'static str,
+}
+
+const TIPS: &[Tip] = &[
+    Tip {
+        cmd: "arcis audit .",
+        note: "Static-scan your code for unsafe patterns",
+    },
+    Tip {
+        cmd: "arcis sca .",
+        note: "Match deps against supply-chain threat DB",
+    },
+    Tip {
+        cmd: "arcis scan http://localhost:3000",
+        note: "Probe a live endpoint for vulnerabilities",
+    },
+    Tip {
+        cmd: "arcis --help",
+        note: "Full command reference + flags",
+    },
+];
+
+/// Bullet entries shown in the "What's new" panel. Bump when the CLI
+/// gets new flags / commands worth surfacing on every cold start.
+const WHATS_NEW: &[&str] = &[
+    "Two-panel welcome screen on `arcis` no-args (TTY only).",
+    "Python SDK shim: `pip install arcis` exposes `arcis` again.",
+    "Daily cli-install-smoke workflow catches publish-channel breakage.",
+    "Auto-published from publish.yml on every nwl to main release.",
+];
+
+const LEFT_WIDTH: usize = 42;
+const RIGHT_WIDTH: usize = 72;
+
+/// Print the welcome screen. `version` is the CLI binary version; `cwd`
+/// is the directory the user invoked `arcis` from (rendered truncated
+/// if it would overflow the left panel).
+pub fn print<W: Write>(w: &mut W, version: &str, cwd: &str) -> io::Result<()> {
+    let title_left = format!(" Arcis CLI v{version} ");
+    let title_tips = " Tips for getting started ";
+    let title_news = " What's new ";
+
+    // Top border with the embedded titles.
+    writeln!(
+        w,
+        "{}  {}",
+        top_border(LEFT_WIDTH, &title_left),
+        top_border(RIGHT_WIDTH, title_tips)
+    )?;
+
+    // Render row-by-row. The two panels are independent vertically so
+    // we compute the height of each and pad the shorter one.
+    let left_rows = build_left_rows(version, cwd);
+    let mut right_rows: Vec<String> = Vec::new();
+    push_blank(&mut right_rows);
+    for tip in TIPS {
+        push_tip(&mut right_rows, tip.cmd, tip.note);
+    }
+    push_blank(&mut right_rows);
+    // Right panel transitions to "What's new" with an inline title.
+    right_rows.push(format!(
+        "{}{}",
+        section_title(title_news),
+        " ".repeat(RIGHT_WIDTH.saturating_sub(title_news.len()).saturating_sub(2))
+    ));
+    push_blank(&mut right_rows);
+    for note in WHATS_NEW {
+        push_news(&mut right_rows, note);
+    }
+    push_blank(&mut right_rows);
+
+    let height = left_rows.len().max(right_rows.len());
+    for i in 0..height {
+        let left = left_rows
+            .get(i)
+            .map(String::as_str)
+            .unwrap_or("");
+        let right = right_rows
+            .get(i)
+            .map(String::as_str)
+            .unwrap_or("");
+        let left_padded = format!("|{}|", pad_inside(left, LEFT_WIDTH - 2));
+        let right_padded = format!("|{}|", pad_inside(right, RIGHT_WIDTH - 2));
+        writeln!(w, "{}  {}", left_padded, right_padded)?;
+    }
+
+    writeln!(
+        w,
+        "{}  {}",
+        bottom_border(LEFT_WIDTH),
+        bottom_border(RIGHT_WIDTH)
+    )?;
+    writeln!(w)?;
+    writeln!(w, "  Run 'arcis --help' for the full reference.")?;
+    writeln!(w, "  Issues: https://github.com/Gagancm/arcis/issues")?;
+    Ok(())
+}
+
+/// Returns true when the terminal is too narrow to render the welcome
+/// nicely. Caller falls back to the plain catalog when true.
+pub fn too_narrow(cols: usize) -> bool {
+    cols < (LEFT_WIDTH + RIGHT_WIDTH + 4)
+}
+
+fn build_left_rows(version: &str, cwd: &str) -> Vec<String> {
+    let mut rows: Vec<String> = Vec::new();
+    push_blank(&mut rows);
+    rows.push(center("Welcome to Arcis", LEFT_WIDTH - 2));
+    push_blank(&mut rows);
+    // Compact ASCII shield as the visual anchor. Box-drawing characters
+    // skipped on purpose so terminals without Unicode font support
+    // still render correctly.
+    rows.push(center("___", LEFT_WIDTH - 2));
+    rows.push(center("/ A \\", LEFT_WIDTH - 2));
+    rows.push(center("\\___/", LEFT_WIDTH - 2));
+    push_blank(&mut rows);
+    rows.push(center(&format!("v{version} (Rust)"), LEFT_WIDTH - 2));
+    push_blank(&mut rows);
+    let cwd_short = truncate_cwd(cwd, LEFT_WIDTH - 4);
+    rows.push(center(&cwd_short, LEFT_WIDTH - 2));
+    push_blank(&mut rows);
+    push_blank(&mut rows);
+    rows
+}
+
+fn truncate_cwd(cwd: &str, width: usize) -> String {
+    if cwd.len() <= width {
+        return cwd.to_string();
+    }
+    // Show the tail of the path with ellipsis. More useful than the head
+    // because the relevant info (project name) is usually at the end.
+    let keep = width.saturating_sub(3);
+    let start = cwd.len().saturating_sub(keep);
+    format!("...{}", &cwd[start..])
+}
+
+fn push_blank(rows: &mut Vec<String>) {
+    rows.push(String::new());
+}
+
+fn push_tip(rows: &mut Vec<String>, cmd: &str, note: &str) {
+    // Two-line tip: command (highlighted) then dim explanation.
+    rows.push(format!("  {cmd}"));
+    rows.push(format!("    {note}"));
+    push_blank(rows);
+}
+
+fn push_news(rows: &mut Vec<String>, note: &str) {
+    rows.push(format!("  - {note}"));
+}
+
+fn section_title(title: &str) -> String {
+    // A subtle inline divider so the right panel reads as two stacked
+    // sections (Tips then What's new) without needing a second box.
+    format!("  {title}")
+}
+
+/// Left-pad and right-pad a row to exactly `width` inner columns. Used
+/// for the contents between the panel's left/right border characters.
+fn pad_inside(s: &str, width: usize) -> String {
+    if s.len() >= width {
+        // Truncate at character boundary; we control the inputs above
+        // so this should never fire in practice.
+        return s[..width.min(s.len())].to_string();
+    }
+    let pad = " ".repeat(width - s.len());
+    format!("{s}{pad}")
+}
+
+fn center(s: &str, width: usize) -> String {
+    if s.len() >= width {
+        return s.to_string();
+    }
+    let total = width - s.len();
+    let left = total / 2;
+    let right = total - left;
+    format!("{}{}{}", " ".repeat(left), s, " ".repeat(right))
+}
+
+fn top_border(width: usize, title: &str) -> String {
+    // Plain ASCII border so it renders on every terminal/font combination.
+    // `+- title --------+` style; mimics the rounded look without using
+    // Unicode box-drawing chars (which fail on default Windows cmd.exe
+    // when chcp != 65001).
+    let mut bar = String::from(",");
+    bar.push('-');
+    bar.push_str(title);
+    let used = bar.len();
+    let pad = width.saturating_sub(used).saturating_sub(1);
+    for _ in 0..pad {
+        bar.push('-');
+    }
+    bar.push('.');
+    bar
+}
+
+fn bottom_border(width: usize) -> String {
+    let mut bar = String::from("'");
+    for _ in 1..(width - 1) {
+        bar.push('-');
+    }
+    bar.push('\'');
+    bar
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render(version: &str, cwd: &str) -> String {
+        let mut buf = Vec::new();
+        print(&mut buf, version, cwd).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn shows_version_and_label() {
+        let out = render("1.0.1", "/tmp/proj");
+        assert!(out.contains("Arcis CLI v1.0.1"));
+        assert!(out.contains("v1.0.1 (Rust)"));
+    }
+
+    #[test]
+    fn shows_three_main_commands() {
+        let out = render("1.0.1", "/tmp/proj");
+        assert!(out.contains("arcis audit ."));
+        assert!(out.contains("arcis sca ."));
+        assert!(out.contains("arcis scan"));
+    }
+
+    #[test]
+    fn shows_tips_panel_title() {
+        let out = render("1.0.1", "/tmp/proj");
+        assert!(out.contains("Tips for getting started"));
+    }
+
+    #[test]
+    fn shows_whats_new_section() {
+        let out = render("1.0.1", "/tmp/proj");
+        assert!(out.contains("What's new"));
+    }
+
+    #[test]
+    fn shows_short_cwd_unchanged() {
+        let out = render("1.0.1", "/tmp/proj");
+        assert!(out.contains("/tmp/proj"));
+    }
+
+    #[test]
+    fn truncates_long_cwd_to_tail() {
+        let long = "/a/very/long/path/that/way/exceeds/the/left/panel/width/projectname";
+        let out = render("1.0.1", long);
+        // Tail (project name) preserved
+        assert!(out.contains("projectname"));
+        // Ellipsis present
+        assert!(out.contains("..."));
+    }
+
+    #[test]
+    fn too_narrow_threshold() {
+        assert!(too_narrow(80));
+        assert!(!too_narrow(120));
+        assert!(!too_narrow(160));
+    }
+
+    #[test]
+    fn truncate_cwd_returns_input_when_short() {
+        assert_eq!(truncate_cwd("/short", 40), "/short");
+    }
+
+    #[test]
+    fn truncate_cwd_keeps_tail() {
+        let result = truncate_cwd("/a/very/long/path/projectname", 20);
+        assert!(result.ends_with("projectname"));
+        assert!(result.starts_with("..."));
+    }
+}

--- a/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
@@ -10,14 +10,16 @@
 
 use std::io::{self, Write};
 
-// Arcis Signal Orange #FF5300, the primary brand color used in the
-// dashboard. Encoded as 24-bit ANSI true color. Modern terminals
-// (Windows Terminal, iTerm2, Alacritty, all modern Linux terminals)
-// support this. Older Windows cmd.exe before Win10 1607 may render
-// the escape as literal text, but we only emit this on TTY, and the
-// user explicitly invoked an interactive command. Anyone hitting that
-// edge case can pipe to `cat` or set NO_COLOR.
-const ORANGE: &str = "\x1b[38;2;255;83;0m";
+// Arcis Emerald #00996D, the brand color used on the website + docs
+// per `documents/arcis-brand.md`. The dashboard uses Signal Orange
+// #FF5300 instead; CLI is marketing-surface so it picks emerald.
+// Encoded as 24-bit ANSI true color. Modern terminals (Windows
+// Terminal, iTerm2, Alacritty, all modern Linux terminals) support
+// this. Older Windows cmd.exe before Win10 1607 may render the
+// escape as literal text, but we only emit this on TTY, and the
+// user explicitly invoked an interactive command. Anyone hitting
+// that edge case can pipe to `cat` or set NO_COLOR.
+const EMERALD: &str = "\x1b[38;2;0;153;109m";
 const DIM: &str = "\x1b[2m";
 const RESET: &str = "\x1b[0m";
 
@@ -78,7 +80,7 @@ fn top_border(title: &str) -> String {
     // The title sits 2 cols in from the left corner. The rest of the
     // top is filled with horizontal lines until the right corner.
     let mut s = String::new();
-    s.push_str(ORANGE);
+    s.push_str(EMERALD);
     s.push_str(TL);
     s.push_str(H);
     s.push_str(title);
@@ -94,7 +96,7 @@ fn top_border(title: &str) -> String {
 
 fn bottom_border() -> String {
     let mut s = String::new();
-    s.push_str(ORANGE);
+    s.push_str(EMERALD);
     s.push_str(BL);
     for _ in 0..(TOTAL_WIDTH - 2) {
         s.push_str(H);
@@ -111,7 +113,7 @@ fn render_row<W: Write>(w: &mut W, left: &str, right: &str) -> io::Result<()> {
     writeln!(
         w,
         "{O}{V}{R} {l} {O}{V}{R} {r} {O}{V}{R}",
-        O = ORANGE,
+        O = EMERALD,
         V = V,
         R = RESET,
         l = left_padded,
@@ -129,15 +131,15 @@ fn build_left(version: &str, cwd: &str) -> Vec<String> {
     // The center glyph U+2738 (heavy 8-pointed star) renders as a
     // single column on every Unicode terminal we've tested.
     rows.push(center(
-        &format!("{ORANGE}\\  {V}  /{RESET}", ORANGE = ORANGE, V = V, RESET = RESET),
+        &format!("{EMERALD}\\  {V}  /{RESET}", EMERALD = EMERALD, V = V, RESET = RESET),
         LEFT_INNER,
     ));
     rows.push(center(
-        &format!("{ORANGE}{H}{H} \u{2738} {H}{H}{RESET}", ORANGE = ORANGE, H = H, RESET = RESET),
+        &format!("{EMERALD}{H}{H} \u{2738} {H}{H}{RESET}", EMERALD = EMERALD, H = H, RESET = RESET),
         LEFT_INNER,
     ));
     rows.push(center(
-        &format!("{ORANGE}/  {V}  \\{RESET}", ORANGE = ORANGE, V = V, RESET = RESET),
+        &format!("{EMERALD}/  {V}  \\{RESET}", EMERALD = EMERALD, V = V, RESET = RESET),
         LEFT_INNER,
     ));
     rows.push(String::new());
@@ -156,12 +158,12 @@ fn build_left(version: &str, cwd: &str) -> Vec<String> {
 fn build_right() -> Vec<String> {
     let mut rows = Vec::new();
     rows.push(String::new());
-    rows.push(format!("{ORANGE}Tips for getting started{RESET}"));
+    rows.push(format!("{EMERALD}Tips for getting started{RESET}"));
     rows.push("Run 'arcis audit .' to scan your code for unsafe patterns".to_string());
     rows.push("Run 'arcis sca .' to match deps against the threat database".to_string());
     rows.push("Run 'arcis scan <url>' to probe a live endpoint".to_string());
     rows.push(String::new());
-    rows.push(format!("{ORANGE}What's new{RESET}"));
+    rows.push(format!("{EMERALD}What's new{RESET}"));
     rows.push("Two-panel welcome screen on 'arcis' with no arguments".to_string());
     rows.push("Python SDK shim restored: 'pip install arcis' exposes 'arcis' again".to_string());
     rows.push("Daily cli-install-smoke workflow catches publish-channel breakage".to_string());
@@ -295,13 +297,13 @@ mod tests {
     #[test]
     fn visible_cols_ignores_ansi_sequences() {
         assert_eq!(visible_cols("hello"), 5);
-        assert_eq!(visible_cols(&format!("{ORANGE}hello{RESET}")), 5);
+        assert_eq!(visible_cols(&format!("{EMERALD}hello{RESET}")), 5);
         assert_eq!(visible_cols("\x1b[38;2;255;0;0mred\x1b[0m"), 3);
     }
 
     #[test]
     fn pad_uses_visible_width_not_byte_count() {
-        let colored = format!("{ORANGE}abc{RESET}");
+        let colored = format!("{EMERALD}abc{RESET}");
         let padded = pad(&colored, 10);
         // 3 visible chars + 7 spaces of padding
         assert_eq!(visible_cols(&padded), 10);

--- a/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
@@ -39,10 +39,9 @@ const TOTAL_WIDTH: usize = 130;
 /// on each side).
 const LEFT_INNER: usize = 34;
 
-/// Inner content width of the right panel. TOTAL_WIDTH minus:
-/// left border (1) + left pad (1) + LEFT_INNER (34) + left pad (1)
-/// + divider (1) + right pad (1) + right pad (1) + right border (1) = 41
-/// remaining for right inner = 130 - 41 = 89.
+/// Inner content width of the right panel. Computed as TOTAL_WIDTH (130)
+/// minus the fixed structural columns: 2 borders, 4 padding spaces, 1
+/// divider, and LEFT_INNER (34). Leaves 89 columns for right-side text.
 const RIGHT_INNER: usize = 89;
 
 /// Terminals narrower than this fall back to the catalog. We need at
@@ -336,7 +335,7 @@ mod tests {
         // Should not panic on multi-byte chars.
         let unicode = "/тест/проект/файл";
         let result = truncate_cwd(unicode, 10);
-        assert!(result.len() > 0);
+        assert!(!result.is_empty());
     }
 
     #[test]

--- a/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
@@ -131,15 +131,30 @@ fn build_left(version: &str, cwd: &str) -> Vec<String> {
     // The center glyph U+2738 (heavy 8-pointed star) renders as a
     // single column on every Unicode terminal we've tested.
     rows.push(center(
-        &format!("{EMERALD}\\  {V}  /{RESET}", EMERALD = EMERALD, V = V, RESET = RESET),
+        &format!(
+            "{EMERALD}\\  {V}  /{RESET}",
+            EMERALD = EMERALD,
+            V = V,
+            RESET = RESET
+        ),
         LEFT_INNER,
     ));
     rows.push(center(
-        &format!("{EMERALD}{H}{H} \u{2738} {H}{H}{RESET}", EMERALD = EMERALD, H = H, RESET = RESET),
+        &format!(
+            "{EMERALD}{H}{H} \u{2738} {H}{H}{RESET}",
+            EMERALD = EMERALD,
+            H = H,
+            RESET = RESET
+        ),
         LEFT_INNER,
     ));
     rows.push(center(
-        &format!("{EMERALD}/  {V}  \\{RESET}", EMERALD = EMERALD, V = V, RESET = RESET),
+        &format!(
+            "{EMERALD}/  {V}  \\{RESET}",
+            EMERALD = EMERALD,
+            V = V,
+            RESET = RESET
+        ),
         LEFT_INNER,
     ));
     rows.push(String::new());
@@ -168,7 +183,9 @@ fn build_right() -> Vec<String> {
     rows.push("Python SDK shim restored: 'pip install arcis' exposes 'arcis' again".to_string());
     rows.push("Daily cli-install-smoke workflow catches publish-channel breakage".to_string());
     rows.push("Auto-published on every nwl to main release via publish.yml".to_string());
-    rows.push(format!("{DIM}arcis --help for the full command reference{RESET}"));
+    rows.push(format!(
+        "{DIM}arcis --help for the full command reference{RESET}"
+    ));
     rows.push(String::new());
     rows
 }

--- a/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
@@ -1,225 +1,236 @@
-//! Two-panel welcome screen for `arcis` no-args on TTY.
+//! Claude-Code-shaped welcome screen for `arcis` no-args on TTY.
 //!
-//! Shows on `arcis` (no arguments) when stdout is a TTY. Inspired by
-//! Claude Code's first-screen layout: left panel for identity (version,
-//! cwd), right panel for tips + commands + "what's new". Non-TTY (pipes,
-//! CI) and `--help` / `--list` continue to use the plain catalog in
-//! `catalog.rs` so byte-equal parity with the Python harness holds.
+//! Layout: a single unified rounded box with the title embedded in the
+//! top border, an internal vertical divider, and two side-by-side
+//! panels. Left panel carries identity (mascot, version, cwd). Right
+//! panel carries Tips + What's new with colored section headers.
 //!
-//! Width: the panels target ~120 columns total. If the terminal is
-//! narrower than 80 columns, fall back to the plain catalog. Wider than
-//! 120 means we just leave extra blank on the right; we don't stretch
-//! panels because hand-stretched panels look worse than fixed-width ones.
+//! Non-TTY paths (pipes, CI, redirects, narrow terminals) keep the
+//! plain catalog so byte-equal parity with the Python harness holds.
 
 use std::io::{self, Write};
 
-/// Bullet entries shown in the right-side "Tips" panel. Kept short so
-/// they fit in ~70 columns minus padding.
-struct Tip {
-    cmd: &'static str,
-    note: &'static str,
+// Arcis Signal Orange #FF5300, the primary brand color used in the
+// dashboard. Encoded as 24-bit ANSI true color. Modern terminals
+// (Windows Terminal, iTerm2, Alacritty, all modern Linux terminals)
+// support this. Older Windows cmd.exe before Win10 1607 may render
+// the escape as literal text, but we only emit this on TTY, and the
+// user explicitly invoked an interactive command. Anyone hitting that
+// edge case can pipe to `cat` or set NO_COLOR.
+const ORANGE: &str = "\x1b[38;2;255;83;0m";
+const DIM: &str = "\x1b[2m";
+const RESET: &str = "\x1b[0m";
+
+// Box character set. Rounded corners + thin lines mirrors Claude Code.
+const TL: &str = "\u{256D}"; // ╭
+const TR: &str = "\u{256E}"; // ╮
+const BL: &str = "\u{2570}"; // ╰
+const BR: &str = "\u{256F}"; // ╯
+const V: &str = "\u{2502}"; // │
+const H: &str = "\u{2500}"; // ─
+
+/// Total width in display columns. 130 fits comfortably in a 144-col
+/// terminal (modern default for most editors / wide terminals).
+const TOTAL_WIDTH: usize = 130;
+
+/// Inner content width of the left panel (excludes border + 1-col pad
+/// on each side).
+const LEFT_INNER: usize = 34;
+
+/// Inner content width of the right panel. TOTAL_WIDTH minus:
+/// left border (1) + left pad (1) + LEFT_INNER (34) + left pad (1)
+/// + divider (1) + right pad (1) + right pad (1) + right border (1) = 41
+/// remaining for right inner = 130 - 41 = 89.
+const RIGHT_INNER: usize = 89;
+
+/// Terminals narrower than this fall back to the catalog. We need at
+/// least TOTAL_WIDTH plus a tiny margin so the right edge doesn't
+/// hug the terminal edge.
+const MIN_COLS: usize = TOTAL_WIDTH + 2;
+
+pub fn too_narrow(cols: usize) -> bool {
+    cols < MIN_COLS
 }
 
-const TIPS: &[Tip] = &[
-    Tip {
-        cmd: "arcis audit .",
-        note: "Static-scan your code for unsafe patterns",
-    },
-    Tip {
-        cmd: "arcis sca .",
-        note: "Match deps against supply-chain threat DB",
-    },
-    Tip {
-        cmd: "arcis scan http://localhost:3000",
-        note: "Probe a live endpoint for vulnerabilities",
-    },
-    Tip {
-        cmd: "arcis --help",
-        note: "Full command reference + flags",
-    },
-];
-
-/// Bullet entries shown in the "What's new" panel. Bump when the CLI
-/// gets new flags / commands worth surfacing on every cold start.
-const WHATS_NEW: &[&str] = &[
-    "Two-panel welcome screen on `arcis` no-args (TTY only).",
-    "Python SDK shim: `pip install arcis` exposes `arcis` again.",
-    "Daily cli-install-smoke workflow catches publish-channel breakage.",
-    "Auto-published from publish.yml on every nwl to main release.",
-];
-
-const LEFT_WIDTH: usize = 42;
-const RIGHT_WIDTH: usize = 72;
-
-/// Print the welcome screen. `version` is the CLI binary version; `cwd`
-/// is the directory the user invoked `arcis` from (rendered truncated
-/// if it would overflow the left panel).
+/// Render the welcome screen. Caller decides TTY-ness; this just
+/// writes the formatted output.
 pub fn print<W: Write>(w: &mut W, version: &str, cwd: &str) -> io::Result<()> {
-    let title_left = format!(" Arcis CLI v{version} ");
-    let title_tips = " Tips for getting started ";
-    let title_news = " What's new ";
+    // Top border with title embedded between dashes.
+    let title = format!(" Arcis CLI v{version} ");
+    writeln!(w, "{}", top_border(&title))?;
 
-    // Top border with the embedded titles.
-    writeln!(
-        w,
-        "{}  {}",
-        top_border(LEFT_WIDTH, &title_left),
-        top_border(RIGHT_WIDTH, title_tips)
-    )?;
+    let left = build_left(version, cwd);
+    let right = build_right();
+    let rows = left.len().max(right.len());
 
-    // Render row-by-row. The two panels are independent vertically so
-    // we compute the height of each and pad the shorter one.
-    let left_rows = build_left_rows(version, cwd);
-    let mut right_rows: Vec<String> = Vec::new();
-    push_blank(&mut right_rows);
-    for tip in TIPS {
-        push_tip(&mut right_rows, tip.cmd, tip.note);
-    }
-    push_blank(&mut right_rows);
-    // Right panel transitions to "What's new" with an inline title.
-    right_rows.push(format!(
-        "{}{}",
-        section_title(title_news),
-        " ".repeat(RIGHT_WIDTH.saturating_sub(title_news.len()).saturating_sub(2))
-    ));
-    push_blank(&mut right_rows);
-    for note in WHATS_NEW {
-        push_news(&mut right_rows, note);
-    }
-    push_blank(&mut right_rows);
-
-    let height = left_rows.len().max(right_rows.len());
-    for i in 0..height {
-        let left = left_rows
-            .get(i)
-            .map(String::as_str)
-            .unwrap_or("");
-        let right = right_rows
-            .get(i)
-            .map(String::as_str)
-            .unwrap_or("");
-        let left_padded = format!("|{}|", pad_inside(left, LEFT_WIDTH - 2));
-        let right_padded = format!("|{}|", pad_inside(right, RIGHT_WIDTH - 2));
-        writeln!(w, "{}  {}", left_padded, right_padded)?;
+    for i in 0..rows {
+        let l = left.get(i).map(String::as_str).unwrap_or("");
+        let r = right.get(i).map(String::as_str).unwrap_or("");
+        render_row(w, l, r)?;
     }
 
-    writeln!(
-        w,
-        "{}  {}",
-        bottom_border(LEFT_WIDTH),
-        bottom_border(RIGHT_WIDTH)
-    )?;
-    writeln!(w)?;
-    writeln!(w, "  Run 'arcis --help' for the full reference.")?;
-    writeln!(w, "  Issues: https://github.com/Gagancm/arcis/issues")?;
+    writeln!(w, "{}", bottom_border())?;
     Ok(())
 }
 
-/// Returns true when the terminal is too narrow to render the welcome
-/// nicely. Caller falls back to the plain catalog when true.
-pub fn too_narrow(cols: usize) -> bool {
-    cols < (LEFT_WIDTH + RIGHT_WIDTH + 4)
+fn top_border(title: &str) -> String {
+    // ╭─ Arcis CLI vX.Y.Z ────────────────────────╮
+    // The title sits 2 cols in from the left corner. The rest of the
+    // top is filled with horizontal lines until the right corner.
+    let mut s = String::new();
+    s.push_str(ORANGE);
+    s.push_str(TL);
+    s.push_str(H);
+    s.push_str(title);
+    let used_cols = 1 + 1 + visible_cols(title);
+    let remaining = TOTAL_WIDTH.saturating_sub(used_cols).saturating_sub(1);
+    for _ in 0..remaining {
+        s.push_str(H);
+    }
+    s.push_str(TR);
+    s.push_str(RESET);
+    s
 }
 
-fn build_left_rows(version: &str, cwd: &str) -> Vec<String> {
-    let mut rows: Vec<String> = Vec::new();
-    push_blank(&mut rows);
-    rows.push(center("Welcome to Arcis", LEFT_WIDTH - 2));
-    push_blank(&mut rows);
-    // Compact ASCII shield as the visual anchor. Box-drawing characters
-    // skipped on purpose so terminals without Unicode font support
-    // still render correctly.
-    rows.push(center("___", LEFT_WIDTH - 2));
-    rows.push(center("/ A \\", LEFT_WIDTH - 2));
-    rows.push(center("\\___/", LEFT_WIDTH - 2));
-    push_blank(&mut rows);
-    rows.push(center(&format!("v{version} (Rust)"), LEFT_WIDTH - 2));
-    push_blank(&mut rows);
-    let cwd_short = truncate_cwd(cwd, LEFT_WIDTH - 4);
-    rows.push(center(&cwd_short, LEFT_WIDTH - 2));
-    push_blank(&mut rows);
-    push_blank(&mut rows);
+fn bottom_border() -> String {
+    let mut s = String::new();
+    s.push_str(ORANGE);
+    s.push_str(BL);
+    for _ in 0..(TOTAL_WIDTH - 2) {
+        s.push_str(H);
+    }
+    s.push_str(BR);
+    s.push_str(RESET);
+    s
+}
+
+fn render_row<W: Write>(w: &mut W, left: &str, right: &str) -> io::Result<()> {
+    let left_padded = pad(left, LEFT_INNER);
+    let right_padded = pad(right, RIGHT_INNER);
+    // Format: │ <left 34 cols> │ <right 89 cols> │
+    writeln!(
+        w,
+        "{O}{V}{R} {l} {O}{V}{R} {r} {O}{V}{R}",
+        O = ORANGE,
+        V = V,
+        R = RESET,
+        l = left_padded,
+        r = right_padded
+    )
+}
+
+fn build_left(version: &str, cwd: &str) -> Vec<String> {
+    let mut rows = Vec::new();
+    rows.push(String::new());
+    rows.push(center("Welcome to Arcis", LEFT_INNER));
+    rows.push(String::new());
+    // Arcis burst mascot. Three rows of radial spokes around a center
+    // star, inspired by the burst SVGs in `cladue desing/exports/`.
+    // The center glyph U+2738 (heavy 8-pointed star) renders as a
+    // single column on every Unicode terminal we've tested.
+    rows.push(center(
+        &format!("{ORANGE}\\  {V}  /{RESET}", ORANGE = ORANGE, V = V, RESET = RESET),
+        LEFT_INNER,
+    ));
+    rows.push(center(
+        &format!("{ORANGE}{H}{H} \u{2738} {H}{H}{RESET}", ORANGE = ORANGE, H = H, RESET = RESET),
+        LEFT_INNER,
+    ));
+    rows.push(center(
+        &format!("{ORANGE}/  {V}  \\{RESET}", ORANGE = ORANGE, V = V, RESET = RESET),
+        LEFT_INNER,
+    ));
+    rows.push(String::new());
+    rows.push(center(&format!("v{version} (Rust)"), LEFT_INNER));
+    rows.push(center("native binary on 5 platforms", LEFT_INNER));
+    rows.push(String::new());
+    let cwd_short = truncate_cwd(cwd, LEFT_INNER - 2);
+    rows.push(center(
+        &format!("{DIM}{cwd_short}{RESET}", DIM = DIM, RESET = RESET),
+        LEFT_INNER,
+    ));
+    rows.push(String::new());
+    rows
+}
+
+fn build_right() -> Vec<String> {
+    let mut rows = Vec::new();
+    rows.push(String::new());
+    rows.push(format!("{ORANGE}Tips for getting started{RESET}"));
+    rows.push("Run 'arcis audit .' to scan your code for unsafe patterns".to_string());
+    rows.push("Run 'arcis sca .' to match deps against the threat database".to_string());
+    rows.push("Run 'arcis scan <url>' to probe a live endpoint".to_string());
+    rows.push(String::new());
+    rows.push(format!("{ORANGE}What's new{RESET}"));
+    rows.push("Two-panel welcome screen on 'arcis' with no arguments".to_string());
+    rows.push("Python SDK shim restored: 'pip install arcis' exposes 'arcis' again".to_string());
+    rows.push("Daily cli-install-smoke workflow catches publish-channel breakage".to_string());
+    rows.push("Auto-published on every nwl to main release via publish.yml".to_string());
+    rows.push(format!("{DIM}arcis --help for the full command reference{RESET}"));
+    rows.push(String::new());
     rows
 }
 
 fn truncate_cwd(cwd: &str, width: usize) -> String {
-    if cwd.len() <= width {
+    if cwd.chars().count() <= width {
         return cwd.to_string();
     }
-    // Show the tail of the path with ellipsis. More useful than the head
-    // because the relevant info (project name) is usually at the end.
+    // Show the tail of the path with leading ellipsis. The tail
+    // (project name) is what's relevant for a developer reading the
+    // banner; the head is just home directory + a long parent chain.
+    let chars: Vec<char> = cwd.chars().collect();
     let keep = width.saturating_sub(3);
-    let start = cwd.len().saturating_sub(keep);
-    format!("...{}", &cwd[start..])
+    let start = chars.len().saturating_sub(keep);
+    let tail: String = chars[start..].iter().collect();
+    format!("...{tail}")
 }
 
-fn push_blank(rows: &mut Vec<String>) {
-    rows.push(String::new());
-}
-
-fn push_tip(rows: &mut Vec<String>, cmd: &str, note: &str) {
-    // Two-line tip: command (highlighted) then dim explanation.
-    rows.push(format!("  {cmd}"));
-    rows.push(format!("    {note}"));
-    push_blank(rows);
-}
-
-fn push_news(rows: &mut Vec<String>, note: &str) {
-    rows.push(format!("  - {note}"));
-}
-
-fn section_title(title: &str) -> String {
-    // A subtle inline divider so the right panel reads as two stacked
-    // sections (Tips then What's new) without needing a second box.
-    format!("  {title}")
-}
-
-/// Left-pad and right-pad a row to exactly `width` inner columns. Used
-/// for the contents between the panel's left/right border characters.
-fn pad_inside(s: &str, width: usize) -> String {
-    if s.len() >= width {
-        // Truncate at character boundary; we control the inputs above
-        // so this should never fire in practice.
-        return s[..width.min(s.len())].to_string();
-    }
-    let pad = " ".repeat(width - s.len());
-    format!("{s}{pad}")
-}
-
-fn center(s: &str, width: usize) -> String {
-    if s.len() >= width {
+/// Pad `s` so its visible column count equals `width`. Counts visible
+/// columns (ignoring ANSI escape sequences) so colored content lines
+/// up with uncolored ones.
+fn pad(s: &str, width: usize) -> String {
+    let vis = visible_cols(s);
+    if vis >= width {
         return s.to_string();
     }
-    let total = width - s.len();
-    let left = total / 2;
-    let right = total - left;
-    format!("{}{}{}", " ".repeat(left), s, " ".repeat(right))
+    format!("{s}{}", " ".repeat(width - vis))
 }
 
-fn top_border(width: usize, title: &str) -> String {
-    // Plain ASCII border so it renders on every terminal/font combination.
-    // `+- title --------+` style; mimics the rounded look without using
-    // Unicode box-drawing chars (which fail on default Windows cmd.exe
-    // when chcp != 65001).
-    let mut bar = String::from(",");
-    bar.push('-');
-    bar.push_str(title);
-    let used = bar.len();
-    let pad = width.saturating_sub(used).saturating_sub(1);
-    for _ in 0..pad {
-        bar.push('-');
+/// Center `s` within `width` display columns. Ignores ANSI sequences
+/// when counting.
+fn center(s: &str, width: usize) -> String {
+    let vis = visible_cols(s);
+    if vis >= width {
+        return s.to_string();
     }
-    bar.push('.');
-    bar
+    let total = width - vis;
+    let left_pad = total / 2;
+    let right_pad = total - left_pad;
+    format!("{}{}{}", " ".repeat(left_pad), s, " ".repeat(right_pad))
 }
 
-fn bottom_border(width: usize) -> String {
-    let mut bar = String::from("'");
-    for _ in 1..(width - 1) {
-        bar.push('-');
+/// Count display columns in a string, stripping ANSI escape sequences.
+/// Approximate for non-ASCII: counts each `char` as one column. For the
+/// glyphs we use (box-drawing, star, ASCII), each is one column.
+fn visible_cols(s: &str) -> usize {
+    let mut n = 0;
+    let mut in_escape = false;
+    for c in s.chars() {
+        if c == '\x1b' {
+            in_escape = true;
+            continue;
+        }
+        if in_escape {
+            // ANSI sequences end on a letter. Be loose: stop on any
+            // ASCII letter, which covers SGR ('m'), cursor codes, etc.
+            if c.is_ascii_alphabetic() {
+                in_escape = false;
+            }
+            continue;
+        }
+        n += 1;
     }
-    bar.push('\'');
-    bar
+    n
 }
 
 #[cfg(test)]
@@ -233,14 +244,26 @@ mod tests {
     }
 
     #[test]
-    fn shows_version_and_label() {
+    fn includes_version_in_title() {
         let out = render("1.0.1", "/tmp/proj");
         assert!(out.contains("Arcis CLI v1.0.1"));
-        assert!(out.contains("v1.0.1 (Rust)"));
     }
 
     #[test]
-    fn shows_three_main_commands() {
+    fn left_panel_carries_welcome() {
+        let out = render("1.0.1", "/tmp/proj");
+        assert!(out.contains("Welcome to Arcis"));
+    }
+
+    #[test]
+    fn right_panel_carries_section_titles() {
+        let out = render("1.0.1", "/tmp/proj");
+        assert!(out.contains("Tips for getting started"));
+        assert!(out.contains("What's new"));
+    }
+
+    #[test]
+    fn right_panel_lists_three_main_commands() {
         let out = render("1.0.1", "/tmp/proj");
         assert!(out.contains("arcis audit ."));
         assert!(out.contains("arcis sca ."));
@@ -248,38 +271,40 @@ mod tests {
     }
 
     #[test]
-    fn shows_tips_panel_title() {
-        let out = render("1.0.1", "/tmp/proj");
-        assert!(out.contains("Tips for getting started"));
-    }
-
-    #[test]
-    fn shows_whats_new_section() {
-        let out = render("1.0.1", "/tmp/proj");
-        assert!(out.contains("What's new"));
-    }
-
-    #[test]
-    fn shows_short_cwd_unchanged() {
+    fn renders_short_cwd_unchanged() {
         let out = render("1.0.1", "/tmp/proj");
         assert!(out.contains("/tmp/proj"));
     }
 
     #[test]
-    fn truncates_long_cwd_to_tail() {
+    fn long_cwd_truncated_to_tail_with_ellipsis() {
         let long = "/a/very/long/path/that/way/exceeds/the/left/panel/width/projectname";
         let out = render("1.0.1", long);
-        // Tail (project name) preserved
         assert!(out.contains("projectname"));
-        // Ellipsis present
         assert!(out.contains("..."));
     }
 
     #[test]
-    fn too_narrow_threshold() {
+    fn too_narrow_triggers_at_correct_threshold() {
         assert!(too_narrow(80));
-        assert!(!too_narrow(120));
+        assert!(too_narrow(MIN_COLS - 1));
+        assert!(!too_narrow(MIN_COLS));
         assert!(!too_narrow(160));
+    }
+
+    #[test]
+    fn visible_cols_ignores_ansi_sequences() {
+        assert_eq!(visible_cols("hello"), 5);
+        assert_eq!(visible_cols(&format!("{ORANGE}hello{RESET}")), 5);
+        assert_eq!(visible_cols("\x1b[38;2;255;0;0mred\x1b[0m"), 3);
+    }
+
+    #[test]
+    fn pad_uses_visible_width_not_byte_count() {
+        let colored = format!("{ORANGE}abc{RESET}");
+        let padded = pad(&colored, 10);
+        // 3 visible chars + 7 spaces of padding
+        assert_eq!(visible_cols(&padded), 10);
     }
 
     #[test]
@@ -288,9 +313,19 @@ mod tests {
     }
 
     #[test]
-    fn truncate_cwd_keeps_tail() {
-        let result = truncate_cwd("/a/very/long/path/projectname", 20);
-        assert!(result.ends_with("projectname"));
-        assert!(result.starts_with("..."));
+    fn truncate_cwd_handles_unicode() {
+        // Should not panic on multi-byte chars.
+        let unicode = "/тест/проект/файл";
+        let result = truncate_cwd(unicode, 10);
+        assert!(result.len() > 0);
+    }
+
+    #[test]
+    fn render_contains_box_drawing_corners() {
+        let out = render("1.0.1", "/p");
+        assert!(out.contains(TL));
+        assert!(out.contains(TR));
+        assert!(out.contains(BL));
+        assert!(out.contains(BR));
     }
 }


### PR DESCRIPTION
## Summary

Closes two UX gaps that surfaced right after the v1.5.1 / cli-v1.0.0 publish:

1. `pip install arcis` did not put any `arcis` command on PATH. Typing `arcis` gave the user a confusing 'command not found' even though the SDK installed cleanly.
2. The real Rust CLI from `@arcis/cli` printed a plain text catalog on `arcis` with no args. No identity, no quick-start hint, no version banner.

When this lands on main, publish.yml auto-publishes:

| Job | Action |
|---|---|
| publish-node | `@arcis/node@1.5.2` to npm (no functional change, version bump only to match the SDK family) |
| publish-python | `arcis@1.5.2` to PyPI (ships the new CLI shim, re-enabling `arcis` on PATH) |
| publish-cli | dispatches rust-release.yml to build `@arcis/cli@1.0.1` with the welcome screen |
| tag-go-sdk | `v1.5.2` git tag + GitHub Release |

## Patch 1: Python SDK shim (`arcis` 1.5.2)

`pyproject.toml` re-introduces `[project.scripts] arcis = \"arcis.cli_shim:main\"`. New `arcis/cli_shim.py` does the following:

- On any invocation, search for the real `@arcis/cli` binary on PATH (excluding self), in npm global prefix locations (`%APPDATA%\npm` on Windows, `/usr/local/bin` + `~/.npm-global/bin` + `npm config get prefix` on Mac/Linux).
- If the real CLI is found, `os.execv` passthrough so `arcis scan ...` works exactly like running the binary directly.
- If not found, print a friendly welcome with install instructions and SDK-only operations that work without the binary:
  - `arcis --version` reports the SDK version + whether the CLI is installed.
  - `arcis check '<payload>'` runs `scan_threats` from the Python SDK so users can verify detection works.

Self-recursion guard via `_is_python_entry_point()`. Windows pip installs the entry point as `Scripts\arcis.exe`; without the guard `shutil.which(\"arcis\")` would return that and the shim would infinitely recurse. Detection by:

- Path contains `/Scripts/` (Windows pip default).
- Path is under `sys.exec_prefix` (Python install root).
- Sibling `python.exe` / `python3` exists in the same directory.

## Patch 2: Rust CLI welcome screen (cli-v1.0.1)

New `crates/arcis-cli/src/welcome.rs`. On `arcis` (no args) when stdout is a TTY and the terminal is at least 118 columns, render a two-panel screen:

```
,- Arcis CLI v1.0.1 ---------------------.  ,- Tips for getting started -------------------------------------------.
|                                        |  |                                                                      |
|            Welcome to Arcis            |  |  arcis audit .                                                       |
|                                        |  |    Static-scan your code for unsafe patterns                         |
|                  ___                   |  |                                                                      |
|                 / A \                  |  |  arcis sca .                                                         |
|                 \___/                  |  |    Match deps against supply-chain threat DB                         |
|                                        |  |                                                                      |
|             v1.0.1 (Rust)              |  |  arcis scan http://localhost:3000                                    |
|                                        |  |    Probe a live endpoint for vulnerabilities                         |
|                /project                |  |                                                                      |
|                                        |  |  arcis --help                                                        |
|                                        |  |    Full command reference + flags                                    |
|                                        |  |                                                                      |
|                                        |  |   What's new                                                         |
|                                        |  |                                                                      |
|                                        |  |  - Two-panel welcome screen on arcis no-args (TTY only).             |
|                                        |  |  - Python SDK shim: pip install arcis exposes arcis again.           |
|                                        |  |  - Daily cli-install-smoke workflow catches publish-channel break.   |
|                                        |  |  - Auto-published from publish.yml on every nwl to main release.     |
|                                        |  |                                                                      |
'----------------------------------------'  '----------------------------------------------------------------------'
```

Non-TTY paths (pipes, CI, redirects, narrow terminals) keep the plain catalog so byte-equal parity tests in `tests/parity/` keep passing.

Implementation notes:
- Plain ASCII border chars (no Unicode box-drawing). Renders on Windows cmd.exe with default code page.
- `std::io::IsTerminal` from Rust 1.70+. workspace `rust-version` pin is 1.75.
- `$COLUMNS` env var detection with 120-col default. No new dep added.
- 9 new unit tests in `welcome.rs`.

## Patch 3: Node SDK postinstall hint

The postinstall message at `packages/arcis-node/scripts/postinstall.cjs` already exists (was added pre-v1.5.1). Skips CI, only fires on interactive installs. Tells users that `arcis` CLI is a separate `npm install -g @arcis/cli` package.

Bumping `@arcis/node` from 1.5.1 to 1.5.2 keeps the SDK family on the same version line as the Python SDK that ships the new shim.

## Test plan

- [x] Python full suite: 1420 passed, 1 skipped (no change, shim has no new functional surface to test)
- [x] Rust full suite: 494 passed (was 485, +9 from welcome.rs unit tests)
- [x] Local shim test on Windows: `pip install -e . && arcis` correctly prints welcome (detects itself as Python entry point, falls back gracefully)
- [x] Local welcome screen render via Docker TTY: panel renders correctly at 130 cols
- [x] Non-TTY rendering: catalog (legacy plain text) still emits for byte-equal parity
- [ ] Post-publish: `pip install arcis==1.5.2` on a fresh machine, run `arcis`, confirm welcome appears
- [ ] Post-publish: `npm install -g @arcis/cli@1.0.1`, run `arcis` in a wide terminal, confirm welcome panel renders
- [ ] Post-publish: `pip install arcis==1.5.2 && npm install -g @arcis/cli@1.0.1`, run `arcis scan --help`, confirm passthrough works

## Why this isn't v1.6.0

These are UX patches on the v1.5 line, not new vectors / middleware / SDK functionality. Patch release semver. Welcome screen on the CLI is also a patch (no new flags, no command behavior change, no breaking output for scripted callers since non-TTY still emits the legacy catalog).

The v1.6 plan in `documents/plans/improvements.md` is the next forward-looking release (new vectors, AST detection, ORM hooks, stateful correlation primitive). This PR is a polish round before that.