### PR TITLE
fix: @arcis/node exports map + honest-claims sweep (v1.6.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ At the checkpoint, Arcis:
 - **635-pattern bot corpus**: Generated from a curated MIT-licensed corpus plus supplementary entries. 7 categories (search engines, social, monitoring, AI crawlers, scrapers, automated tools, unknown) with allow/deny lists and behavioral signal detection.
 - **Lean dependencies**: Node + Python SDKs ship with zero runtime dependencies. Go SDK has a stdlib-only core; framework adapters (Gin, Echo, chi, Fiber) are imported on demand.
 - **Three-language parity**: Same API, same behavior, same test results across Node.js, Python, and Go. Enforced by shared test vectors.
-- **First-party framework adapters (Node)**: Express, Fastify, Koa, Hono, Next.js, NestJS, SvelteKit, Astro, Nuxt, Bun. Each subpath import (`@arcis/node/fastify`, `@arcis/node/hono`, `@arcis/node/nextjs`, etc.) keeps the framework SDK as a type-only dependency, so non-users pay nothing.
-- **First-party framework adapters (Python)**: FastAPI, Flask, Django, Litestar (and any ASGI host).
-- **First-party framework adapters (Go)**: Gin, Echo, chi, Fiber, plus a stdlib `net/http` helper.
+- **Framework adapters (Node)**: ten subpath imports keep each framework SDK as a type-only dependency, so non-users pay nothing. Adapter surface varies by framework:
+  - *Full sanitizer pipeline* (XSS, SQL, NoSQL, SSTI, XXE, path, command, prompt injection, prototype, LDAP, XPath, header injection): **Express** (`@arcis/node`), **NestJS** (`@arcis/node/nestjs`).
+  - *Rate-limit + bot + security headers* (narrower scope because the runtime cannot easily inspect request bodies, or because the adapter is `v1` and ships the basics first): **Fastify, Koa, Hono, Next.js (Edge Middleware), SvelteKit, Astro, Nuxt, Bun**. Pair with `sanitizeObject()` / `detectXss()` / `sanitizeString()` from `@arcis/node/sanitizers` inside your route handlers for body-payload inspection.
+- **Framework adapters (Python)**: FastAPI, Flask, Django, Litestar (full pipeline on every adapter — Python middleware can read request bodies natively).
+- **Framework adapters (Go)**: Gin, Echo, chi, Fiber, plus a stdlib `net/http` helper (full pipeline on every adapter when `Block: true` is set).
 - **Context-aware output encoding**: `encodeForHtml()`, `encodeForJs()`, `encodeForUrl()`, `encodeForCss()`, `encodeForAttribute()` for safe rendering in every output context.
 - **Supply chain scanner**: `arcis sca` checks lockfiles, `node_modules`, and Python environments against a database of known compromised packages.
 - **Static analysis CLI**: `arcis scan` and `arcis audit` flag unsafe patterns (`eval()`, `pickle.loads()`, `innerHTML`, SQL concat, SSRF sinks, weak crypto) across 24 rules.
@@ -124,7 +126,7 @@ At the checkpoint, Arcis:
 | **CSRF** | Double-submit cookie, token generation and validation |
 | **Rate Limiting** | Per-IP, sliding window, token bucket, in-memory or Redis, `X-RateLimit-*` headers |
 | **Bot Detection** | 635 patterns sourced from a curated MIT corpus + supplementary entries, 7 categories (search engines, social, monitoring, AI crawlers, scrapers, automated tools, unknown), behavioral signals on missing browser headers. The corpus is also published standalone at [`getarcis/well-known-bots`](https://github.com/getarcis/well-known-bots). |
-| **MCP server (`@arcis/mcp`)** | Model Context Protocol server exposing `arcis_audit`, `arcis_sca`, `arcis_scan`, and `arcis_detect_prompt_injection` as tools that Cursor, Claude Code, and any MCP-aware agent can call. |
+| **MCP server (`@arcis/mcp`)** | Model Context Protocol server exposing `arcis_audit`, `arcis_sca`, `arcis_scan`, and `arcis_detect_prompt_injection` as tools that Cursor and any MCP-aware AI agent can call. |
 | **Prompt Injection** | 28 signatures across HIGH/MEDIUM/LOW tiers: jailbreak frameworks, system-prompt extraction, fake `<system>` tags, conversation-replay forgeries, base64/ROT13 smuggling hints, plus 5 v1.6 agent toolcall patterns (`"tool_call"` / `"function_call"` markers, ANSI escapes, tool-name spoofing) |
 | **Modern Deserialization (v1.6)** | `detectDeserialization()` flags request bodies that look like Python pickle (`\x80\x04`), Java FastJSON (`"@type":`), PHP `unserialize` (`O:N:"Class":`), Ruby Marshal (`\x04\x08`), or .NET BinaryFormatter (`\x00\x01\x00\x00\x00`). Detection-only: caller refuses the request. |
 | **GraphQL Abuse** | `graphqlGuard` rejects oversize queries, deep selection sets, introspection in production, and (v1.6) alias bombs + fragment cycles via `max_aliases` and `block_fragment_cycles`. |
@@ -492,13 +494,17 @@ Response sent to client
 
 ## Supported Frameworks
 
-| SDK | Built-in Adapters | Core Functions | Status |
-|-----|-------------------|----------------|--------|
-| **Node.js** | Express | Work with any framework | Stable |
-| **Python** | Flask, FastAPI, Django | Work standalone | Stable |
-| **Go** | net/http, Gin, Echo | Work standalone | Beta |
+| SDK | Full-pipeline adapters | Edge / narrow-scope adapters | Status |
+|-----|------------------------|------------------------------|--------|
+| **Node.js** | Express, NestJS | Fastify, Koa, Hono, Next.js, SvelteKit, Astro, Nuxt, Bun | Stable |
+| **Python** | FastAPI, Flask, Django, Litestar | (none — every Python adapter runs the full pipeline) | Stable |
+| **Go** | Gin, Echo, chi, Fiber, net/http | (none — every Go adapter runs the full pipeline when `Block: true`) | Stable |
 
-**Node.js:** First-party adapters ship for Express, Fastify, Koa, Hono, Next.js, NestJS, SvelteKit, Astro, Nuxt, and Bun. Import any of them via subpath (`@arcis/node/fastify`, `@arcis/node/hono`, etc.) — framework types stay compile-time-only.
+**Full-pipeline** adapters run the full Arcis sanitization stack (XSS, SQL, NoSQL, SSTI, XXE, path, command, prototype, prompt injection, LDAP, XPath, header injection) against query, params, headers, and body.
+
+**Edge / narrow-scope** adapters ship rate-limit + bot + security headers only. The runtime either cannot easily inspect request bodies (Next.js Edge Middleware, Cloudflare Workers via Hono, Bun) or the adapter is `v1` and deliberately keeps the surface narrow (Fastify, Koa, SvelteKit, Astro, Nuxt). Pair with `sanitizeObject()` / `detectXss()` / `sanitizeString()` from `@arcis/node/sanitizers` inside route handlers for body-payload inspection.
+
+Import any subpath via `@arcis/node/<adapter>` (e.g., `@arcis/node/fastify`, `@arcis/node/nextjs`). Framework types stay compile-time-only.
 
 ---
 
@@ -569,7 +575,7 @@ The script is stripped. The rest of the comment is saved normally.
 
 - 20+ security flaw coverage (runtime + detection)
 - 3 SDKs (Node.js, Python, Go) at full parity
-- **12 framework adapters**: Express, NestJS, SvelteKit, Astro, Nuxt, Bun + Hono (Node), FastAPI, Flask, Django, Litestar (Python), Gin, Echo, chi, Fiber, net/http (Go)
+- **19 framework adapters**: Express, NestJS, Fastify, Koa, Hono, Next.js, SvelteKit, Astro, Nuxt, Bun (Node, 10 total), FastAPI, Flask, Django, Litestar (Python, 4 total), Gin, Echo, chi, Fiber, net/http (Go, 5 total)
 - **635-pattern bot corpus** (was 80) with allow/deny categorization
 - **AI/LLM prompt-injection detection** across all 3 SDKs (28 signatures, 3 severity tiers)
 - **`tokenBudget` middleware** for per-key LLM token spend caps

--- a/packages/arcis-cli-npm/bin/arcis
+++ b/packages/arcis-cli-npm/bin/arcis
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 // Tiny shim: finds the native binary that the postinstall script wrote
 // next to this file, then exec's it with the same argv. Same pattern as
-// esbuild / swc / Claude Code. Done in JS instead of platform-specific
-// shell wrappers so npm's `bin` field works the same on Linux, macOS,
-// and Windows (npm cmd-shim wraps this for us on Windows).
+// esbuild and swc. Done in JS instead of platform-specific shell wrappers
+// so npm's `bin` field works the same on Linux, macOS, and Windows (npm
+// cmd-shim wraps this for us on Windows).
 
 "use strict";
 

--- a/packages/arcis-cli-npm/install.js
+++ b/packages/arcis-cli-npm/install.js
@@ -8,7 +8,7 @@
 //
 // Plain stdlib: no transitive deps. Runs at install time, before any
 // optional dependencies are available, so we cannot rely on third-party
-// packages here. Same pattern Claude Code, esbuild, and swc use.
+// packages here. Same pattern esbuild and swc use.
 
 "use strict";
 

--- a/packages/arcis-mcp/README.md
+++ b/packages/arcis-mcp/README.md
@@ -1,6 +1,6 @@
 # @arcis/mcp
 
-> Model Context Protocol server for Arcis. Plugs Arcis security tools into Cursor, Claude Code, and any MCP-aware AI agent.
+> Model Context Protocol server for Arcis. Plugs Arcis security tools into Cursor and any MCP-aware AI agent.
 
 [![npm version](https://img.shields.io/npm/v/@arcis/mcp.svg?label=%40arcis%2Fmcp&color=00996D)](https://www.npmjs.com/package/@arcis/mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
@@ -43,9 +43,9 @@ Add to your Cursor config (`~/.cursor/mcp.json` or `cursor-mcp.json`):
 
 Restart Cursor. The four tools become available to any chat where you've enabled MCP tool calls.
 
-### Claude Code
+### Other MCP-aware AI agents
 
-Claude Code reads the same MCP server format. Add to your project's `.mcp.json`:
+Any IDE or coding-assistant client that reads the standard `.mcp.json` format works. Add to your project's `.mcp.json`:
 
 ```json
 {

--- a/packages/arcis-mcp/package.json
+++ b/packages/arcis-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arcis/mcp",
   "version": "1.6.0",
-  "description": "Arcis MCP server. Exposes Arcis CLI scanners (audit / scan / sca) and the prompt-injection detector as tools that Cursor, Claude Code, and any other MCP-aware AI agent can call. One install, four tools, zero cloud round trip.",
+  "description": "Arcis MCP server. Exposes Arcis CLI scanners (audit / scan / sca) and the prompt-injection detector as tools that Cursor and any other MCP-aware AI agent can call. One install, four tools, zero cloud round trip.",
   "main": "dist/server.js",
   "bin": {
     "arcis-mcp": "dist/server.js"
@@ -23,7 +23,6 @@
     "arcis",
     "security",
     "cursor",
-    "claude-code",
     "ai-agent",
     "tool",
     "prompt-injection"

--- a/packages/arcis-mcp/src/server.ts
+++ b/packages/arcis-mcp/src/server.ts
@@ -1,8 +1,8 @@
 /**
  * @arcis/mcp — Model Context Protocol server for Arcis.
  *
- * Exposes Arcis security tools so MCP-aware AI agents (Cursor, Claude Code,
- * Anthropic's MCP clients, OpenAI's tool-call shim) can call them directly.
+ * Exposes Arcis security tools so MCP-aware AI agents (Cursor, the MCP CLI,
+ * and any other MCP client) can call them directly.
  *
  * Four tools:
  *   - arcis_audit                   static analysis on a directory
@@ -14,8 +14,8 @@
  * `npm install -g @arcis/cli`). The fourth runs entirely in-process via
  * the Node SDK — no extra binary required.
  *
- * Speak the protocol over stdio; that's how Cursor, Claude Code, and the
- * MCP CLI launch servers.
+ * Speak the protocol over stdio; that's how Cursor, the MCP CLI, and
+ * other MCP clients launch servers.
  */
 
 import { spawn } from 'node:child_process';

--- a/packages/arcis-node/package.json
+++ b/packages/arcis-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/node",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Inside-the-app security middleware for Node.js. One install protects Express, NestJS, SvelteKit, Astro, Nuxt, Bun, Hono, Fastify, Koa, and Next.js against XSS, SQL injection, CSRF, SSRF, HPP, prompt injection, bot traffic, rate limiting, and 20+ more attack types. v1.6 ships interactive REPL, NFKC + multi-decode hardening, deserialization markers (V33), GraphQL alias-bomb guard (V34), and a stateful per-IP correlation window. Includes prompt-injection signature library, LLM token-budget middleware, 635-pattern bot corpus, and the @arcis/cli native CLI.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -52,47 +52,47 @@
       "require": "./dist/telemetry/index.js"
     },
     "./fastify": {
-      "types": "./dist/fastify/index.d.ts",
+      "types": "./dist/middleware/fastify.d.ts",
       "import": "./dist/fastify/index.mjs",
       "require": "./dist/fastify/index.js"
     },
     "./koa": {
-      "types": "./dist/koa/index.d.ts",
+      "types": "./dist/middleware/koa.d.ts",
       "import": "./dist/koa/index.mjs",
       "require": "./dist/koa/index.js"
     },
     "./nestjs": {
-      "types": "./dist/nestjs/index.d.ts",
+      "types": "./dist/middleware/nestjs.d.ts",
       "import": "./dist/nestjs/index.mjs",
       "require": "./dist/nestjs/index.js"
     },
     "./nextjs": {
-      "types": "./dist/nextjs/index.d.ts",
+      "types": "./dist/middleware/nextjs.d.ts",
       "import": "./dist/nextjs/index.mjs",
       "require": "./dist/nextjs/index.js"
     },
     "./sveltekit": {
-      "types": "./dist/sveltekit/index.d.ts",
+      "types": "./dist/middleware/sveltekit.d.ts",
       "import": "./dist/sveltekit/index.mjs",
       "require": "./dist/sveltekit/index.js"
     },
     "./astro": {
-      "types": "./dist/astro/index.d.ts",
+      "types": "./dist/middleware/astro.d.ts",
       "import": "./dist/astro/index.mjs",
       "require": "./dist/astro/index.js"
     },
     "./nuxt": {
-      "types": "./dist/nuxt/index.d.ts",
+      "types": "./dist/middleware/nuxt.d.ts",
       "import": "./dist/nuxt/index.mjs",
       "require": "./dist/nuxt/index.js"
     },
     "./bun": {
-      "types": "./dist/bun/index.d.ts",
+      "types": "./dist/middleware/bun.d.ts",
       "import": "./dist/bun/index.mjs",
       "require": "./dist/bun/index.js"
     },
     "./hono": {
-      "types": "./dist/hono/index.d.ts",
+      "types": "./dist/middleware/hono.d.ts",
       "import": "./dist/hono/index.mjs",
       "require": "./dist/hono/index.js"
     }

--- a/packages/arcis-node/package.json
+++ b/packages/arcis-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arcis/node",
   "version": "1.6.1",
-  "description": "Inside-the-app security middleware for Node.js. One install protects Express, NestJS, SvelteKit, Astro, Nuxt, Bun, Hono, Fastify, Koa, and Next.js against XSS, SQL injection, CSRF, SSRF, HPP, prompt injection, bot traffic, rate limiting, and 20+ more attack types. v1.6 ships interactive REPL, NFKC + multi-decode hardening, deserialization markers (V33), GraphQL alias-bomb guard (V34), and a stateful per-IP correlation window. Includes prompt-injection signature library, LLM token-budget middleware, 635-pattern bot corpus, and the @arcis/cli native CLI.",
+  "description": "Inside-the-app security middleware for Node.js. Express and NestJS run the full sanitizer pipeline (XSS, SQL, NoSQL, SSTI, XXE, path, command, prompt injection, prototype pollution, LDAP, XPath, header injection, plus 20+ more attack types). Fastify, Koa, Hono, Next.js, SvelteKit, Astro, Nuxt, and Bun ship rate-limit + bot detection + security headers as v1 adapters; pair them with `sanitizeObject` from @arcis/node/sanitizers for body inspection. v1.6 ships interactive REPL, NFKC + multi-decode hardening, deserialization markers (V33), GraphQL alias-bomb guard (V34), and a stateful per-IP correlation window. Includes prompt-injection signature library, LLM token-budget middleware, 635-pattern bot corpus, and the @arcis/cli native CLI.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/arcis-node/src/middleware/astro.ts
+++ b/packages/arcis-node/src/middleware/astro.ts
@@ -1,7 +1,12 @@
 /**
  * @module @arcis/node/astro
  *
- * Astro adapter for Arcis. Drop into `src/middleware.ts`:
+ * Astro adapter for Arcis. Drop into `src/middleware.ts`.
+ *
+ * **Scope:** rate-limit + bot detection + security headers. For
+ * XSS/SQL/SSTI/etc. body-payload blocking, call `sanitizeObject` from
+ * `@arcis/node/sanitizers` inside your endpoint handler. v1 keeps the
+ * middleware surface narrow.
  *
  * ```ts
  * import { defineMiddleware } from 'astro:middleware';

--- a/packages/arcis-node/src/middleware/bun.ts
+++ b/packages/arcis-node/src/middleware/bun.ts
@@ -1,7 +1,14 @@
 /**
  * @module @arcis/node/bun
  *
- * Bun + Hono adapter for Arcis. Two entry points:
+ * Bun + Hono adapter for Arcis. Two entry points.
+ *
+ * **Scope:** rate-limit + bot detection + security headers. Bun's
+ * Web Fetch runtime cannot easily inspect request bodies inside this
+ * adapter (consuming the stream defeats the downstream handler). For
+ * XSS/SQL/SSTI/etc. body-payload blocking, call
+ * `sanitizeObject(await req.json())` from `@arcis/node/sanitizers`
+ * inside your route handler.
  *
  * **1. `Bun.serve` fetch wrapper:**
  *

--- a/packages/arcis-node/src/middleware/hono.ts
+++ b/packages/arcis-node/src/middleware/hono.ts
@@ -7,6 +7,12 @@
  * That means it works in any runtime Hono targets: Cloudflare Workers,
  * Deno Deploy, Bun, AWS Lambda, Node, and so on.
  *
+ * **Scope:** rate-limit + bot detection + security headers. The
+ * Web Fetch shape means consuming the body stream in this adapter
+ * would defeat the downstream handler. For XSS/SQL/SSTI/etc. body
+ * payload blocking, call `sanitizeObject(await c.req.json())` from
+ * `@arcis/node/sanitizers` inside your route handler.
+ *
  * Quick start:
  *
  * ```ts

--- a/packages/arcis-node/src/middleware/koa.ts
+++ b/packages/arcis-node/src/middleware/koa.ts
@@ -6,6 +6,11 @@
  * handler); security headers are applied AFTER `next()` so they ride on
  * the buffered response that Koa flushes on its own.
  *
+ * **Scope:** rate-limit + bot detection + security headers. For
+ * XSS/SQL/SSTI/etc. body-payload blocking, call `sanitizeObject` from
+ * `@arcis/node/sanitizers` inside your handler. v1 keeps the middleware
+ * surface narrow.
+ *
  * ```ts
  * import Koa from 'koa';
  * import { arcisKoa } from '@arcis/node/koa';

--- a/packages/arcis-node/src/middleware/nextjs.ts
+++ b/packages/arcis-node/src/middleware/nextjs.ts
@@ -2,7 +2,15 @@
  * @module @arcis/node/nextjs
  *
  * Next.js adapter for Arcis. Two entry points covering the modern Next.js
- * stack (Edge Middleware + App Router route handlers):
+ * stack (Edge Middleware + App Router route handlers).
+ *
+ * **Scope:** rate-limit + bot detection + security headers. The Edge
+ * runtime cannot easily inspect request bodies (they are streams that
+ * can only be read once, and consuming them in middleware defeats the
+ * route handler). For XSS/SQL/SSTI/etc. body-payload blocking, call
+ * `sanitizeObject(await request.json())` from `@arcis/node/sanitizers`
+ * inside your route handler, or wrap individual handlers with
+ * `arcisProtect` (also exported from this module).
  *
  * **1. Edge Middleware (`middleware.ts` at the project root):**
  *

--- a/packages/arcis-node/src/middleware/nuxt.ts
+++ b/packages/arcis-node/src/middleware/nuxt.ts
@@ -1,7 +1,12 @@
 /**
  * @module @arcis/node/nuxt
  *
- * Nuxt (h3) adapter for Arcis. Drop into a server middleware file:
+ * Nuxt (h3) adapter for Arcis. Drop into a server middleware file.
+ *
+ * **Scope:** rate-limit + bot detection + security headers. For
+ * XSS/SQL/SSTI/etc. body-payload blocking, call `sanitizeObject` from
+ * `@arcis/node/sanitizers` inside your route handler. v1 keeps the
+ * middleware surface narrow.
  *
  * ```ts
  * // server/middleware/arcis.ts

--- a/packages/arcis-node/src/middleware/sveltekit.ts
+++ b/packages/arcis-node/src/middleware/sveltekit.ts
@@ -2,7 +2,12 @@
  * @module @arcis/node/sveltekit
  *
  * SvelteKit adapter for Arcis. Returns a `Handle` factory you can drop into
- * `src/hooks.server.ts`:
+ * `src/hooks.server.ts`.
+ *
+ * **Scope:** rate-limit + bot detection + security headers. For
+ * XSS/SQL/SSTI/etc. body-payload blocking, call `sanitizeObject` from
+ * `@arcis/node/sanitizers` inside your route handler. v1 keeps the
+ * middleware surface narrow.
  *
  * ```ts
  * import { arcisHandle } from '@arcis/node/sveltekit';

--- a/packages/arcis-python/README.md
+++ b/packages/arcis-python/README.md
@@ -5,7 +5,7 @@
 [![Python 3.9+](https://img.shields.io/pypi/pyversions/arcis.svg)](https://pypi.org/project/arcis/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-**Inside-the-app security middleware for Python. One line of code, 30+ attack vectors handled, zero runtime dependencies.**
+**Inside-the-app security middleware for Python. One line of code, 20+ attack vectors handled, zero runtime dependencies.**
 
 ```bash
 pip install arcis

--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "arcis"
 version = "1.5.5"
-description = "Inside-the-app security middleware for Python. One install protects FastAPI, Flask, and Django against XSS, SQL injection, CSRF, SSRF, HPP, prompt injection, bot traffic, rate limiting, and 20+ more attack types. Includes prompt-injection signature library, LLM token-budget middleware, and a 646-pattern bot corpus with consistent API across the Node and Go SDKs. The CLI ships separately at npm install -g @arcis/cli."
+description = "Inside-the-app security middleware for Python. One install protects FastAPI, Flask, Django, and Litestar against XSS, SQL injection, CSRF, SSRF, HPP, prompt injection, bot traffic, rate limiting, and 20+ more attack types. Includes prompt-injection signature library, LLM token-budget middleware, and a 635-pattern bot corpus with consistent API across the Node and Go SDKs. The CLI ships separately at npm install -g @arcis/cli."
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/packages/arcis-rust/crates/arcis-cli/Cargo.toml
+++ b/packages/arcis-rust/crates/arcis-cli/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { workspace = true }
 # branch on PowerShell, which never exports COLUMNS.
 terminal_size = "0.4"
 # Interactive REPL (cli-bugs.md Part B / improvements.md §1.5). Drops
-# users into a Claude-Code-shaped TUI on bare `arcis`. Backend is
+# users into a full-screen rounded TUI on bare `arcis`. Backend is
 # crossterm (ratatui's default).
 ratatui = { workspace = true }
 crossterm = { workspace = true }

--- a/packages/arcis-rust/crates/arcis-cli/src/console.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/console.rs
@@ -1,8 +1,7 @@
 //! `arcis console` — interactive REPL surface.
 //!
 //! Dropped into when a user invokes `arcis` with no args on a TTY (and
-//! not under CI, not piped). Shape mirrors Claude Code / Hermes Agent
-//! CLI / Shannon CLI: a full-screen TUI with a persistent header, a
+//! not under CI, not piped). Full-screen TUI shape with a persistent header, a
 //! scrollback area below it, and a prompt at the bottom. Slash commands
 //! `/help` and `/exit` plus the three scanners (`audit`, `sca`, `scan`)
 //! run inline; output streams into the scrollback as the subprocess
@@ -345,9 +344,8 @@ impl ReplState {
     }
 
     /// Append the welcome banner. Banner is part of scrollback so it
-    /// scrolls naturally as the user runs commands — same shape as
-    /// Claude Code, where the welcome content sits at the top of the
-    /// session and slides off as work accumulates.
+    /// scrolls naturally as the user runs commands. The welcome content
+    /// sits at the top of the session and slides off as work accumulates.
     ///
     /// Sections mirror the Figma V2 mockup: braille sunburst mascot +
     /// wordmark on the left, version + cwd row, then Quick start /
@@ -913,8 +911,8 @@ fn char_pos_to_byte(s: &str, char_pos: usize) -> usize {
 fn ui_render(f: &mut ratatui::Frame, state: &ReplState) {
     let area = f.area();
 
-    // Two-pane layout — banner is part of scrollback (Claude Code-style:
-    // scrolls naturally as the user works, eventually off-screen).
+    // Two-pane layout. Banner is part of scrollback and scrolls naturally
+    // as the user works, eventually off-screen.
     // Prompt is pinned at the bottom in a 3-row block (border-top +
     // input row + border-bottom).
     let chunks = Layout::default()

--- a/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
@@ -269,7 +269,8 @@ fn build_right() -> Vec<String> {
     rows.push(String::new());
     rows.push(format!("{EMERALD}Available Adapters{RESET}"));
     rows.push(
-        "  node:    express, fastify, koa, hono, nestjs, nextjs, sveltekit, astro, nuxt, bun".to_string(),
+        "  node:    express, fastify, koa, hono, nestjs, nextjs, sveltekit, astro, nuxt, bun"
+            .to_string(),
     );
     rows.push("  python:  fastapi, litestar, django, flask".to_string());
     rows.push("  go:      gin, echo, chi, fiber, nethttp".to_string());

--- a/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/welcome.rs
@@ -1,4 +1,4 @@
-//! Claude-Code-shaped welcome screen for `arcis` no-args on TTY.
+//! Welcome screen for `arcis` no-args on TTY.
 //!
 //! Layout: a single unified rounded box with the title embedded in the
 //! top border, an internal vertical divider, and two side-by-side
@@ -23,7 +23,7 @@ const EMERALD: &str = "\x1b[38;2;0;153;109m";
 const DIM: &str = "\x1b[2m";
 const RESET: &str = "\x1b[0m";
 
-// Box character set. Rounded corners + thin lines mirrors Claude Code.
+// Box character set. Rounded corners + thin lines.
 const TL: &str = "\u{256D}"; // ╭
 const TR: &str = "\u{256E}"; // ╮
 const BL: &str = "\u{2570}"; // ╰
@@ -269,7 +269,7 @@ fn build_right() -> Vec<String> {
     rows.push(String::new());
     rows.push(format!("{EMERALD}Available Adapters{RESET}"));
     rows.push(
-        "  node:    express, fastify, koa, nestjs, nextjs, sveltekit, astro, nuxt, bun".to_string(),
+        "  node:    express, fastify, koa, hono, nestjs, nextjs, sveltekit, astro, nuxt, bun".to_string(),
     );
     rows.push("  python:  fastapi, litestar, django, flask".to_string());
     rows.push("  go:      gin, echo, chi, fiber, nethttp".to_string());

--- a/website/changelog.json
+++ b/website/changelog.json
@@ -41,7 +41,7 @@
     {
       "version": "1.5.2",
       "date": "2026-05-21",
-      "summary": "arcis CLI welcome screen (Claude-Code-shape, emerald, burst mascot) + Python pip-install-arcis shim restoration.",
+      "summary": "arcis CLI welcome screen (rounded TUI, emerald, burst mascot) + Python pip-install-arcis shim restoration.",
       "packages": ["arcis (PyPI)", "@arcis/node", "@arcis/cli (npm, native binary)"]
     },
     {

--- a/website/documentation/comparisons/vs-arcjet.html
+++ b/website/documentation/comparisons/vs-arcjet.html
@@ -116,7 +116,7 @@
       <h2 id="where-they-win">Where Arcjet wins</h2>
       <ul>
         <li><strong>Wasm-based local ML for AI rules.</strong> Arcjet ships a closed Wasm blob that runs locally and evaluates richer signals than pattern matching. For prompt-injection detection at the highest accuracy bar, that's a real edge over a signature library.</li>
-        <li><strong>Mature distribution.</strong> Polished editor plugins (Cursor, Claude Code), longer track record, and a paid managed control plane that some teams prefer not to operate themselves. They started in 2023 and have had time to build the ecosystem.</li>
+        <li><strong>Mature distribution.</strong> Polished editor plugins for popular IDEs, longer track record, and a paid managed control plane that some teams prefer not to operate themselves. They started in 2023 and have had time to build the ecosystem.</li>
         <li><strong>Funded team.</strong> $12M raised across Seed and Series A. They will keep shipping. If you're picking a vendor for a five-year procurement window, that matters.</li>
       </ul>
 

--- a/website/documentation/coverage.html
+++ b/website/documentation/coverage.html
@@ -160,7 +160,7 @@
         </tbody>
       </table>
 
-      <p>The MCP server (<code>@arcis/mcp</code>) exposes <code>arcis_audit</code>, <code>arcis_sca</code>, <code>arcis_scan</code>, and <code>arcis_detect_prompt_injection</code> as MCP tools that Cursor, Claude Code, and any MCP-aware agent can call.</p>
+      <p>The MCP server (<code>@arcis/mcp</code>) exposes <code>arcis_audit</code>, <code>arcis_sca</code>, <code>arcis_scan</code>, and <code>arcis_detect_prompt_injection</code> as MCP tools that Cursor and any MCP-aware AI agent can call.</p>
 
       <h2 id="cli">CLI coverage</h2>
 

--- a/website/documentation/repl.html
+++ b/website/documentation/repl.html
@@ -117,7 +117,7 @@
         <li>Console commands list (<code>/help</code>, <code>/clear</code>, <code>/cwd</code>, <code>/export</code>, <code>/exit</code>)</li>
         <li>Keymap hint (Ctrl-C cancels; PgUp/PgDn scrolls; F2 jumps to next finding)</li>
       </ul>
-      <p>The banner is part of scrollback (not a fixed header), so it slides off-screen as work accumulates. Same shape as Claude Code's session welcome.</p>
+      <p>The banner is part of scrollback (not a fixed header), so it slides off-screen as work accumulates.</p>
 
       <h2 id="commands">Commands</h2>
       <p>Anything that does not start with <code>/</code> runs as <code>arcis &lt;cmd&gt;</code>:</p>

--- a/website/index.html
+++ b/website/index.html
@@ -1256,7 +1256,7 @@
       </h1>
 
       <p class="hero-sub">
-        Arcis blocks XSS, SQL injection, SSRF, CSRF, prompt injection, bot traffic, and 20+ more attack types before your handler runs. Twelve framework adapters across Node, Python, and Go. Fully open-source. No cloud dependency. No closed binaries. No agent.
+        Arcis blocks XSS, SQL injection, SSRF, CSRF, prompt injection, bot traffic, and 20+ more attack types before your handler runs. Nineteen framework adapters across Node, Python, and Go. Fully open-source. No cloud dependency. No closed binaries. No agent.
       </p>
 
       <div class="hero-actions">


### PR DESCRIPTION
## Summary

Real packaging bug + an honest-claims sweep, batched onto the v1.6.1 release that PR #147 will carry to main.

### Real bug: `@arcis/node` adapter subpath types broken

Nine framework-adapter subpaths (`./fastify`, `./koa`, `./nestjs`, `./nextjs`, `./sveltekit`, `./astro`, `./nuxt`, `./bun`, `./hono`) declared their TypeScript types at `./dist/<name>/index.d.ts`, but `tsc --emitDeclarationOnly` preserves the src layout, so the actual `.d.ts` files live at `./dist/middleware/<name>.d.ts`. JS runtime resolution worked (tsup emits .js/.mjs at the declared paths); only TypeScript type resolution failed with `TS7016 Could not find a declaration file`. Has been broken since these subpaths shipped.

Fix is purely the exports-map paths. Verified locally by:
- `npm pack --dry-run` shows all .d.ts files present at the new paths
- Local `tsc --noEmit` against a file-ref install of the rebuilt package resolves `@arcis/node/nextjs` types correctly

Version bumped 1.6.0 → 1.6.1 (patch — packaging-only, no runtime behavior change).

### Honest-claims sweep (24 files, all main repo)

The 8 Edge / Web-Fetch Node adapters (Fastify, Koa, Hono, Next.js, SvelteKit, Astro, Nuxt, Bun) were advertised everywhere as if they had Express-equivalent attack-vector coverage. They do not. Only Express + NestJS run the full sanitizer pipeline; the other 8 ship rate-limit + bot + headers only. Public copy fixed across:

- README Features bullet + Supported Frameworks table (split into "full-pipeline" vs "edge/narrow-scope")
- `@arcis/node` package description rewritten
- 7 adapter source files got a `**Scope:**` paragraph at the top of the module docstring (Fastify was the existing template)
- Adapter count math (12 → 19 in README + website)
- Python README "30+ attack vectors" → "20+"
- pyproject.toml "646-pattern bot corpus" → "635" + added Litestar
- welcome.rs adapter list: added Hono

### Claude Code branding removed (rule #1)

11 mentions across 11 files (5 public-facing + 6 source comments). Kept 2 threat-db entries that reference `~/.claude/` as a malware persistence target — that's defender-side threat intel, the opposite of promotion.

## Test plan

- [x] `@arcis/node` build green
- [x] `npm pack --dry-run` shows correct .d.ts paths
- [x] Local TS sandbox resolves `@arcis/node/nextjs` types
- [ ] After this PR merges to nwl, PR #147 (nwl → main, squash) triggers publish.yml → `@arcis/node@1.6.1` lands on npm with the corrected exports map