### PR TITLE
chore: bump versions for v1.6.0 release

### DIFF
--- a/packages/arcis-cli-npm/package.json
+++ b/packages/arcis-cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/cli",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Arcis security CLI — scan running apps, audit source, and check dependencies. Native Rust binary distributed via npm.",
   "keywords": [
     "security",

--- a/packages/arcis-node/package.json
+++ b/packages/arcis-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/node",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Inside-the-app security middleware for Node.js. One install protects Express, NestJS, SvelteKit, Astro, Nuxt, Bun, Hono, Fastify, Koa, and Next.js against XSS, SQL injection, CSRF, SSRF, HPP, prompt injection, bot traffic, rate limiting, and 20+ more attack types. v1.6 ships interactive REPL, NFKC + multi-decode hardening, deserialization markers (V33), GraphQL alias-bomb guard (V34), and a stateful per-IP correlation window. Includes prompt-injection signature library, LLM token-budget middleware, 635-pattern bot corpus, and the @arcis/cli native CLI.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/arcis-python/arcis/__init__.py
+++ b/packages/arcis-python/arcis/__init__.py
@@ -197,7 +197,7 @@ try:
 except ImportError:
     _HAS_ASYNC = False
 
-__version__ = "1.5.4"
+__version__ = "1.5.5"
 __all__ = [
     # Main class
     "Arcis",

--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arcis"
-version = "1.5.4"
+version = "1.5.5"
 description = "Inside-the-app security middleware for Python. One install protects FastAPI, Flask, and Django against XSS, SQL injection, CSRF, SSRF, HPP, prompt injection, bot traffic, rate limiting, and 20+ more attack types. Includes prompt-injection signature library, LLM token-budget middleware, and a 646-pattern bot corpus with consistent API across the Node and Go SDKs. The CLI ships separately at npm install -g @arcis/cli."
 readme = "README.md"
 license = "MIT"

--- a/packages/arcis-rust/Cargo.lock
+++ b/packages/arcis-rust/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arcis-cli"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "arcis-data",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "arcis-data"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "arcis-engine"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "arcis-data",
  "dirs",

--- a/packages/arcis-rust/Cargo.toml
+++ b/packages/arcis-rust/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 license = "MIT"
 authors = ["Gagan CM <cm.g@northeastern.edu>"]


### PR DESCRIPTION
Per-package version bumps for the v1.6.0 release.

| Package | From | To |
|---|---|---|
| @arcis/node (npm) | 1.5.2 | 1.6.0 |
| arcis (PyPI) | 1.5.4 | 1.5.5 |
| @arcis/cli (npm) | 1.0.2 | 1.1.0 |
| Rust workspace | 1.0.2 | 1.1.0 |
| Go module tag | (last 1.5.x) | v1.6.0 |

Per-package independent semver per the v1.6 scope memory.

Following this merge, the next step is a release PR `nwl → main` which triggers publish.yml + pages.yml on the squash-merge.