### PR TITLE
fix: 6 bugs blocking the v1.5.2 CLI welcome screen on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,15 @@ obj/
 *.nupkg
 **/packages/repositories.config
 
+# ─── @arcis/cli wrapper exception ──────────────────────────────────────────────
+# The generic `bin/` rule above (intended for C# build output) accidentally
+# hides the JS launcher shim that npm needs to ship at packages/arcis-cli-npm/
+# bin/arcis. Re-include just that one file. The native binary that postinstall
+# downloads (bin/arcis-bin or bin/arcis-bin.exe) stays ignored.
+!packages/arcis-cli-npm/bin/
+packages/arcis-cli-npm/bin/*
+!packages/arcis-cli-npm/bin/arcis
+
 # ─── Java / Maven / Gradle ─────────────────────────────────────────────────────
 target/
 .gradle/

--- a/packages/arcis-cli-npm/bin/arcis
+++ b/packages/arcis-cli-npm/bin/arcis
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Tiny shim: finds the native binary that the postinstall script wrote
+// next to this file, then exec's it with the same argv. Same pattern as
+// esbuild / swc / Claude Code. Done in JS instead of platform-specific
+// shell wrappers so npm's `bin` field works the same on Linux, macOS,
+// and Windows (npm cmd-shim wraps this for us on Windows).
+
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs");
+const { spawnSync } = require("node:child_process");
+
+const exeName = process.platform === "win32" ? "arcis-bin.exe" : "arcis-bin";
+const exePath = path.join(__dirname, exeName);
+
+if (!fs.existsSync(exePath)) {
+  process.stderr.write(
+    `arcis: native binary not found at ${exePath}.\n` +
+      "  This usually means npm postinstall did not run.\n" +
+      "  Reinstall with: npm install -g @arcis/cli\n" +
+      "  Or, if you used --ignore-scripts: run `node $(npm root -g)/@arcis/cli/install.js`\n",
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(exePath, process.argv.slice(2), {
+  stdio: "inherit",
+});
+
+if (result.error) {
+  process.stderr.write(`arcis: failed to spawn binary: ${result.error.message}\n`);
+  process.exit(1);
+}
+
+// Exit code propagation:
+//   * Normal exit:           result.status holds the child's exit code (use it).
+//   * Killed by signal:      result.status === null AND result.signal is set.
+//                            POSIX convention is 128+N; map the signal to its
+//                            numeric value so wrapper scripts can detect e.g.
+//                            SIGINT (130 = 128 + 2) vs SIGTERM (143).
+//   * Truly unexpected:      both null. Fall back to 1.
+if (result.status !== null) {
+  process.exit(result.status);
+}
+
+// Signal name -> number table for the signals callers are likely to see.
+// Node's `os.constants.signals` could give this dynamically, but the table
+// is short, stable, and saves a require() that would otherwise run on every
+// happy-path invocation.
+const SIGNUM = {
+  SIGHUP: 1,
+  SIGINT: 2,
+  SIGQUIT: 3,
+  SIGILL: 4,
+  SIGABRT: 6,
+  SIGFPE: 8,
+  SIGKILL: 9,
+  SIGSEGV: 11,
+  SIGPIPE: 13,
+  SIGTERM: 15,
+};
+if (result.signal && SIGNUM[result.signal] !== undefined) {
+  process.exit(128 + SIGNUM[result.signal]);
+}
+process.exit(1);

--- a/packages/arcis-cli-npm/install.js
+++ b/packages/arcis-cli-npm/install.js
@@ -53,43 +53,110 @@ function packageVersion() {
   return pkg.version;
 }
 
-/** Stream-download a URL with redirect-following + timeout. Returns a
- * Promise<Buffer>. Bails after MAX_REDIRECTS to avoid loops. */
+/** Pick a proxy URL from the standard environment variables.
+ * HTTPS_PROXY / https_proxy / HTTP_PROXY / http_proxy in that priority order
+ * (uppercase wins per RFC and curl convention; lowercase honored for
+ * compatibility with older shells). Honors NO_PROXY too: if the target host
+ * matches an entry in NO_PROXY, returns null so we go direct.
+ */
+function proxyForUrl(targetUrl) {
+  const proxy =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy ||
+    "";
+  if (!proxy) return null;
+
+  const noProxy = process.env.NO_PROXY || process.env.no_proxy || "";
+  if (noProxy) {
+    const host = new URL(targetUrl).hostname;
+    for (const entry of noProxy.split(",").map((s) => s.trim().toLowerCase())) {
+      if (!entry) continue;
+      if (entry === "*") return null;
+      // Match either exact hostname or suffix (".github.com" entry matches
+      // "api.github.com"). curl semantics.
+      const e = entry.startsWith(".") ? entry : "." + entry;
+      if (host.toLowerCase() === entry || host.toLowerCase().endsWith(e)) {
+        return null;
+      }
+    }
+  }
+  return proxy;
+}
+
+/** Stream-download a URL with redirect-following + timeout + proxy support.
+ * Returns a Promise<Buffer>. Bails after MAX_REDIRECTS to avoid loops. */
 function fetchToBuffer(url, redirects = 0) {
   if (redirects > MAX_REDIRECTS) {
     return Promise.reject(new Error(`too many redirects fetching ${url}`));
   }
   return new Promise((resolve, reject) => {
-    const req = https.get(
-      url,
-      { headers: { "User-Agent": "@arcis/cli installer" }, timeout: 60_000 },
-      (res) => {
-        // 3xx redirects: location header, recurse.
-        if (
-          res.statusCode &&
-          res.statusCode >= 300 &&
-          res.statusCode < 400 &&
-          res.headers.location
-        ) {
-          // Some redirect targets are relative — resolve via URL ctor.
-          const next = new URL(res.headers.location, url).toString();
-          res.resume();
-          fetchToBuffer(next, redirects + 1).then(resolve, reject);
-          return;
-        }
-        if (res.statusCode !== 200) {
-          res.resume();
-          reject(
-            new Error(`HTTP ${res.statusCode} fetching ${url}`),
-          );
-          return;
-        }
-        const chunks = [];
-        res.on("data", (c) => chunks.push(c));
-        res.on("end", () => resolve(Buffer.concat(chunks)));
-        res.on("error", reject);
-      },
-    );
+    const proxy = proxyForUrl(url);
+    const commonHeaders = { "User-Agent": "@arcis/cli installer" };
+    const timeout = 60_000;
+
+    // Shared response handler: 3xx -> recurse, 200 -> buffer, else reject.
+    const handleResponse = (res) => {
+      if (
+        res.statusCode &&
+        res.statusCode >= 300 &&
+        res.statusCode < 400 &&
+        res.headers.location
+      ) {
+        const next = new URL(res.headers.location, url).toString();
+        res.resume();
+        fetchToBuffer(next, redirects + 1).then(resolve, reject);
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error(`HTTP ${res.statusCode} fetching ${url}`));
+        return;
+      }
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => resolve(Buffer.concat(chunks)));
+      res.on("error", reject);
+    };
+
+    let req;
+    if (proxy) {
+      // Forward-proxy convention: send the absolute target URL as the
+      // request path. Works with corporate proxies that accept absolute-URI
+      // GET requests (Squid, most enterprise gateways). For HTTPS targets
+      // a CONNECT tunnel is more standard, but absolute-URI GET works for
+      // every proxy we've validated and avoids hand-rolling CONNECT logic
+      // for what is, by definition, a one-shot install step.
+      const proxyUrl = new URL(proxy);
+      const isProxyHttps = proxyUrl.protocol === "https:";
+      const proxyClient = isProxyHttps ? https : require("node:http");
+      const proxyOpts = {
+        host: proxyUrl.hostname,
+        port: proxyUrl.port || (isProxyHttps ? 443 : 80),
+        method: "GET",
+        path: url,
+        headers: {
+          ...commonHeaders,
+          Host: new URL(url).host,
+        },
+        timeout,
+      };
+      if (proxyUrl.username || proxyUrl.password) {
+        const creds = `${decodeURIComponent(proxyUrl.username)}:${decodeURIComponent(proxyUrl.password)}`;
+        proxyOpts.headers["Proxy-Authorization"] =
+          "Basic " + Buffer.from(creds).toString("base64");
+      }
+      req = proxyClient.request(proxyOpts, handleResponse);
+      req.on("timeout", () => {
+        req.destroy(new Error(`timeout fetching ${url} via proxy ${proxyUrl.host}`));
+      });
+      req.on("error", reject);
+      req.end();
+      return;
+    }
+
+    req = https.get(url, { headers: commonHeaders, timeout }, handleResponse);
     req.on("timeout", () => {
       req.destroy(new Error(`timeout fetching ${url}`));
     });
@@ -291,14 +358,28 @@ async function main() {
   // Place the binary alongside the Node shim. `bin/arcis` is the shim
   // npm puts on PATH; it `spawnSync`s the native binary saved here as
   // `bin/arcis-bin` (or `arcis-bin.exe` on Windows).
+  //
+  // Atomic-write pattern: write to a temp filename in the same directory,
+  // chmod it (Unix), then rename. fs.rename is atomic on a single
+  // filesystem, so if postinstall is interrupted (Ctrl+C, OOM, npm killed)
+  // the user is left with EITHER the previous binary OR no binary at all,
+  // never a half-written one that bin/arcis would happily try to execute.
   const binDir = path.join(__dirname, "bin");
   await fsp.mkdir(binDir, { recursive: true });
   const binaryName =
     process.platform === "win32" ? "arcis-bin.exe" : "arcis-bin";
   const binaryPath = path.join(binDir, binaryName);
-  await fsp.writeFile(binaryPath, binaryBuf);
-  if (process.platform !== "win32") {
-    await fsp.chmod(binaryPath, 0o755);
+  const tmpPath = `${binaryPath}.${process.pid}.tmp`;
+  try {
+    await fsp.writeFile(tmpPath, binaryBuf);
+    if (process.platform !== "win32") {
+      await fsp.chmod(tmpPath, 0o755);
+    }
+    await fsp.rename(tmpPath, binaryPath);
+  } catch (err) {
+    // Best-effort cleanup of the temp file if rename failed.
+    await fsp.rm(tmpPath, { force: true }).catch(() => {});
+    throw err;
   }
   log(`installed binary -> ${binaryPath}`);
 }

--- a/packages/arcis-cli-npm/package.json
+++ b/packages/arcis-cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Arcis security CLI — scan running apps, audit source, and check dependencies. Native Rust binary distributed via npm.",
   "keywords": [
     "security",

--- a/packages/arcis-python/arcis/__init__.py
+++ b/packages/arcis-python/arcis/__init__.py
@@ -183,7 +183,7 @@ try:
 except ImportError:
     _HAS_ASYNC = False
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"
 __all__ = [
     # Main class
     "Arcis",

--- a/packages/arcis-python/arcis/cli_shim.py
+++ b/packages/arcis-python/arcis/cli_shim.py
@@ -74,24 +74,32 @@ def _candidate_paths() -> List[str]:
             candidates.append(os.path.join(prefix, "arcis"))
 
     # As a last attempt, ask npm itself where its global prefix is.
-    try:
-        result = subprocess.run(
-            ["npm", "config", "get", "prefix"],
-            capture_output=True,
-            text=True,
-            timeout=2,
-        )
-        if result.returncode == 0:
-            prefix = result.stdout.strip()
-            if prefix:
-                if sys.platform == "win32":
-                    candidates.append(os.path.join(prefix, "arcis.cmd"))
-                    candidates.append(os.path.join(prefix, "arcis.exe"))
-                else:
-                    candidates.append(os.path.join(prefix, "bin", "arcis"))
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        # npm not installed, or hung. Don't block on it.
-        pass
+    # On Windows we must resolve `npm` to its full `.cmd` path because
+    # subprocess.run with shell=False does NOT honor PATHEXT; calling
+    # "npm" directly would CreateProcess("npm.exe") and fail since npm
+    # ships as npm.cmd on Windows.
+    npm_exe = shutil.which("npm")
+    if npm_exe:
+        try:
+            result = subprocess.run(
+                [npm_exe, "config", "get", "prefix"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            if result.returncode == 0:
+                prefix = result.stdout.strip()
+                if prefix:
+                    if sys.platform == "win32":
+                        # npm on Windows places the shim directly in
+                        # the prefix root: <prefix>\arcis.cmd|exe|ps1
+                        for name in ("arcis.cmd", "arcis.exe", "arcis.ps1", "arcis"):
+                            candidates.append(os.path.join(prefix, name))
+                    else:
+                        candidates.append(os.path.join(prefix, "bin", "arcis"))
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            # npm hung or returned garbage. Don't block on it.
+            pass
 
     return candidates
 
@@ -261,19 +269,107 @@ def _sdk_self_test(payload: str) -> int:
     return 1
 
 
+def _exec_real(real_cli: str, args: List[str]) -> int:
+    """Hand off to the real CLI with the given args.
+
+    Unix: `os.execv` replaces this process, so signals (Ctrl+C, SIGTERM)
+    propagate naturally to the binary and we never return.
+
+    Windows: `os.execv` can ONLY launch a Windows executable. npm-global
+    binaries on Windows are `.cmd` files (the JS shim that spawns the
+    real binary), and `execv` on a `.cmd` raises OSError. We fall back
+    to `subprocess.run`, which routes through CreateProcess properly
+    for `.cmd` / `.bat` / `.ps1` shims. We return its exit code so the
+    caller can `sys.exit(...)` with it.
+    """
+    if sys.platform == "win32":
+        try:
+            result = subprocess.run([real_cli, *args])
+            return result.returncode if result.returncode is not None else 1
+        except OSError as exc:
+            print(
+                f"arcis: failed to launch CLI ({real_cli}): {exc}",
+                file=sys.stderr,
+            )
+            return 2
+    else:
+        try:
+            os.execv(real_cli, [real_cli, *args])
+        except OSError as exc:
+            print(
+                f"arcis: failed to launch CLI ({real_cli}): {exc}",
+                file=sys.stderr,
+            )
+            return 2
+        return 0  # unreachable; execv replaces the process on success
+
+
+def _print_diag() -> int:
+    """Diagnostic dump. Shows what the shim sees when looking for the
+    real CLI: PATH matches, _is_python_entry_point verdict per match,
+    candidate paths from `_candidate_paths`, npm's reported prefix, and
+    the platform pair Python detected. Helps debug "shim won't pass
+    through" reports without having to remote into the user's box.
+    """
+    print(f"arcis-shim diag (SDK {SDK_VERSION} on {sys.platform})")
+    print(f"  sys.argv[0]:     {os.path.realpath(sys.argv[0])}")
+    print(f"  sys.exec_prefix: {sys.exec_prefix}")
+    print()
+    print("PATH walk for 'arcis':")
+    matches = _path_matches("arcis")
+    if not matches:
+        print("  (no PATH hits)")
+    for m in matches:
+        flag = "shim" if _is_python_entry_point(m) else "real"
+        print(f"  [{flag}] {m}")
+    print()
+    print("Candidate paths from _candidate_paths():")
+    candidates = _candidate_paths()
+    if not candidates:
+        print("  (none)")
+    for c in candidates:
+        exists = "exists" if os.path.isfile(c) else "missing"
+        print(f"  [{exists}] {c}")
+    print()
+    npm_exe = shutil.which("npm")
+    print(f"npm on PATH:       {npm_exe or '(not found)'}")
+    if npm_exe:
+        try:
+            result = subprocess.run(
+                [npm_exe, "config", "get", "prefix"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            print(f"npm config prefix: {(result.stdout or '').strip() or '(empty)'}")
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            print(f"npm config prefix: (failed: {exc})")
+    print()
+    resolved = _find_real_cli()
+    print(f"_find_real_cli():  {resolved or '(None)'}")
+    return 0
+
+
 def main() -> int:
     """Entry point registered as `arcis` in pyproject.toml.
 
     Behavior:
-      - With no args or `--help` or `-h`: print welcome screen.
+      - With no args or `--help` or `-h`: pass through to the real CLI
+        when installed, else print the shim's welcome screen.
       - With `--version` or `-V`: print SDK version + tell user about
         the separate CLI binary.
+      - With `--diag`: print a diagnostic dump (PATH matches, candidate
+        paths, npm prefix, what _find_real_cli resolved to). Always
+        runs locally so users with a broken setup can still get answers.
       - With `check <payload>`: run scan_threats on the payload (SDK
         self-test).
       - With any other args: try to passthrough to the real CLI; if
-        not installed, print welcome screen.
+        not installed, print install hint.
     """
     args = sys.argv[1:]
+
+    if args and args[0] == "--diag":
+        return _print_diag()
 
     # No-args and `--help` / `-h`: prefer the real CLI's own surface
     # whenever it's installed. The Rust binary prints a richer welcome
@@ -283,10 +379,7 @@ def main() -> int:
     if not args or args[0] in ("-h", "--help"):
         real_cli = _find_real_cli()
         if real_cli:
-            try:
-                os.execv(real_cli, [real_cli] + args)
-            except OSError:
-                pass
+            return _exec_real(real_cli, args)
         _print_welcome()
         return 0
 
@@ -321,11 +414,7 @@ def main() -> int:
     # Any other subcommand: passthrough to the real CLI if installed.
     real_cli = _find_real_cli()
     if real_cli:
-        try:
-            os.execv(real_cli, [real_cli] + args)
-        except OSError as exc:
-            print(f"arcis: failed to launch real CLI ({real_cli}): {exc}", file=sys.stderr)
-            return 2
+        return _exec_real(real_cli, args)
 
     # Real CLI not installed. Be helpful instead of cryptic.
     print(

--- a/packages/arcis-python/arcis/cli_shim.py
+++ b/packages/arcis-python/arcis/cli_shim.py
@@ -41,7 +41,7 @@ from typing import List, Optional
 
 # Version of the SDK shipping this shim. Kept in sync with
 # arcis/__init__.py:__version__ — both should bump together.
-SDK_VERSION = "1.5.2"
+SDK_VERSION = "1.5.3"
 
 
 # Locations where npm install -g writes binaries. We check these in
@@ -235,13 +235,14 @@ def main() -> int:
     """
     args = sys.argv[1:]
 
-    # Fast path for self-help / version. Don't probe for the CLI
-    # binary on these because the Python SDK can answer them honestly.
+    # No-args and `--help` / `-h`: prefer the real CLI's own surface
+    # whenever it's installed. The Rust binary prints a richer welcome
+    # screen (with the burst mascot + commands list) on no-args, and a
+    # full per-command flag reference on --help. The shim's plain-text
+    # welcome is only a fallback for when the binary isn't installed.
     if not args or args[0] in ("-h", "--help"):
-        # If the real CLI is on the system, defer to its help rather
-        # than printing the shim's welcome.
         real_cli = _find_real_cli()
-        if real_cli and args:
+        if real_cli:
             try:
                 os.execv(real_cli, [real_cli] + args)
             except OSError:

--- a/packages/arcis-python/arcis/cli_shim.py
+++ b/packages/arcis-python/arcis/cli_shim.py
@@ -138,6 +138,43 @@ def _is_python_entry_point(path: str) -> bool:
     return False
 
 
+def _path_matches(name: str) -> List[str]:
+    """Return every `name` hit on PATH, in PATH order.
+
+    `shutil.which` stops at the first match. On Windows when Python's
+    `Scripts/` sits ahead of npm's prefix on PATH, that first match is
+    our own shim and we'd never get to consider the npm binary further
+    down. Walking the full PATH and returning all matches lets the
+    caller skip past the shim. PATHEXT (the Windows list of executable
+    extensions) is honored so `arcis.cmd`, `arcis.exe`, etc. all count.
+    """
+    matches: List[str] = []
+    seen: set = set()
+
+    if sys.platform == "win32":
+        pathext = os.environ.get("PATHEXT", ".EXE;.CMD;.BAT;.COM").split(";")
+        extensions = [""] + [e for e in pathext if e]
+    else:
+        extensions = [""]
+
+    for d in os.environ.get("PATH", "").split(os.pathsep):
+        d = d.strip().strip('"')
+        if not d:
+            continue
+        for ext in extensions:
+            candidate = os.path.join(d, name + ext)
+            if not os.path.isfile(candidate):
+                continue
+            key = os.path.normcase(os.path.abspath(candidate))
+            if key in seen:
+                continue
+            seen.add(key)
+            matches.append(candidate)
+            break  # only the first valid extension per directory
+
+    return matches
+
+
 def _find_real_cli() -> Optional[str]:
     """Return the path to the real @arcis/cli binary, or None.
 
@@ -146,13 +183,16 @@ def _find_real_cli() -> Optional[str]:
     loop on systems where Python's Scripts/ dir comes before npm's
     global bin on PATH (common on Windows).
     """
-    # Check PATH first; fast path when the npm bin is ahead of Python's
-    # Scripts/.
-    found = shutil.which("arcis")
-    if found and not _is_python_entry_point(found):
-        return found
+    # Walk PATH for ALL `arcis` matches and pick the first that isn't
+    # this shim. shutil.which would stop at the first match (our own
+    # shim) and we'd never see the npm binary one directory later.
+    for found in _path_matches("arcis"):
+        if not _is_python_entry_point(found):
+            return found
 
-    # Probe well-known npm install locations.
+    # Belt-and-suspenders: probe well-known npm install locations in
+    # case the binary lives somewhere not on PATH (broken setups,
+    # custom prefixes, etc.).
     for candidate in _candidate_paths():
         if not os.path.isfile(candidate):
             continue

--- a/packages/arcis-python/arcis/cli_shim.py
+++ b/packages/arcis-python/arcis/cli_shim.py
@@ -143,6 +143,23 @@ def _is_python_entry_point(path: str) -> bool:
             if os.path.isfile(os.path.join(parent, python_name)):
                 return True
 
+    # Shebang probe (Unix): `pip install --user arcis` drops a Python
+    # script at ~/.local/bin/arcis with no sibling python interpreter,
+    # and that location is never under sys.exec_prefix or /Scripts/.
+    # The script itself starts with `#!/.../python...`, which is the
+    # cleanest signal we have for that layout. We only read the first
+    # 256 bytes (enough for any reasonable shebang) and fail open so a
+    # binary or unreadable file falls through to the non-shim branch.
+    try:
+        with open(path, "rb") as f:
+            head = f.read(256)
+        if head.startswith(b"#!"):
+            first_line = head.split(b"\n", 1)[0].lower()
+            if b"python" in first_line:
+                return True
+    except (OSError, ValueError):
+        pass
+
     return False
 
 

--- a/packages/arcis-python/arcis/cli_shim.py
+++ b/packages/arcis-python/arcis/cli_shim.py
@@ -147,10 +147,17 @@ def _is_python_entry_point(path: str) -> bool:
     # script at ~/.local/bin/arcis with no sibling python interpreter,
     # and that location is never under sys.exec_prefix or /Scripts/.
     # The script itself starts with `#!/.../python...`, which is the
-    # cleanest signal we have for that layout. We only read the first
-    # 256 bytes (enough for any reasonable shebang) and fail open so a
-    # binary or unreadable file falls through to the non-shim branch.
+    # cleanest signal we have for that layout.
+    #
+    # We skip the probe when the file is larger than 64 KiB: pip-generated
+    # entry-point scripts are well under 4 KiB, while native Arcis binaries
+    # are several MB. The size gate caps disk I/O so that PATH dirs on slow
+    # filesystems (network drives, fuse mounts) don't make every `arcis`
+    # invocation block on a multi-MB read. Fail open on any OSError so
+    # unreadable files still fall through to the non-shim branch.
     try:
+        if os.path.getsize(path) > 64 * 1024:
+            return False
         with open(path, "rb") as f:
             head = f.read(256)
         if head.startswith(b"#!"):

--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arcis"
-version = "1.5.2"
+version = "1.5.3"
 description = "Inside-the-app security middleware for Python. One install protects FastAPI, Flask, and Django against XSS, SQL injection, CSRF, SSRF, HPP, prompt injection, bot traffic, rate limiting, and 20+ more attack types. Includes prompt-injection signature library, LLM token-budget middleware, and a 646-pattern bot corpus with consistent API across the Node and Go SDKs. The CLI ships separately at npm install -g @arcis/cli."
 readme = "README.md"
 license = "MIT"

--- a/packages/arcis-python/tests/test_cli_shim.py
+++ b/packages/arcis-python/tests/test_cli_shim.py
@@ -327,6 +327,21 @@ def test_is_python_entry_point_does_not_flag_node_shim(tmp_path):
     assert cli_shim._is_python_entry_point(str(node_shim)) is False
 
 
+def test_is_python_entry_point_size_gate_skips_large_files(tmp_path):
+    """A multi-MB file should never trigger a full read. The size gate
+    bails before opening so PATH walks on slow filesystems (network
+    drives, fuse mounts) don't add latency to every `arcis` invocation."""
+    big = tmp_path / "arcis-bin"
+    # Write a 128 KiB file that starts with a python shebang. Without
+    # the size gate the probe would match and incorrectly flag it as
+    # a shim. With the gate, the function returns False before reading.
+    payload = b"#!/usr/bin/python3\n" + b"\x00" * (128 * 1024)
+    big.write_bytes(payload)
+    if sys.platform != "win32":
+        big.chmod(0o755)
+    assert cli_shim._is_python_entry_point(str(big)) is False
+
+
 def test_find_real_cli_returns_none_when_only_shim_exists(tmp_path, monkeypatch):
     """No npm binary anywhere on PATH => `_find_real_cli` returns None."""
     python_scripts = tmp_path / "Scripts"

--- a/packages/arcis-python/tests/test_cli_shim.py
+++ b/packages/arcis-python/tests/test_cli_shim.py
@@ -5,12 +5,17 @@ defer to the real `@arcis/cli` binary whenever that binary is on the
 system, so users see the Rust CLI's rich welcome screen rather than the
 shim's plain-text install hint.
 
-The bug this guards: before v1.5.3 the no-args branch incorrectly
-required `args` to be non-empty before calling `os.execv`, which meant
-typing bare `arcis` always rendered the shim welcome even after
-`npm install -g @arcis/cli`.
+Bugs these guard (both shipped in v1.5.3):
+1. The no-args branch incorrectly required `args` to be non-empty
+   before calling `os.execv`, which meant typing bare `arcis` always
+   rendered the shim welcome even after `npm install -g @arcis/cli`.
+2. `_find_real_cli` relied on `shutil.which`, which returns only the
+   first PATH hit. On Windows where Python's `Scripts/` sits ahead of
+   npm's prefix, that first hit is the shim itself, and the npm
+   binary further down PATH was never considered.
 """
 
+import os
 import sys
 from unittest.mock import patch
 
@@ -102,3 +107,93 @@ def test_unknown_subcommand_without_real_cli_prints_install_hint(no_real_cli, mo
     err = capsys.readouterr().err
     assert rc == 127
     assert "npm install -g @arcis/cli" in err
+
+
+# ---------------------------------------------------------------------------
+# _path_matches + _find_real_cli PATH-walk regression coverage.
+# Guards bug #2 from v1.5.3: on Windows shutil.which("arcis") returns the
+# Python shim first, and we need to keep walking PATH to find the npm
+# binary one directory later.
+# ---------------------------------------------------------------------------
+
+
+def test_path_matches_returns_all_hits_in_path_order(tmp_path, monkeypatch):
+    """Two PATH entries both holding `arcis` should both appear in result."""
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    (dir_a / "arcis").write_text("#!/bin/sh\necho a\n")
+    (dir_b / "arcis").write_text("#!/bin/sh\necho b\n")
+    if sys.platform != "win32":
+        (dir_a / "arcis").chmod(0o755)
+        (dir_b / "arcis").chmod(0o755)
+
+    monkeypatch.setenv("PATH", os.pathsep.join([str(dir_a), str(dir_b)]))
+    results = cli_shim._path_matches("arcis")
+    assert len(results) == 2
+    assert results[0].endswith(os.path.join("a", "arcis")) or results[0].endswith(
+        os.path.join("a", "arcis.exe")
+    )
+    assert results[1].endswith(os.path.join("b", "arcis")) or results[1].endswith(
+        os.path.join("b", "arcis.exe")
+    )
+
+
+def test_path_matches_dedupes_repeated_directories(tmp_path, monkeypatch):
+    """A PATH with the same directory listed twice still returns one match."""
+    d = tmp_path / "only"
+    d.mkdir()
+    (d / "arcis").write_text("#!/bin/sh\n")
+    if sys.platform != "win32":
+        (d / "arcis").chmod(0o755)
+
+    monkeypatch.setenv("PATH", os.pathsep.join([str(d), str(d)]))
+    results = cli_shim._path_matches("arcis")
+    assert len(results) == 1
+
+
+def test_find_real_cli_skips_python_shim_and_returns_npm_binary(tmp_path, monkeypatch):
+    """The fix: when Python's Scripts/ comes first, the npm prefix wins."""
+    python_scripts = tmp_path / "Scripts"
+    npm_prefix = tmp_path / "npm"
+    python_scripts.mkdir()
+    npm_prefix.mkdir()
+    (python_scripts / "arcis").write_text("#!/bin/sh\n# pip shim\n")
+    (npm_prefix / "arcis").write_text("#!/bin/sh\n# real cli\n")
+    if sys.platform != "win32":
+        (python_scripts / "arcis").chmod(0o755)
+        (npm_prefix / "arcis").chmod(0o755)
+
+    monkeypatch.setenv(
+        "PATH", os.pathsep.join([str(python_scripts), str(npm_prefix)])
+    )
+    # Force _is_python_entry_point to match ONLY the Scripts/ path.
+    real_python_shim = str(python_scripts / "arcis")
+    monkeypatch.setattr(
+        cli_shim,
+        "_is_python_entry_point",
+        lambda p: os.path.normcase(p) == os.path.normcase(real_python_shim),
+    )
+
+    result = cli_shim._find_real_cli()
+    assert result is not None
+    assert os.path.normcase(result).endswith(
+        os.path.normcase(os.path.join("npm", "arcis"))
+    )
+
+
+def test_find_real_cli_returns_none_when_only_shim_exists(tmp_path, monkeypatch):
+    """No npm binary anywhere on PATH => `_find_real_cli` returns None."""
+    python_scripts = tmp_path / "Scripts"
+    python_scripts.mkdir()
+    (python_scripts / "arcis").write_text("#!/bin/sh\n")
+    if sys.platform != "win32":
+        (python_scripts / "arcis").chmod(0o755)
+
+    monkeypatch.setenv("PATH", str(python_scripts))
+    monkeypatch.setattr(cli_shim, "_is_python_entry_point", lambda p: True)
+    # Disable _candidate_paths fallback so the test is hermetic.
+    monkeypatch.setattr(cli_shim, "_candidate_paths", lambda: [])
+
+    assert cli_shim._find_real_cli() is None

--- a/packages/arcis-python/tests/test_cli_shim.py
+++ b/packages/arcis-python/tests/test_cli_shim.py
@@ -1,0 +1,104 @@
+"""Regression tests for `arcis.cli_shim`.
+
+The shim is the entry point registered by `pip install arcis`. It must
+defer to the real `@arcis/cli` binary whenever that binary is on the
+system, so users see the Rust CLI's rich welcome screen rather than the
+shim's plain-text install hint.
+
+The bug this guards: before v1.5.3 the no-args branch incorrectly
+required `args` to be non-empty before calling `os.execv`, which meant
+typing bare `arcis` always rendered the shim welcome even after
+`npm install -g @arcis/cli`.
+"""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from arcis import cli_shim
+
+
+@pytest.fixture
+def no_real_cli(monkeypatch):
+    """Force `_find_real_cli` to report the binary is not installed."""
+    monkeypatch.setattr(cli_shim, "_find_real_cli", lambda: None)
+
+
+@pytest.fixture
+def real_cli_at(monkeypatch):
+    """Inject a fake `@arcis/cli` path that `_find_real_cli` will return."""
+    fake_path = "/usr/local/bin/arcis-real"
+    monkeypatch.setattr(cli_shim, "_find_real_cli", lambda: fake_path)
+    return fake_path
+
+
+def test_no_args_with_real_cli_execs_passthrough(real_cli_at, monkeypatch):
+    """Bare `arcis` defers to the real CLI when installed (regression: v1.5.2)."""
+    monkeypatch.setattr(sys, "argv", ["arcis"])
+    with patch.object(cli_shim.os, "execv") as mock_execv:
+        cli_shim.main()
+    mock_execv.assert_called_once_with(real_cli_at, [real_cli_at])
+
+
+def test_no_args_without_real_cli_prints_welcome(no_real_cli, monkeypatch, capsys):
+    """Bare `arcis` falls back to shim welcome when the real CLI is missing."""
+    monkeypatch.setattr(sys, "argv", ["arcis"])
+    with patch.object(cli_shim.os, "execv") as mock_execv:
+        rc = cli_shim.main()
+    mock_execv.assert_not_called()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Arcis Python SDK" in out
+    assert "npm install -g @arcis/cli" in out
+
+
+def test_help_with_real_cli_execs_passthrough(real_cli_at, monkeypatch):
+    """`arcis --help` defers to the real CLI when installed."""
+    monkeypatch.setattr(sys, "argv", ["arcis", "--help"])
+    with patch.object(cli_shim.os, "execv") as mock_execv:
+        cli_shim.main()
+    mock_execv.assert_called_once_with(real_cli_at, [real_cli_at, "--help"])
+
+
+def test_subcommand_with_real_cli_execs_passthrough(real_cli_at, monkeypatch):
+    """`arcis scan ...` defers to the real CLI when installed."""
+    monkeypatch.setattr(sys, "argv", ["arcis", "scan", "http://localhost"])
+    with patch.object(cli_shim.os, "execv") as mock_execv:
+        cli_shim.main()
+    mock_execv.assert_called_once_with(
+        real_cli_at, [real_cli_at, "scan", "http://localhost"]
+    )
+
+
+def test_check_command_runs_locally_even_with_real_cli(real_cli_at, monkeypatch, capsys):
+    """`arcis check '<payload>'` is SDK-local; never delegates to the binary."""
+    monkeypatch.setattr(sys, "argv", ["arcis", "check", "hello world"])
+    with patch.object(cli_shim.os, "execv") as mock_execv:
+        rc = cli_shim.main()
+    mock_execv.assert_not_called()
+    # rc 0 if clean, 1 if threat detected. Either is fine; we only care
+    # that the shim didn't execv.
+    assert rc in (0, 1)
+
+
+def test_version_flag_prints_sdk_version_without_execv(real_cli_at, monkeypatch, capsys):
+    """`arcis --version` prints the Python SDK version locally."""
+    monkeypatch.setattr(sys, "argv", ["arcis", "--version"])
+    # subprocess.run on the fake path will fail; we accept either exit
+    # path so long as the shim doesn't execv away from us.
+    with patch.object(cli_shim.os, "execv") as mock_execv:
+        rc = cli_shim.main()
+    mock_execv.assert_not_called()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert cli_shim.SDK_VERSION in out
+
+
+def test_unknown_subcommand_without_real_cli_prints_install_hint(no_real_cli, monkeypatch, capsys):
+    """Unknown subcommand + no binary prints an install hint, exits 127."""
+    monkeypatch.setattr(sys, "argv", ["arcis", "audit", "."])
+    rc = cli_shim.main()
+    err = capsys.readouterr().err
+    assert rc == 127
+    assert "npm install -g @arcis/cli" in err

--- a/packages/arcis-python/tests/test_cli_shim.py
+++ b/packages/arcis-python/tests/test_cli_shim.py
@@ -168,9 +168,11 @@ def test_candidate_paths_resolves_npm_via_shutil_which_on_windows(monkeypatch):
     # Must have invoked the .cmd-resolved path, not bare "npm".
     invoked = mock_run.call_args[0][0]
     assert invoked[0] == r"C:\nodejs\npm.cmd"
-    # Must have added the npm-prefix-based candidate variants.
-    joined = " ".join(candidates).lower()
-    assert r"c:\nodejs\npm-prefix\arcis.cmd".lower() in joined
+    # Must have added the npm-prefix-based candidate variants. Normalize
+    # separators because os.path.join uses the HOST's separator (Linux's
+    # forward slash on CI) even when sys.platform is mocked to win32.
+    norm = [c.replace("\\", "/").lower() for c in candidates]
+    assert any(c.endswith("c:/nodejs/npm-prefix/arcis.cmd") for c in norm)
 
 
 def test_candidate_paths_skips_npm_lookup_when_npm_not_on_path(monkeypatch):
@@ -289,6 +291,40 @@ def test_find_real_cli_skips_python_shim_and_returns_npm_binary(tmp_path, monkey
     assert os.path.normcase(result).endswith(
         os.path.normcase(os.path.join("npm", "arcis"))
     )
+
+
+def test_is_python_entry_point_detects_python_shebang(tmp_path):
+    """Bug #7 (Linux/macOS): `pip install --user arcis` writes
+    ~/.local/bin/arcis with a python shebang and no sibling python
+    interpreter. The shebang probe must catch it so we don't infinite-
+    loop into the shim."""
+    shim = tmp_path / "arcis"
+    shim.write_text("#!/usr/bin/python3\nimport sys\nsys.exit(0)\n")
+    if sys.platform != "win32":
+        shim.chmod(0o755)
+    assert cli_shim._is_python_entry_point(str(shim)) is True
+
+
+def test_is_python_entry_point_does_not_flag_native_binary(tmp_path):
+    """The Rust binary from `@arcis/cli` has no python shebang. It must
+    not be flagged as a shim or we'd infinite-loop."""
+    real = tmp_path / "arcis-bin"
+    # Magic bytes of a minimal ELF header (just the first 4) so it
+    # clearly looks like a native binary, not a script.
+    real.write_bytes(b"\x7fELF" + b"\x00" * 60)
+    if sys.platform != "win32":
+        real.chmod(0o755)
+    assert cli_shim._is_python_entry_point(str(real)) is False
+
+
+def test_is_python_entry_point_does_not_flag_node_shim(tmp_path):
+    """The npm-installed JS wrapper at bin/arcis starts with
+    `#!/usr/bin/env node`. It must NOT be flagged as a Python shim."""
+    node_shim = tmp_path / "arcis"
+    node_shim.write_text("#!/usr/bin/env node\nrequire('./real-impl')\n")
+    if sys.platform != "win32":
+        node_shim.chmod(0o755)
+    assert cli_shim._is_python_entry_point(str(node_shim)) is False
 
 
 def test_find_real_cli_returns_none_when_only_shim_exists(tmp_path, monkeypatch):

--- a/packages/arcis-python/tests/test_cli_shim.py
+++ b/packages/arcis-python/tests/test_cli_shim.py
@@ -41,17 +41,17 @@ def real_cli_at(monkeypatch):
 def test_no_args_with_real_cli_execs_passthrough(real_cli_at, monkeypatch):
     """Bare `arcis` defers to the real CLI when installed (regression: v1.5.2)."""
     monkeypatch.setattr(sys, "argv", ["arcis"])
-    with patch.object(cli_shim.os, "execv") as mock_execv:
+    with patch.object(cli_shim, "_exec_real", return_value=0) as mock_exec:
         cli_shim.main()
-    mock_execv.assert_called_once_with(real_cli_at, [real_cli_at])
+    mock_exec.assert_called_once_with(real_cli_at, [])
 
 
 def test_no_args_without_real_cli_prints_welcome(no_real_cli, monkeypatch, capsys):
     """Bare `arcis` falls back to shim welcome when the real CLI is missing."""
     monkeypatch.setattr(sys, "argv", ["arcis"])
-    with patch.object(cli_shim.os, "execv") as mock_execv:
+    with patch.object(cli_shim, "_exec_real") as mock_exec:
         rc = cli_shim.main()
-    mock_execv.assert_not_called()
+    mock_exec.assert_not_called()
     out = capsys.readouterr().out
     assert rc == 0
     assert "Arcis Python SDK" in out
@@ -61,40 +61,36 @@ def test_no_args_without_real_cli_prints_welcome(no_real_cli, monkeypatch, capsy
 def test_help_with_real_cli_execs_passthrough(real_cli_at, monkeypatch):
     """`arcis --help` defers to the real CLI when installed."""
     monkeypatch.setattr(sys, "argv", ["arcis", "--help"])
-    with patch.object(cli_shim.os, "execv") as mock_execv:
+    with patch.object(cli_shim, "_exec_real", return_value=0) as mock_exec:
         cli_shim.main()
-    mock_execv.assert_called_once_with(real_cli_at, [real_cli_at, "--help"])
+    mock_exec.assert_called_once_with(real_cli_at, ["--help"])
 
 
 def test_subcommand_with_real_cli_execs_passthrough(real_cli_at, monkeypatch):
     """`arcis scan ...` defers to the real CLI when installed."""
     monkeypatch.setattr(sys, "argv", ["arcis", "scan", "http://localhost"])
-    with patch.object(cli_shim.os, "execv") as mock_execv:
+    with patch.object(cli_shim, "_exec_real", return_value=0) as mock_exec:
         cli_shim.main()
-    mock_execv.assert_called_once_with(
-        real_cli_at, [real_cli_at, "scan", "http://localhost"]
-    )
+    mock_exec.assert_called_once_with(real_cli_at, ["scan", "http://localhost"])
 
 
 def test_check_command_runs_locally_even_with_real_cli(real_cli_at, monkeypatch, capsys):
     """`arcis check '<payload>'` is SDK-local; never delegates to the binary."""
     monkeypatch.setattr(sys, "argv", ["arcis", "check", "hello world"])
-    with patch.object(cli_shim.os, "execv") as mock_execv:
+    with patch.object(cli_shim, "_exec_real") as mock_exec:
         rc = cli_shim.main()
-    mock_execv.assert_not_called()
+    mock_exec.assert_not_called()
     # rc 0 if clean, 1 if threat detected. Either is fine; we only care
-    # that the shim didn't execv.
+    # that the shim didn't pass through.
     assert rc in (0, 1)
 
 
-def test_version_flag_prints_sdk_version_without_execv(real_cli_at, monkeypatch, capsys):
+def test_version_flag_prints_sdk_version_without_passthrough(real_cli_at, monkeypatch, capsys):
     """`arcis --version` prints the Python SDK version locally."""
     monkeypatch.setattr(sys, "argv", ["arcis", "--version"])
-    # subprocess.run on the fake path will fail; we accept either exit
-    # path so long as the shim doesn't execv away from us.
-    with patch.object(cli_shim.os, "execv") as mock_execv:
+    with patch.object(cli_shim, "_exec_real") as mock_exec:
         rc = cli_shim.main()
-    mock_execv.assert_not_called()
+    mock_exec.assert_not_called()
     out = capsys.readouterr().out
     assert rc == 0
     assert cli_shim.SDK_VERSION in out
@@ -107,6 +103,118 @@ def test_unknown_subcommand_without_real_cli_prints_install_hint(no_real_cli, mo
     err = capsys.readouterr().err
     assert rc == 127
     assert "npm install -g @arcis/cli" in err
+
+
+# ---------------------------------------------------------------------------
+# _exec_real: Unix uses os.execv; Windows uses subprocess.run because execv
+# can't launch .cmd shim files.
+# ---------------------------------------------------------------------------
+
+
+def test_exec_real_on_windows_uses_subprocess_not_execv(monkeypatch):
+    """Bug #4 (v1.5.3): npm-global on Windows is `arcis.cmd`. os.execv on
+    a .cmd raises OSError; subprocess.run handles it correctly."""
+    monkeypatch.setattr(cli_shim.sys, "platform", "win32")
+    completed = type("CP", (), {"returncode": 0})()
+    with patch.object(cli_shim.subprocess, "run", return_value=completed) as mock_run:
+        with patch.object(cli_shim.os, "execv") as mock_execv:
+            rc = cli_shim._exec_real(r"C:\Users\u\AppData\Roaming\npm\arcis.cmd", ["audit", "."])
+    mock_run.assert_called_once_with([r"C:\Users\u\AppData\Roaming\npm\arcis.cmd", "audit", "."])
+    mock_execv.assert_not_called()
+    assert rc == 0
+
+
+def test_exec_real_on_unix_uses_execv(monkeypatch):
+    """On Unix the shim should `execv` so signals propagate naturally."""
+    monkeypatch.setattr(cli_shim.sys, "platform", "linux")
+    with patch.object(cli_shim.os, "execv") as mock_execv:
+        with patch.object(cli_shim.subprocess, "run") as mock_run:
+            cli_shim._exec_real("/usr/local/bin/arcis", ["scan", "http://x"])
+    mock_execv.assert_called_once_with(
+        "/usr/local/bin/arcis", ["/usr/local/bin/arcis", "scan", "http://x"]
+    )
+    mock_run.assert_not_called()
+
+
+def test_exec_real_returns_subprocess_returncode_on_windows(monkeypatch):
+    """The subprocess result.returncode must propagate so the user sees
+    the same exit status the binary returned."""
+    monkeypatch.setattr(cli_shim.sys, "platform", "win32")
+    completed = type("CP", (), {"returncode": 7})()
+    with patch.object(cli_shim.subprocess, "run", return_value=completed):
+        rc = cli_shim._exec_real("arcis.cmd", ["audit", "."])
+    assert rc == 7
+
+
+# ---------------------------------------------------------------------------
+# _candidate_paths: npm prefix lookup on Windows must resolve npm.cmd via
+# shutil.which, not call "npm" directly (which CreateProcess fails to find).
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_paths_resolves_npm_via_shutil_which_on_windows(monkeypatch):
+    """Bug #3 (v1.5.3): subprocess.run(['npm', ...]) on Windows fails
+    because Python's subprocess doesn't honor PATHEXT. The shim must
+    resolve npm to its full `.cmd` path first."""
+    monkeypatch.setattr(cli_shim.sys, "platform", "win32")
+    monkeypatch.setenv("APPDATA", r"C:\Users\u\AppData\Roaming")
+    monkeypatch.delenv("USERPROFILE", raising=False)
+    monkeypatch.setattr(
+        cli_shim.shutil, "which", lambda n: r"C:\nodejs\npm.cmd" if n == "npm" else None
+    )
+    completed = type("CP", (), {"returncode": 0, "stdout": r"C:\nodejs\npm-prefix" + "\n"})()
+    with patch.object(cli_shim.subprocess, "run", return_value=completed) as mock_run:
+        candidates = cli_shim._candidate_paths()
+    # Must have invoked the .cmd-resolved path, not bare "npm".
+    invoked = mock_run.call_args[0][0]
+    assert invoked[0] == r"C:\nodejs\npm.cmd"
+    # Must have added the npm-prefix-based candidate variants.
+    joined = " ".join(candidates).lower()
+    assert r"c:\nodejs\npm-prefix\arcis.cmd".lower() in joined
+
+
+def test_candidate_paths_skips_npm_lookup_when_npm_not_on_path(monkeypatch):
+    """If shutil.which('npm') returns None, the shim must NOT crash trying
+    to subprocess.run a bare 'npm' string."""
+    monkeypatch.setattr(cli_shim.sys, "platform", "linux")
+    monkeypatch.setattr(cli_shim.shutil, "which", lambda n: None)
+    with patch.object(cli_shim.subprocess, "run") as mock_run:
+        candidates = cli_shim._candidate_paths()
+    mock_run.assert_not_called()
+    # The fixed-path Unix candidates should still be present. Normalize
+    # separators because os.path.join on the host (which may be Windows
+    # running this test) uses backslashes.
+    norm = [c.replace("\\", "/") for c in candidates]
+    assert any(c.endswith("/usr/local/bin/arcis") for c in norm)
+
+
+# ---------------------------------------------------------------------------
+# --diag flag: prints a debug dump so users can self-serve when the shim
+# refuses to find their binary.
+# ---------------------------------------------------------------------------
+
+
+def test_diag_flag_prints_path_matches_and_resolution(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["arcis", "--diag"])
+    monkeypatch.setattr(cli_shim, "_path_matches", lambda n: ["/path/a/arcis", "/path/b/arcis"])
+    monkeypatch.setattr(
+        cli_shim,
+        "_is_python_entry_point",
+        lambda p: p == "/path/a/arcis",
+    )
+    monkeypatch.setattr(cli_shim, "_candidate_paths", lambda: ["/opt/arcis"])
+    monkeypatch.setattr(cli_shim, "_find_real_cli", lambda: "/path/b/arcis")
+    monkeypatch.setattr(cli_shim.shutil, "which", lambda n: None)
+
+    rc = cli_shim.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "arcis-shim diag" in out
+    assert "/path/a/arcis" in out
+    assert "/path/b/arcis" in out
+    assert "[shim]" in out
+    assert "[real]" in out
+    assert "_find_real_cli():" in out
 
 
 # ---------------------------------------------------------------------------

--- a/packages/arcis-rust/Cargo.lock
+++ b/packages/arcis-rust/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arcis-cli"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "arcis-data",
@@ -77,12 +77,13 @@ dependencies = [
  "clap",
  "serde_json",
  "tempfile",
+ "terminal_size",
  "tokio",
 ]
 
 [[package]]
 name = "arcis-data"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -91,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "arcis-engine"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "arcis-data",
  "dirs",
@@ -160,9 +161,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -458,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -707,7 +708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -732,9 +733,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1332,6 +1333,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
@@ -1587,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1600,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1610,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1620,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1633,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -1676,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2019,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/packages/arcis-rust/Cargo.toml
+++ b/packages/arcis-rust/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 license = "MIT"
 authors = ["Gagan CM <cm.g@northeastern.edu>"]
@@ -24,8 +24,8 @@ description = "Native Rust CLI for Arcis security middleware"
 rust-version = "1.75"
 
 [workspace.dependencies]
-arcis-engine = { path = "crates/arcis-engine", version = "1.0.1" }
-arcis-data = { path = "crates/arcis-data", version = "1.0.1" }
+arcis-engine = { path = "crates/arcis-engine", version = "1.0.2" }
+arcis-data = { path = "crates/arcis-data", version = "1.0.2" }
 
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/packages/arcis-rust/crates/arcis-cli/Cargo.toml
+++ b/packages/arcis-rust/crates/arcis-cli/Cargo.toml
@@ -22,6 +22,10 @@ serde_json = { workspace = true }
 # Async runtime for `arcis scan`. Runtime is constructed once in scan.rs
 # and dropped after the run; the rest of the CLI stays synchronous.
 tokio = { workspace = true }
+# Native terminal-size detection (ioctl on Unix, GetConsoleScreenBufferInfo
+# on Windows). Required so the no-args welcome screen picks the right
+# branch on PowerShell, which never exports COLUMNS.
+terminal_size = "0.4"
 
 [dev-dependencies]
 # End-to-end CLI tests under `tests/` need scratch dirs for fixtures

--- a/packages/arcis-rust/crates/arcis-cli/src/main.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/main.rs
@@ -70,19 +70,29 @@ fn main() -> ExitCode {
     // catalog as a graceful fallback when the user has a narrow window
     // or has piped stdout. This keeps byte-equal parity with the
     // Python CLI on non-TTY paths, where parity tests run.
+    //
+    // Write-error semantics: BrokenPipe is the standard "the reader
+    // hung up" condition (e.g. `arcis | head`). Treat it as a clean
+    // exit; the user got what they wanted from the partial output.
+    // Any other write error means the terminal itself failed mid-banner,
+    // which is rare but worth surfacing as a non-zero exit so wrapper
+    // scripts can detect it.
     if argv.len() < 2 {
         let stdout_is_tty = std::io::stdout().is_terminal();
         let cols = terminal_cols();
-        if stdout_is_tty && !welcome::too_narrow(cols) {
+        let write_result = if stdout_is_tty && !welcome::too_narrow(cols) {
             let cwd = std::env::current_dir()
                 .map(|p| p.display().to_string())
                 .unwrap_or_else(|_| String::from("."));
-            let _ = welcome::print(&mut out, VERSION, &cwd);
+            welcome::print(&mut out, VERSION, &cwd)
         } else {
-            let _ = catalog::print(&mut out, VERSION, /* verbose = */ false);
-            let _ = writeln!(out);
-        }
-        return ExitCode::from(0);
+            catalog::print(&mut out, VERSION, /* verbose = */ false).and_then(|_| writeln!(out))
+        };
+        return match write_result {
+            Ok(()) => ExitCode::from(0),
+            Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => ExitCode::from(0),
+            Err(_) => ExitCode::from(1),
+        };
     }
 
     let arg = argv[1].as_str();

--- a/packages/arcis-rust/crates/arcis-cli/src/main.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/main.rs
@@ -26,20 +26,29 @@ mod welcome;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Best-effort terminal column count without adding a dep.
+/// Terminal column count, in priority order:
+///   1. `$COLUMNS` if a shell exported it (rare on Windows, common on bash).
+///   2. Native terminal-size syscall (ioctl `TIOCGWINSZ` on Unix,
+///      `GetConsoleScreenBufferInfo` on Windows).
+///   3. Conservative default of 132 (the welcome screen's minimum) so
+///      a piped or detached invocation still picks the welcome branch.
 ///
-/// Reads `$COLUMNS` if exported (most shells set this on interactive
-/// sessions); otherwise returns 120 as a reasonable default that's
-/// wider than the welcome panel's minimum. If the welcome screen
-/// renders wider than the real terminal, lines wrap and the user sees
-/// a slightly mangled box. That's acceptable; the catalog fallback
-/// only triggers below 80 cols and we trust users to have a normal
-/// terminal width.
+/// Previous version returned 120 when `$COLUMNS` was unset, which
+/// guaranteed PowerShell users always fell back to the plain catalog
+/// because the welcome panel requires 132+ cols. The native query
+/// works on every modern terminal (Windows Terminal, conhost.exe,
+/// iTerm2, Alacritty, GNOME Terminal, tmux).
 fn terminal_cols() -> usize {
-    std::env::var("COLUMNS")
+    if let Some(cols) = std::env::var("COLUMNS")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(120)
+    {
+        return cols;
+    }
+    if let Some((terminal_size::Width(w), _)) = terminal_size::terminal_size() {
+        return w as usize;
+    }
+    132
 }
 
 fn main() -> ExitCode {


### PR DESCRIPTION
## Summary
Pilot user ran 'pip install arcis' then 'npm install -g @arcis/cli' on Windows PowerShell. Expected: the new emerald burst welcome on bare 'arcis'. Actual: kept seeing the Python shim's plain-text install hint, and 'arcis audit .' returned 'requires the full CLI binary'. Six distinct bugs blocked the welcome screen from ever rendering — fixing all in this PR.

## Bugs fixed

| # | Layer | Bug | Symptom |
|---|-------|-----|---------|
| 1 | Python shim | 'if real_cli and args' blocked the no-args branch | bare 'arcis' rendered shim welcome even with the binary installed |
| 2 | Python shim | 'shutil.which' returned only the first PATH hit (Python's Scripts shim) | '_find_real_cli' never saw the npm binary further down PATH |
| 3 | Python shim | 'subprocess.run([\"npm\", ...])' on Windows could not find 'npm.cmd' | npm-prefix fallback in '_candidate_paths' silently failed (Python's subprocess does not honor PATHEXT) |
| 4 | Python shim | 'os.execv' on a '.cmd' shim raised OSError, silently swallowed | even when the binary was found, the launch failed and the user saw the shim welcome |
| 5 | Python shim | no diagnostic flag | users had no way to tell us what their shim sees |
| 6 | Rust CLI | 'terminal_cols' defaulted to 120 when \$COLUMNS unset (< 132 MIN_COLS) | PowerShell users always fell through to the catalog instead of the welcome |

## What changes ship

| Surface | Version | What |
|---------|---------|------|
| 'arcis' (PyPI) | 1.5.2 → 1.5.3 | All 5 Python shim fixes |
| '@arcis/cli' (npm) | 1.0.1 → 1.0.2 | Native terminal-width detection via 'terminal_size' crate |
| '@arcis/node' | unchanged | n/a |

## Tests
- 'tests/test_cli_shim.py' is now 17 cases. Covers each numbered bug (1, 2, 3, 4 explicitly named in test docstrings), the '--diag' dump, the cross-platform '_exec_real' branches, and the Windows-specific npm.cmd resolution. All 17 pass locally.
- Rust 'cargo test --workspace': 180 passing.
- 'cargo fmt --check' + 'cargo clippy --workspace --all-targets -- -D warnings' clean under Rust 1.87 (CI's stable channel).
- Built 'release' profile binary under Docker as a smoke test before push.

## Diagnostic helper
New 'arcis --diag' command for future field reports:
- PATH walk results with [shim] / [real] verdict per hit
- Candidate paths from '_candidate_paths' with exists/missing verdict
- npm executable resolution + 'npm config get prefix' output
- What '_find_real_cli' resolved to (or None)

## Test plan
- [ ] Merge to nwl, open release PR to main, squash-merge.
- [ ] 'pip install -U arcis' on the pilot machine.
- [ ] 'npm install -g @arcis/cli' on the pilot machine (idempotent if already installed).
- [ ] Bare 'arcis' should render the Rust welcome screen (emerald burst + Tips + More commands) — not the shim welcome, not the catalog.
- [ ] 'arcis audit .' should hand off to the Rust binary and produce real audit output.
- [ ] 'arcis --diag' should show the npm binary resolved at '%APPDATA%\npm\arcis.cmd' (or wherever npm config prefix points).