### PR TITLE
feat: publish @arcis/mcp@1.6.0 (first publish)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,41 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  publish-mcp:
+    name: Publish MCP
+    runs-on: ubuntu-latest
+    needs: [publish-node]
+    defaults:
+      run:
+        working-directory: packages/arcis-mcp
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: packages/arcis-mcp/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - name: Check if version already published
+        id: check-npm
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          if npm view "@arcis/mcp@${PACKAGE_VERSION}" version 2>/dev/null; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "v${PACKAGE_VERSION} already published to npm, skipping"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm
+        if: steps.check-npm.outputs.skip != 'true'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish-python:
     name: Publish Python
     runs-on: ubuntu-latest

--- a/packages/arcis-mcp/package-lock.json
+++ b/packages/arcis-mcp/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@arcis/mcp",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcis/mcp",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "@arcis/node": "file:../arcis-node",
+        "@arcis/node": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.0.0"
       },
       "bin": {
@@ -32,20 +32,20 @@
     },
     "../arcis-node": {
       "name": "@arcis/node",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
-        "@nestjs/common": "^11.1.19",
+        "@nestjs/common": "^11.1.21",
         "@types/express": "^5.0.6",
-        "@types/node": "^25.5.0",
-        "@typescript-eslint/eslint-plugin": "^8.58.0",
+        "@types/node": "^25.9.1",
+        "@typescript-eslint/eslint-plugin": "^8.59.4",
         "@typescript-eslint/parser": "^8.58.0",
-        "@vitest/coverage-v8": "^4.1.5",
-        "eslint": "^10.1.0",
+        "@vitest/coverage-v8": "^4.1.7",
+        "eslint": "^10.4.0",
         "express": "^5.2.1",
         "tsup": "^8.0.1",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.0"
       },
       "engines": {

--- a/packages/arcis-mcp/package.json
+++ b/packages/arcis-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/mcp",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Arcis MCP server. Exposes Arcis CLI scanners (audit / scan / sca) and the prompt-injection detector as tools that Cursor, Claude Code, and any other MCP-aware AI agent can call. One install, four tools, zero cloud round trip.",
   "main": "dist/server.js",
   "bin": {
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@arcis/node": "file:../arcis-node"
+    "@arcis/node": "^1.6.0"
   },
   "peerDependenciesMeta": {
     "@arcis/cli": {


### PR DESCRIPTION
## Summary

First-publish of `@arcis/mcp` to npm. The package has been in the monorepo since 2026-05-07 but never reached the registry.

- Bumps `@arcis/mcp` from 1.5.0 → 1.6.0 to match the v1.6 cohort (Node, Python, CLI, Go all on 1.6 line).
- Replaces the local `file:../arcis-node` dependency with the registry range `^1.6.0` so npm consumers resolve from `@arcis/node@1.6.0`.
- Adds `publish-mcp` job to `.github/workflows/publish.yml` mirroring the `publish-node` pattern (checkout → `npm ci` → build → version-exists check → `npm publish`). Runs after `publish-node` so the `@arcis/node@1.6.0` referenced as a dep is guaranteed on npm first.

## What the package does

Exposes 4 tools so MCP-aware AI agents can call Arcis:

| Tool | Backed by |
|---|---|
| `arcis_audit` | `arcis audit` CLI |
| `arcis_sca` | `arcis sca` CLI |
| `arcis_scan` | `arcis scan` CLI |
| `arcis_detect_prompt_injection` | `@arcis/node` in-process |

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 12/12 passing
- [x] `npm run build` — `dist/server.js` 9.2 KB
- [ ] After merge to main: `publish.yml` runs, `@arcis/mcp@1.6.0` lands on npm
- [ ] Verify `npx -y @arcis/mcp` boots and responds to MCP `initialize` request