### PR TITLE
ci: cut runner minutes across four workflows

### DIFF
--- a/.github/workflows/cli-install-smoke.yml
+++ b/.github/workflows/cli-install-smoke.yml
@@ -6,7 +6,10 @@ name: CLI install smoke
 # this job goes red the next morning instead of staying broken for weeks
 # until a user reports a 404.
 #
-# Triggered: 06:00 UTC daily + workflow_dispatch for on-demand runs.
+# Triggered: 06:00 UTC on the 1st of each month + workflow_dispatch
+# for on-demand runs. Previously daily; reduced to monthly to cut
+# macOS/Windows runner minutes (~86% reduction). Manually trigger
+# before each release if the CLI install path changed.
 #
 # What it verifies on each host:
 #   1. `npm install -g @arcis/cli` succeeds + postinstall completes
@@ -22,7 +25,7 @@ name: CLI install smoke
 
 on:
   schedule:
-    - cron: "0 6 * * *"
+    - cron: "0 6 1 * *"  # Monthly: 1st of each month at 06:00 UTC
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,22 @@ name: CI
 on:
   push:
     branches: [nwl]
+    paths-ignore:
+      - "**.md"
+      - "documents/**"
+      - "blog/**"
+      - "LICENSE"
+      - "NOTICE"
+      - "THIRDPARTY-LICENSES.md"
   pull_request:
     branches: [nwl]
+    paths-ignore:
+      - "**.md"
+      - "documents/**"
+      - "blog/**"
+      - "LICENSE"
+      - "NOTICE"
+      - "THIRDPARTY-LICENSES.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pack-and-attack.yml
+++ b/.github/workflows/pack-and-attack.yml
@@ -19,8 +19,22 @@ name: Pack and Attack QA
 on:
   push:
     branches: [nwl, main]
+    paths-ignore:
+      - "**.md"
+      - "documents/**"
+      - "blog/**"
+      - "LICENSE"
+      - "NOTICE"
+      - "THIRDPARTY-LICENSES.md"
   pull_request:
     branches: [nwl]
+    paths-ignore:
+      - "**.md"
+      - "documents/**"
+      - "blog/**"
+      - "LICENSE"
+      - "NOTICE"
+      - "THIRDPARTY-LICENSES.md"
   # Allow manual trigger for ad-hoc verification
   workflow_dispatch:
 

--- a/.github/workflows/pre-publish-smoke.yml
+++ b/.github/workflows/pre-publish-smoke.yml
@@ -22,11 +22,16 @@ name: Pre-publish smoke
 
 on:
   pull_request:
-    branches: [nwl, main]
+    # Limited to release PRs (target main) to cut macOS/Windows runner
+    # minutes. CLI/shim PRs to nwl land first; the release PR (nwl -> main)
+    # is the right gate to catch Windows shim crashes before publish.
+    # Manually trigger via workflow_dispatch for ad-hoc validation.
+    branches: [main]
     paths:
       - "packages/arcis-python/**"
       - "packages/arcis-cli-npm/**"
       - ".github/workflows/pre-publish-smoke.yml"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Four GitHub Actions changes targeting macOS + Windows runner cost. Linux runners remain free on public repos regardless. The goal is to reduce ongoing macOS/Windows minute usage by ~70-80% with minimal risk to release-gate coverage.

## Changes

### 1. cli-install-smoke.yml: daily → monthly

Was: cron `0 6 * * *` (every day at 06:00 UTC, ~365 runs/year × 5 OSes).
Now: cron `0 6 1 * *` (1st of each month at 06:00 UTC, 12 runs/year × 5 OSes).

The job catches post-publish breakage of `npm install -g @arcis/cli` / `pip install arcis`. Daily was overkill given we ship every 2-3 weeks. Monthly still catches breakage well before the next release window. `workflow_dispatch` remains for manual runs before releases.

Estimated saving: ~86% of this workflow's macOS/Windows minutes (~770 weighted minutes/month).

### 2. main.yml: added paths-ignore

Docs-only PRs (\`.md\` / \`documents/\` / \`blog/\` / \`LICENSE\` / \`NOTICE\`) now skip the full Node + Python + Go test suite. Saves Linux minutes (free) but also speeds up dev-loop feedback on doc changes.

### 3. pack-and-attack.yml: added paths-ignore

Same paths-ignore as main.yml. The 10-job pack-and-attack workflow doesn't need to run on README edits.

### 4. pre-publish-smoke.yml: PR to main only

Was: PRs to \`[nwl, main]\` that touch CLI/shim paths, including macOS + Windows matrix.
Now: PRs to \`[main]\` only. CLI/shim PRs land on nwl first; the nwl → main release PR is the right gate to catch Windows shim crashes before publish. `workflow_dispatch` added for ad-hoc validation.

## What does NOT change

- All unit tests still run on every nwl PR (Linux only, already free)
- pack-and-attack QA still runs on every code-affecting PR
- rust-release.yml unchanged (tag-only trigger, cost locked to release frequency)
- publish.yml unchanged (push-to-main only, infrequent)
- Linux minute usage unchanged (free regardless)

## Estimated impact

- Daily macOS/Windows minutes: ~30 multi-OS smoke runs/month → ~1 multi-OS smoke run/month
- Pre-publish-smoke macOS/Windows: ~10 PR runs/month → ~2-3 release-PR runs/month
- Combined: ~70-80% reduction in macOS/Windows runner minutes

## Test plan

- [ ] After merge, watch first 24h: no scheduled cli-install-smoke run should fire (next is the 1st of next month)
- [ ] Push a docs-only commit to nwl after merge: main.yml + pack-and-attack should NOT trigger
- [ ] Push a code commit to nwl: main.yml + pack-and-attack should trigger normally
- [ ] Open a release PR (nwl → main): pre-publish-smoke should trigger on the release PR
- [ ] Manually dispatch cli-install-smoke before the next release: all 5 OS jobs should run

## Risk

Low. Each change preserves the catch-bug safety net at release time:
- Daily smoke moved to monthly: caught by manual dispatch before each release
- Pre-publish-smoke removed from nwl PRs: caught on the release PR before publish
- Paths-ignore for docs: pure cleanup, no code paths skipped