### PR TITLE
chore: bump versions for v1.6.4 org-transfer release

### DIFF
--- a/packages/arcis-cli-npm/package.json
+++ b/packages/arcis-cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Arcis security CLI — scan running apps, audit source, and check dependencies. Native Rust binary distributed via npm.",
   "keywords": [
     "security",

--- a/packages/arcis-mcp/package.json
+++ b/packages/arcis-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/mcp",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Arcis MCP server. Exposes Arcis CLI scanners (audit / scan / sca) and the prompt-injection detector as tools that Cursor and any other MCP-aware AI agent can call. One install, four tools, zero cloud round trip.",
   "main": "dist/server.js",
   "bin": {

--- a/packages/arcis-node/package.json
+++ b/packages/arcis-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/node",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Inside-the-app security middleware for Node.js. Express and NestJS run the full sanitizer pipeline (XSS, SQL, NoSQL, SSTI, XXE, path, command, prompt injection, prototype pollution, LDAP, XPath, header injection, plus 20+ more attack types). Fastify, Koa, Hono, Next.js, SvelteKit, Astro, Nuxt, and Bun ship rate-limit + bot detection + security headers as v1 adapters; pair them with `sanitizeObject` from @arcis/node/sanitizers for body inspection. v1.6 ships interactive REPL, NFKC + multi-decode hardening, deserialization markers (V33), GraphQL alias-bomb guard (V34), and a stateful per-IP correlation window. Includes prompt-injection signature library, LLM token-budget middleware, 695-pattern bot corpus, and the @arcis/cli native CLI.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/arcis-python/arcis/__init__.py
+++ b/packages/arcis-python/arcis/__init__.py
@@ -197,7 +197,7 @@ try:
 except ImportError:
     _HAS_ASYNC = False
 
-__version__ = "1.6.3"
+__version__ = "1.6.4"
 __all__ = [
     # Main class
     "Arcis",

--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arcis"
-version = "1.6.3"
+version = "1.6.4"
 description = "Inside-the-app security middleware for Python. FastAPI, Django, Litestar run the full sanitizer pipeline (XSS, SQL, NoSQL, path, command, SSTI, XXE, LDAP, XPath, email-header, prototype). Flask is sanitize-only. Opt-in helpers: 695-bot corpus, CSRF, HPP, SSRF URL validation, prompt-injection signatures (V32 toolcall, V33 deserialization, V34 GraphQL), per-IP correlation window, LLM token-budget. Same API as the Node and Go SDKs. CLI ships at npm install -g @arcis/cli."
 readme = "README.md"
 license = "MIT"

--- a/packages/arcis-rust/Cargo.toml
+++ b/packages/arcis-rust/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "MIT"
 authors = ["Gagan CM <cm.g@northeastern.edu>"]


### PR DESCRIPTION
## Summary

Per-package version bumps to ship the org-rename metadata changes (PRs #168 + #169) to npm + PyPI. Lands on nwl first; a separate release PR will promote nwl to main.

## Version bumps

| Package | From | To |
|---|---|---|
| `@arcis/node` | 1.6.3 | **1.6.4** |
| `arcis` (Python) | 1.6.3 | **1.6.4** |
| `@arcis/mcp` | 1.6.0 | **1.6.1** |
| `@arcis/cli` (cli-npm) | 1.1.0 | **1.1.1** |
| `arcis-rust` (Cargo workspace) | 1.1.0 | **1.1.1** |
| `arcis-go` | v1.6.3 | **v1.6.4** tag (auto-created by publish.yml on release) |

## What's in this release (cumulative since v1.6.3)

- **#168 CI optimization** ` cli-install-smoke moved daily to monthly; main.yml and pack-and-attack got paths-ignore for docs; pre-publish-smoke restricted to release PRs only
- **#169 Metadata rename** ` package.json + pyproject.toml + Cargo.toml + READMEs all updated from Gagancm/arcis to getarcis/arcis; @arcis/cli binary download URL constant updated; gagancm.github.io doc links redirected to arcis-website.pages.dev

## What changes for users after v1.6.4 publishes

| Surface | New value |
|---|---|
| npmjs.com Repository link | github.com/getarcis/arcis |
| npmjs.com Homepage | arcis-website.pages.dev |
| pypi.org Homepage / Repository / Documentation | github.com/getarcis/arcis + wiki |
| README rendered on registry pages | All links reference getarcis/arcis |
| `@arcis/cli@1.1.1` binary downloads | From github.com/getarcis/arcis/releases |

## What does NOT change

- Functional behavior: identical to v1.6.3
- Package ownership on npm and PyPI: unchanged (same gagan account)
- Download counts: persist (1,549 npm and 6,931 PyPI lifetime)
- Go SDK module path: still github.com/GagancM/arcis (the path rename is deferred to a future v2.0.0 with /v2 suffix per Go semver)

## After this merges to nwl

Open a separate release PR (nwl to main) with a "release: v1.6.4" title. Squash and merge that release PR. publish.yml fires on main push and publishes all five packages.

## Test plan

- [ ] CI green on nwl (all unit tests + pack-and-attack across 10 frameworks)
- [ ] Version strings consistent across all six files
- [ ] No functional changes (review the diff: should be exactly six version-string lines)