### PR TITLE
ci(pack-and-attack): pre-build gin binaries so boot wait does not race the compile

### DIFF
--- a/.github/workflows/pack-and-attack.yml
+++ b/.github/workflows/pack-and-attack.yml
@@ -360,23 +360,33 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.25"
+          cache-dependency-path: example/go.sum
       - name: Point example at local SDK
         working-directory: example
         run: |
           go mod edit -replace="github.com/GagancM/arcis=$GITHUB_WORKSPACE/arcis/packages/arcis-go"
           go mod tidy
           cat go.mod
+      - name: Pre-build server + attack binaries
+        # Front-load the compile so the boot-wait timer below does not
+        # race against go run's cold-cache build. Cold gin-stack compile
+        # can take 25-30s; the previous `go run . &` + 30s wait loop hit
+        # this exact race on PR #154's first push.
+        working-directory: example
+        run: |
+          go build -o /tmp/arcis-gin-server .
+          go build -tags attack -o /tmp/arcis-gin-attack attack.go
       - name: Boot server + fire attack
         working-directory: example
         run: |
-          go run . &
+          /tmp/arcis-gin-server &
           SERVER_PID=$!
-          for i in $(seq 1 30); do
+          for i in $(seq 1 60); do
             if curl -fs http://localhost:8080/ >/dev/null 2>&1; then break; fi
             sleep 1
           done
           curl -fs http://localhost:8080/ >/dev/null || { echo "Server did not boot"; kill $SERVER_PID || true; exit 1; }
-          go run -tags attack attack.go
+          /tmp/arcis-gin-attack
           ATTACK_EXIT=$?
           kill $SERVER_PID || true
           exit $ATTACK_EXIT


### PR DESCRIPTION
## Summary

PR #154's first push-context run failed because the gin attack job timed out at "Server did not boot". Root cause was a three-way miss:

1. `actions/setup-go@v5` cache missed. It looks at the workspace root for `go.sum` by default, but the example's `go.sum` lives at `example/go.sum`. Cold cache forced a full download of about 40 modules during `go mod tidy`.
2. The follow-on `go run .` then began a full compile of the gin + arcis-go stack inside the 30-second boot-wait window.
3. The boot-wait timer fired before the binary started serving. Job marked failure.

A `workflow_dispatch` retry on the same nwl SHA passed (run 26555138962) because the module cache from the first failed run was warm. The fix is to make the success path the default rather than the warm-cache lucky path.

## What changed

`.github/workflows/pack-and-attack.yml` (gin job only):

- `cache-dependency-path: example/go.sum` on the `setup-go-v5` step. Module cache populates and reuses across runs.
- New `Pre-build server + attack binaries` step. Runs `go build -o /tmp/arcis-gin-server .` and `go build -tags attack -o /tmp/arcis-gin-attack attack.go` ahead of the boot loop. The boot-wait now races only against binary startup, which is sub-second.
- Bumped the boot-wait loop from 30 to 60 iterations as a belt-and-braces safety margin.

No SDK code changes. No version bump. Workflow file only.

## Test plan

- [ ] After this merges to nwl, the push trigger fires a fresh pack-and-attack run.
- [ ] gin job completes in under 45 seconds.
- [ ] All 7 attack jobs green.
- [ ] PR #154's status rollup refreshes (the head ref is nwl; the new push run produces a check-run on the new nwl tip).