### PR TITLE
feat(v1.6.2 D4): Q8 LDAP NOT-bypass + Q10 mail-header + FastAPI protect_login factory

### DIFF
--- a/packages/arcis-go/sanitizers/data/patterns.json
+++ b/packages/arcis-go/sanitizers/data/patterns.json
@@ -405,6 +405,14 @@
           "description": "Detects attack-specific LDAP filter-break shapes ')(' and '*)('. Safe to wire into request-boundary scanners. Catches '*)(uid=*))(|(uid=*' style payloads.",
           "redos_safe": true,
           "request_boundary_safe": true
+        },
+        {
+          "id": "ldap-not-bypass",
+          "pattern": "\\)\\s*\\(\\s*!|&\\s*\\(\\s*!|\\|\\s*\\(\\s*!",
+          "flags": "g",
+          "description": "Detects LDAP NOT-operator bypass shapes ')(!', '&(!', and '|(!'. Catches injections where attacker appends a NOT clause to enumerate or exclude specific entries, e.g. '*)(uid=*)(!(uid=admin))'. Companion to ldap-injection-strict; together they cover the OR-then-NOT enumeration corpus that legitimate LDAP queries never produce. (improvements.md Q8.)",
+          "redos_safe": true,
+          "request_boundary_safe": true
         }
       ]
     },
@@ -433,6 +441,14 @@
           "pattern": "(\\r\\n|\\r|\\n)\\s*(bcc|cc|to|from|subject|reply-to|return-path|content-type|x-mailer)\\s*:",
           "flags": "gi",
           "description": "Detects SMTP header injection: CR/LF followed by a known SMTP header keyword. Narrow enough for request-boundary scanning because legitimate user input rarely contains '\\nBcc:' verbatim.",
+          "redos_safe": true,
+          "request_boundary_safe": true
+        },
+        {
+          "id": "email-header-bare-newline",
+          "pattern": "(\\r\\n|\\r|\\n)\\s*[a-z][a-z0-9-]{0,40}\\s*:",
+          "flags": "gi",
+          "description": "Detects bare CR/LF followed by ANY plausible header keyword (not just the SMTP allowlist). Catches MTAs that accept bare LF or bare CR as a header separator (qmail, sendmail variants), where attacker bypasses the strict keyword list by injecting a non-SMTP-keyword header (X-Custom, Authentication-Results, DKIM-Signature, ...). Companion to email-header-smtp-keyword; together they cover the bypass class. (improvements.md Q10.)",
           "redos_safe": true,
           "request_boundary_safe": true
         }

--- a/packages/arcis-node/src/sanitizers/ldap.ts
+++ b/packages/arcis-node/src/sanitizers/ldap.ts
@@ -22,6 +22,13 @@ const LDAP_DETECT_PATTERN = /[*()\\\x00]/;
 // Detection pattern for OR/AND bypass and wildcard abuse
 const LDAP_INJECTION_PATTERN = /\)\s*\(|\*\s*\)\s*\(/;
 
+// Detection pattern for LDAP NOT-operator bypass (improvements.md Q8).
+// Catches ')(!', '&(!', '|(!' shapes that legitimate filters never contain;
+// these are the attacker's NOT-clause appended to enumerate or exclude
+// entries (e.g. '*)(uid=*)(!(uid=admin))'). Companion to
+// LDAP_INJECTION_PATTERN; together they cover the OR-then-NOT corpus.
+const LDAP_NOT_BYPASS_PATTERN = /\)\s*\(\s*!|&\s*\(\s*!|\|\s*\(\s*!/;
+
 const escapeChar = (char: string) => '\\' + char.charCodeAt(0).toString(16).padStart(2, '0');
 
 /**
@@ -63,5 +70,9 @@ export function sanitizeLdapDn(input: string): string {
  */
 export function detectLdapInjection(input: string): boolean {
   if (typeof input !== 'string') return false;
-  return LDAP_DETECT_PATTERN.test(input) || LDAP_INJECTION_PATTERN.test(input);
+  return (
+    LDAP_DETECT_PATTERN.test(input) ||
+    LDAP_INJECTION_PATTERN.test(input) ||
+    LDAP_NOT_BYPASS_PATTERN.test(input)
+  );
 }

--- a/packages/arcis-node/tests/sanitizers/ldap.test.ts
+++ b/packages/arcis-node/tests/sanitizers/ldap.test.ts
@@ -96,6 +96,19 @@ describe('detectLdapInjection', () => {
     expect(detectLdapInjection('ad\x00min')).toBe(true);
   });
 
+  // improvements.md Q8 — LDAP NOT-operator bypass corpus.
+  it('detects NOT-bypass after OR escape: )(!', () => {
+    expect(detectLdapInjection('*)(uid=*)(!(uid=admin))')).toBe(true);
+  });
+
+  it('detects NOT-bypass after AND: &(!', () => {
+    expect(detectLdapInjection('foo&(!(role=anon))')).toBe(true);
+  });
+
+  it('detects NOT-bypass after pipe: |(!', () => {
+    expect(detectLdapInjection('foo|(!(deleted=true))')).toBe(true);
+  });
+
   it('returns false for safe input', () => {
     expect(detectLdapInjection('johndoe')).toBe(false);
     expect(detectLdapInjection('john.doe@example.com')).toBe(false);

--- a/packages/arcis-python/arcis/fastapi.py
+++ b/packages/arcis-python/arcis/fastapi.py
@@ -806,7 +806,7 @@ def create_rate_limit_dependency(
         skip_func=skip_func,
         store=store,
     )
-    
+
     async def rate_limit_dependency(request: Request):
         try:
             info = await limiter.check(request)
@@ -819,5 +819,69 @@ def create_rate_limit_dependency(
                 detail={"error": e.message, "retry_after": e.retry_after},
                 headers={"Retry-After": str(e.retry_after)},
             )
-    
+
     return rate_limit_dependency
+
+
+# improvements.md §1.4 — per-framework protect_login factory for FastAPI.
+def create_login_protection_dependency(
+    *,
+    username_field: str = "username",
+    password_field: str = "password",
+    require_credentials: bool = True,
+    check_bot: bool = True,
+    allowed_bot_categories: Optional[List[str]] = None,
+    correlation_window: Any = None,
+    route: str = "/login",
+):
+    """
+    Create a FastAPI dependency that runs check_login() and raises
+    HTTPException on rejection.
+
+    Wraps arcis.check_login (which is framework-agnostic) into the
+    FastAPI Depends() shape, including IP extraction from request.client
+    so callers don't have to pull it manually.
+
+    Usage:
+        from fastapi import FastAPI, Depends
+        from arcis.fastapi import create_login_protection_dependency
+        from arcis.middleware.correlation import CorrelationWindow
+
+        cw = CorrelationWindow()
+        login_protect = create_login_protection_dependency(
+            correlation_window=cw,
+            route="/login",
+        )
+
+        @app.post("/login", dependencies=[Depends(login_protect)])
+        async def login(req: Request):
+            ...
+
+    On rejection the dependency raises HTTPException(429) with
+    detail = {"reason": "<bot|missing_credentials|correlation>",
+              "details": {...}}.
+    """
+    from .middleware.protect_login import check_login as _check_login
+
+    async def login_protection_dependency(request: Request):
+        client_ip = request.client.host if request.client else None
+        result = _check_login(
+            request,
+            username_field=username_field,
+            password_field=password_field,
+            require_credentials=require_credentials,
+            check_bot=check_bot,
+            allowed_bot_categories=allowed_bot_categories,
+            correlation_window=correlation_window,
+            client_ip=client_ip,
+            route=route,
+        )
+        if not result.allowed:
+            from fastapi import HTTPException
+            raise HTTPException(
+                status_code=429,
+                detail={"reason": result.reason, "details": result.details},
+            )
+        return result
+
+    return login_protection_dependency

--- a/packages/arcis-python/arcis/fastapi.py
+++ b/packages/arcis-python/arcis/fastapi.py
@@ -8,7 +8,7 @@ import time
 import json
 import asyncio
 import logging
-from typing import Callable, Optional, Dict, Any, Protocol
+from typing import Callable, Optional, Dict, Any, List, Protocol
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response, JSONResponse

--- a/packages/arcis-python/arcis/sanitizers/ldap.py
+++ b/packages/arcis-python/arcis/sanitizers/ldap.py
@@ -16,6 +16,12 @@ _LDAP_DETECT = re.compile(r'[*()\\\x00]')
 # Detection: OR/AND bypass and wildcard abuse patterns
 _LDAP_INJECTION = re.compile(r'\)\s*\(|\*\s*\)\s*\(')
 
+# Detection: LDAP NOT-operator bypass (improvements.md Q8). Catches
+# ')(!', '&(!', '|(!' shapes that legitimate filters never produce;
+# attacker appends a NOT clause to enumerate or exclude entries (e.g.
+# '*)(uid=*)(!(uid=admin))').
+_LDAP_NOT_BYPASS = re.compile(r'\)\s*\(\s*!|&\s*\(\s*!|\|\s*\(\s*!')
+
 # Filter chars per RFC 4515
 _FILTER_CHARS = re.compile(r'[*()\\\x00]')
 
@@ -84,7 +90,11 @@ def detect_ldap_injection(value: str) -> bool:
     """
     if not isinstance(value, str):
         return False
-    return bool(_LDAP_DETECT.search(value) or _LDAP_INJECTION.search(value))
+    return bool(
+        _LDAP_DETECT.search(value)
+        or _LDAP_INJECTION.search(value)
+        or _LDAP_NOT_BYPASS.search(value)
+    )
 
 
 def detect_ldap_injection_strict(value: str) -> bool:
@@ -113,4 +123,4 @@ def detect_ldap_injection_strict(value: str) -> bool:
     """
     if not isinstance(value, str):
         return False
-    return bool(_LDAP_INJECTION.search(value))
+    return bool(_LDAP_INJECTION.search(value) or _LDAP_NOT_BYPASS.search(value))

--- a/packages/arcis-python/tests/sanitizers/test_ldap.py
+++ b/packages/arcis-python/tests/sanitizers/test_ldap.py
@@ -77,6 +77,16 @@ class TestDetectLdapInjection:
     def test_detects_nul_byte(self):
         assert detect_ldap_injection("ad\x00min") is True
 
+    # improvements.md Q8 — NOT-bypass corpus.
+    def test_detects_not_bypass_after_or_escape(self):
+        assert detect_ldap_injection("*)(uid=*)(!(uid=admin))") is True
+
+    def test_detects_not_bypass_after_and(self):
+        assert detect_ldap_injection("foo&(!(role=anon))") is True
+
+    def test_detects_not_bypass_after_pipe(self):
+        assert detect_ldap_injection("foo|(!(deleted=true))") is True
+
     def test_returns_false_for_safe_input(self):
         assert detect_ldap_injection("johndoe") is False
         assert detect_ldap_injection("john.doe@example.com") is False

--- a/packages/core/patterns.json
+++ b/packages/core/patterns.json
@@ -405,6 +405,14 @@
           "description": "Detects attack-specific LDAP filter-break shapes ')(' and '*)('. Safe to wire into request-boundary scanners. Catches '*)(uid=*))(|(uid=*' style payloads.",
           "redos_safe": true,
           "request_boundary_safe": true
+        },
+        {
+          "id": "ldap-not-bypass",
+          "pattern": "\\)\\s*\\(\\s*!|&\\s*\\(\\s*!|\\|\\s*\\(\\s*!",
+          "flags": "g",
+          "description": "Detects LDAP NOT-operator bypass shapes ')(!', '&(!', and '|(!'. Catches injections where attacker appends a NOT clause to enumerate or exclude specific entries, e.g. '*)(uid=*)(!(uid=admin))'. Companion to ldap-injection-strict; together they cover the OR-then-NOT enumeration corpus that legitimate LDAP queries never produce. (improvements.md Q8.)",
+          "redos_safe": true,
+          "request_boundary_safe": true
         }
       ]
     },
@@ -433,6 +441,14 @@
           "pattern": "(\\r\\n|\\r|\\n)\\s*(bcc|cc|to|from|subject|reply-to|return-path|content-type|x-mailer)\\s*:",
           "flags": "gi",
           "description": "Detects SMTP header injection: CR/LF followed by a known SMTP header keyword. Narrow enough for request-boundary scanning because legitimate user input rarely contains '\\nBcc:' verbatim.",
+          "redos_safe": true,
+          "request_boundary_safe": true
+        },
+        {
+          "id": "email-header-bare-newline",
+          "pattern": "(\\r\\n|\\r|\\n)\\s*[a-z][a-z0-9-]{0,40}\\s*:",
+          "flags": "gi",
+          "description": "Detects bare CR/LF followed by ANY plausible header keyword (not just the SMTP allowlist). Catches MTAs that accept bare LF or bare CR as a header separator (qmail, sendmail variants), where attacker bypasses the strict keyword list by injecting a non-SMTP-keyword header (X-Custom, Authentication-Results, DKIM-Signature, ...). Companion to email-header-smtp-keyword; together they cover the bypass class. (improvements.md Q10.)",
           "redos_safe": true,
           "request_boundary_safe": true
         }


### PR DESCRIPTION
## Summary

Three small additions piggybacking on the v1.6.2 cohort. Pattern hardenings deferred from v1.6 + the canonical template for the per-framework protect_login factories that v1.7 will finish.

### Q8 — LDAP NOT-operator bypass

`patterns.json` `ldap_injection` gains `ldap-not-bypass`. Catches `)(!`, `&(!`, `|(!` shapes that legitimate filters never produce; attacker appends a NOT clause after an OR/AND escape to enumerate or exclude entries (`*)(uid=*)(!(uid=admin))`).

- Node: `LDAP_NOT_BYPASS_PATTERN` in `ldap.ts`. `detectLdapInjection` now ORs all three patterns. +3 tests.
- Python: `_LDAP_NOT_BYPASS` in `ldap.py`. Both `detect_ldap_injection` AND `detect_ldap_injection_strict` now check it. +3 tests.
- Go: auto-picks-up via the runtime `patterns.json` loader; bundled copy synced + SHA-256 check satisfied.

### Q10 — mail-header bare-newline bypass

`patterns.json` `email_header_injection` gains `email-header-bare-newline`. Catches CR/LF followed by ANY plausible header keyword shape (not just the SMTP allowlist). Closes the bypass where qmail / sendmail variants accept bare LF as a header separator and attacker injects a non-SMTP-keyword header.

Node's existing `detectHeaderInjection` already catches any raw CR/LF/NUL byte (broader than this Q10 rule), so the Node detection surface is already strong. Python similarly. The patterns.json addition exists for Go's runtime loader and any future cross-SDK conformance audit.

### FastAPI `create_login_protection_dependency`

Per-framework sugar for the v1.6 `check_login` pipeline. Wraps the framework-agnostic detector into a FastAPI Depends() shape, including automatic client-IP extraction from `request.client`.

Usage:

\`\`\`py
from arcis.fastapi import create_login_protection_dependency
from arcis.middleware.correlation import CorrelationWindow

cw = CorrelationWindow()
login_protect = create_login_protection_dependency(correlation_window=cw)

@app.post('/login', dependencies=[Depends(login_protect)])
async def login(req: Request): ...
\`\`\`

Same shape as the existing `create_rate_limit_dependency` in `arcis.fastapi`. The Litestar / Django / Gin / Echo / chi / Fiber / nethttp variants are mechanical from here and deferred to v1.7 per the original improvements.md §1.4 note (touches 9 separate adapter files).

## Test plan

- [x] Node: 3 new LDAP NOT-bypass tests in `ldap.test.ts`
- [x] Python: 3 new LDAP NOT-bypass tests in `test_ldap.py`
- [x] Go: bundled `patterns.json` synced; existing `TestBundledPatternsMatchCanonical` covers parity
- [ ] CI: full matrix run on this PR
- [ ] After merge to nwl + nwl→main, v1.6.2 ships:
  - `@arcis/node` and `arcis` Python both bump for the Q8 changes
  - Go module tag `v1.6.2`