### PR TITLE
fix(detect): close 5 benchmark FP classes + 3 path-traversal pattern gaps

### DIFF
--- a/packages/arcis-node/src/core/constants.ts
+++ b/packages/arcis-node/src/core/constants.ts
@@ -150,10 +150,37 @@ export const XSS_REMOVE_PATTERNS = [
 // SQL INJECTION PATTERNS
 // =============================================================================
 export const SQL_PATTERNS = [
-  /** SQL keywords */
-  /(\b(SELECT|INSERT|UPDATE|DELETE|DROP|UNION|ALTER|CREATE|TRUNCATE|EXEC|EXECUTE)\b)/gi,
-  /** SQL comments: ANSI (--), C-style (slash-star ... star-slash), MySQL (#) */
-  /(--|\/\*|\*\/|#)/g,
+  /**
+   * Multi-token SQL attack shapes that never appear in normal English.
+   * Replaces the older bare-keyword pattern `\b(SELECT|INSERT|...)\b`
+   * which false-positived on natural language ("please select an option",
+   * "I'll update you tomorrow", "delete this file"). Each shape below
+   * is a token combination that real attackers use and benign users
+   * essentially never type. Matches `sqli-keywords` in
+   * packages/core/patterns.json. Benchmark FP class B3, 2026-06-07.
+   *
+   * Catches:
+   *   UNION SELECT / UNION ALL SELECT          (data exfiltration)
+   *   DROP|TRUNCATE TABLE|DATABASE|INDEX|...   (DDL destruction)
+   *   INTO OUTFILE / INTO DUMPFILE             (MySQL file write RCE)
+   *   ATTACH DATABASE                          (SQLite hijack)
+   *   CREATE USER|FUNCTION|TRIGGER|PROCEDURE   (privilege escalation)
+   *   GRANT ALL|SELECT|INSERT|...              (privilege grant)
+   *   xp_cmdshell / sp_executesql              (SQL Server RCE)
+   *   SHUTDOWN                                 (DoS)
+   */
+  /(\bUNION\s+(?:ALL\s+)?SELECT\b)|(\b(?:DROP|TRUNCATE)\s+(?:TABLE|DATABASE|INDEX|VIEW|SCHEMA)\b)|(\bINTO\s+(?:OUTFILE|DUMPFILE)\b)|(\bATTACH\s+DATABASE\b)|(\bCREATE\s+(?:USER|FUNCTION|TRIGGER|PROCEDURE)\b)|(\bGRANT\s+(?:ALL|SELECT|INSERT|UPDATE|DELETE)\b)|(\bSHUTDOWN\b)|(\bxp_cmdshell\b)|(\bsp_executesql\b)/gi,
+  /**
+   * SQL comments: ANSI (--), C-style (slash-star ... star-slash).
+   * MySQL `#` line comment intentionally excluded: a bare `#` matches
+   * every hex color (#FF5300), hashtag (#trending), issue ref (#123),
+   * markdown heading (# Title). Real `admin' #`-style injections are
+   * already caught by the quote/semicolon + keyword/boolean patterns
+   * below — `#` adds nothing as a primary signal and a lot of FP noise.
+   * Matches `sqli-comments` rule in packages/core/patterns.json (which
+   * also excludes `#`). Benchmark FP class B1, found 2026-06-07.
+   */
+  /(--|\/\*|\*\/)/g,
   /** SQL statement separators */
   /(;|\|\||&&)/g,
   /** Boolean injection: OR 1=1 */
@@ -210,6 +237,25 @@ export const PATH_PATTERNS = [
   /\.{2,}[/\\]{2,}/g,
   /** Null byte injection in paths */
   /\0/g,
+  /**
+   * Mixed encoding: literal `..` + URL-encoded slash (`..%2F`).
+   * Existed in old Node SQL_PATTERNS history; restated explicitly here
+   * for parity with patterns.json `path-mixed-encoded`. Benchmark B6.
+   */
+  /\.\.%2[fF]/g,
+  /**
+   * Overlong UTF-8 encoding of `.` (`%C0%AE`). Historic IIS/Apache
+   * decoder bypass — legitimate `.` is always `%2E`; overlong-form
+   * encoding only appears in evasion attempts. Benchmark B6 gap that
+   * neither SDK caught before 2026-06-07.
+   */
+  /%[Cc]0%[Aa][Ee]/g,
+  /**
+   * Windows UNC paths (`\\server\share`) in user input. Legitimate
+   * web-app inputs never contain UNC references; attacker UNC
+   * payloads leak SMB auth or pull remote payloads. Benchmark B6.
+   */
+  /\\\\[A-Za-z0-9_.-]+\\/g,
 ] as const;
 
 // =============================================================================

--- a/packages/arcis-node/src/sanitizers/ldap.ts
+++ b/packages/arcis-node/src/sanitizers/ldap.ts
@@ -10,16 +10,24 @@
  * while making it safe to embed in LDAP queries.
  */
 
-// LDAP filter special characters per RFC 4515 (single pass includes NUL)
+// LDAP filter special characters per RFC 4515 (single pass includes NUL).
+// Used for ESCAPING — broad set is fine here because escaping a benign
+// char is safe; the value just gets a `\xx` representation.
 const LDAP_FILTER_CHARS = /[*()\\\x00]/g;
 
 // LDAP DN special characters per RFC 4514 (single pass includes NUL)
 const LDAP_DN_CHARS = /[,+<>;"=\/\\\x00*()\x00]/g;
 
-// Detection pattern — unescaped LDAP special chars in filter context
-const LDAP_DETECT_PATTERN = /[*()\\\x00]/;
+// Wildcard-value detection: `=*` inside a filter (e.g. `(uid=*)`).
+// Real LDAP filter abuse; legitimate values don't end in `=*`.
+const LDAP_WILDCARD_VALUE_PATTERN = /=\s*\*/;
 
-// Detection pattern for OR/AND bypass and wildcard abuse
+// NUL byte detection — used for LDAP query truncation attacks.
+// Bare `\x00` is suspicious in any field that flows to an LDAP query.
+const LDAP_NUL_PATTERN = /\x00/;
+
+// Detection pattern for OR/AND bypass and wildcard abuse.
+// Real shapes: `*)(uid=*` (break the filter, inject a new clause).
 const LDAP_INJECTION_PATTERN = /\)\s*\(|\*\s*\)\s*\(/;
 
 // Detection pattern for LDAP NOT-operator bypass (improvements.md Q8).
@@ -61,18 +69,31 @@ export function sanitizeLdapDn(input: string): string {
  * Detects potential LDAP injection patterns in a string.
  * Does not sanitize — use sanitizeLdapFilter() or sanitizeLdapDn() for that.
  *
+ * Designed for request-boundary scanning: matches only the specific
+ * shapes real LDAP injection produces. The older broad
+ * `[*()\\\x00]` pattern was removed because it false-positived on
+ * every markdown bold `**bold**`, every parenthesised string, every
+ * apostrophe-in-name. Mirrors the `ldap-injection-strict` +
+ * `ldap-not-bypass` rules from packages/core/patterns.json which are
+ * marked `request_boundary_safe: true`. Benchmark FP class B2, 2026-06-07.
+ *
  * @param input - The string to check
  * @returns True if LDAP injection patterns detected
  *
  * @example
- * detectLdapInjection("*)(uid=*))(|(uid=*")  // true
+ * detectLdapInjection("*)(uid=*))(|(uid=*")  // true  — filter break-out
+ * detectLdapInjection("(uid=*)")              // true  — wildcard value
+ * detectLdapInjection("ad\x00min")            // true  — NUL truncation
+ * detectLdapInjection("**bold**")             // false — markdown
+ * detectLdapInjection("hello *world*")        // false — emphasis
  * detectLdapInjection("john")                 // false
  */
 export function detectLdapInjection(input: string): boolean {
   if (typeof input !== 'string') return false;
   return (
-    LDAP_DETECT_PATTERN.test(input) ||
     LDAP_INJECTION_PATTERN.test(input) ||
-    LDAP_NOT_BYPASS_PATTERN.test(input)
+    LDAP_NOT_BYPASS_PATTERN.test(input) ||
+    LDAP_WILDCARD_VALUE_PATTERN.test(input) ||
+    LDAP_NUL_PATTERN.test(input)
   );
 }

--- a/packages/arcis-node/tests/conformance.test.ts
+++ b/packages/arcis-node/tests/conformance.test.ts
@@ -79,12 +79,26 @@ describe('Conformance: sanitizeString', () => {
       expect(() => sanitizeString('1 OR 1=1', { mode: 'reject' })).toThrow();
     });
 
-    it('must reject SELECT keyword (reject mode)', () => {
-      expect(() => sanitizeString('SELECT * FROM users', { mode: 'reject' })).toThrow();
+    // Updated 2026-06-07 (benchmark FP class B3): bare SELECT / DELETE
+    // FROM no longer reject because they false-positive on natural text
+    // and shared code snippets. Multi-token attack shapes (UNION SELECT,
+    // DROP TABLE, INTO OUTFILE, etc.) remain reject targets.
+    it('must reject UNION SELECT shape (reject mode)', () => {
+      expect(() => sanitizeString('1 UNION SELECT password FROM users', { mode: 'reject' })).toThrow();
     });
 
-    it('must reject DELETE keyword (reject mode)', () => {
-      expect(() => sanitizeString('1; DELETE FROM users', { mode: 'reject' })).toThrow();
+    it('must reject INTO OUTFILE shape (reject mode)', () => {
+      expect(() => sanitizeString("1 UNION SELECT 'x' INTO OUTFILE '/var/www/x.php'", { mode: 'reject' })).toThrow();
+    });
+
+    it('must NOT reject bare SELECT * FROM (FP regression — B3)', () => {
+      // Sharing example SQL in chat/issue/comment is benign content.
+      // Real SQL injection has additional shape (quotes, ;, --, UNION).
+      expect(() => sanitizeString('SELECT * FROM users WHERE id = ?', { mode: 'reject' })).not.toThrow();
+    });
+
+    it('must NOT reject "please select" plain English (FP regression — B3)', () => {
+      expect(() => sanitizeString('please select an option', { mode: 'reject' })).not.toThrow();
     });
 
     it('must reject -- comment syntax (reject mode)', () => {

--- a/packages/arcis-node/tests/sanitizers/ldap.test.ts
+++ b/packages/arcis-node/tests/sanitizers/ldap.test.ts
@@ -76,23 +76,25 @@ describe('sanitizeLdapDn', () => {
 });
 
 describe('detectLdapInjection', () => {
-  it('detects wildcard injection', () => {
-    expect(detectLdapInjection('*')).toBe(true);
+  // Wildcard in filter value context — `=*` shape only, not bare `*`.
+  // Updated 2026-06-07 (benchmark FP class B2): bare `*` was too broad.
+  it('detects wildcard value in filter context: =*', () => {
+    expect(detectLdapInjection('(uid=*)')).toBe(true);
+  });
+
+  it('detects wildcard value with whitespace: = *', () => {
+    expect(detectLdapInjection('uid = *')).toBe(true);
   });
 
   it('detects OR bypass payload', () => {
     expect(detectLdapInjection('*)(uid=*))(|(uid=*')).toBe(true);
   });
 
-  it('detects parentheses', () => {
+  it('detects parentheses break-out: )(', () => {
     expect(detectLdapInjection('admin)(&(password=*)')).toBe(true);
   });
 
-  it('detects backslash', () => {
-    expect(detectLdapInjection('ad\\min')).toBe(true);
-  });
-
-  it('detects NUL byte', () => {
+  it('detects NUL byte (LDAP query truncation)', () => {
     expect(detectLdapInjection('ad\x00min')).toBe(true);
   });
 
@@ -113,6 +115,33 @@ describe('detectLdapInjection', () => {
     expect(detectLdapInjection('johndoe')).toBe(false);
     expect(detectLdapInjection('john.doe@example.com')).toBe(false);
     expect(detectLdapInjection('John Doe')).toBe(false);
+  });
+
+  // Benchmark FP class B2 — false-positive regression guards.
+  // These payloads previously triggered LDAP detection via the
+  // overly-broad `[*()\\\x00]` rule and would block every markdown
+  // editor, math expression, and parenthetical comment.
+  it('returns false for markdown bold (**)', () => {
+    expect(detectLdapInjection('this is **bold** text')).toBe(false);
+  });
+
+  it('returns false for markdown italic (*)', () => {
+    expect(detectLdapInjection('hello *world* hi')).toBe(false);
+  });
+
+  it('returns false for math expression with asterisk', () => {
+    expect(detectLdapInjection('area = x * y')).toBe(false);
+  });
+
+  it('returns false for parenthetical text', () => {
+    expect(detectLdapInjection('one (two) three')).toBe(false);
+  });
+
+  it('returns false for single backslash in text', () => {
+    // Single `\` is escape syntax — only meaningful adjacent to a real
+    // LDAP special. Bare `\` in middle of text is legitimate (e.g.
+    // Windows-style file paths shared in a comment).
+    expect(detectLdapInjection('ad\\min')).toBe(false);
   });
 
   it('returns false for empty string', () => {

--- a/packages/arcis-node/tests/sanitizers/mutation-resistance.test.ts
+++ b/packages/arcis-node/tests/sanitizers/mutation-resistance.test.ts
@@ -113,7 +113,12 @@ const SQL_CASES: readonly Case[] = [
   ["'; DROP TABLE users--", ['drop']],
   ['UNION SELECT * FROM users', ['union', 'select']],
   ["admin'--", ['--']],
-  ['1; DELETE FROM users', ['delete']],
+  // 2026-06-07 (B3): bare `DELETE FROM` no longer flagged because we
+  // also let benign `SELECT * FROM` through (consistency with code
+  // snippet sharing). Real DELETE injection has `;`, `--`, or quote
+  // shape that other patterns catch. Replaced with INTO OUTFILE,
+  // which is exclusive to attacker file-write primitives.
+  ["1 UNION SELECT 'pwn' INTO OUTFILE '/var/www/x.php'", ['into outfile']],
   ['SLEEP(5)', ['sleep(']],
   // improvements.md §1.1.e Q3: Oracle DBMS_* packages.
   ['foo; DBMS_LOCK.SLEEP(5)', ['dbms_']],

--- a/packages/arcis-node/tests/sanitizers/path.test.ts
+++ b/packages/arcis-node/tests/sanitizers/path.test.ts
@@ -105,6 +105,33 @@ describe('sanitizePath', () => {
     });
   });
 
+  // Added 2026-06-07 (benchmark B6): three path-traversal gaps the
+  // Python SDK missed and Node partially covered — now in patterns.json
+  // + Node SQL_PATTERNS for both.
+  describe('Benchmark B6 gaps', () => {
+    it('should block mixed-encoded traversal (..%2F)', () => {
+      const result = sanitizePath('..%2F..%2F..%2Fetc%2Fpasswd');
+      expect(result).not.toContain('..%2F');
+    });
+
+    it('should block overlong UTF-8 (%c0%ae)', () => {
+      const result = sanitizePath('%c0%ae%c0%ae/%c0%ae%c0%ae/etc/passwd');
+      expect(result).not.toMatch(/%c0%ae/i);
+    });
+
+    it('should block Windows UNC paths in user input', () => {
+      const result = sanitizePath('\\\\evil-server\\share\\stolen');
+      expect(result).not.toContain('\\\\evil-server');
+    });
+
+    it('should preserve normal Windows absolute paths (UNC FP regression)', () => {
+      // C:\Users\Public is NOT a UNC path — single drive letter +
+      // single backslash separators. UNC starts with double backslash.
+      const safe = 'C:\\Users\\Public\\file.txt';
+      expect(sanitizePath(safe)).toBe(safe);
+    });
+  });
+
   describe('Threat Collection', () => {
     it('should collect threat info when requested', () => {
       const result = sanitizePath('../../etc/passwd', true);

--- a/packages/arcis-node/tests/sanitizers/sql.test.ts
+++ b/packages/arcis-node/tests/sanitizers/sql.test.ts
@@ -7,40 +7,96 @@ import { describe, it, expect } from 'vitest';
 import { sanitizeSql, detectSql } from '../../src/sanitizers/sql';
 
 describe('sanitizeSql', () => {
-  describe('Dangerous Keywords', () => {
-    it('should block DROP keyword', () => {
+  // Updated 2026-06-07 (benchmark FP class B3): bare SQL keywords
+  // (SELECT, INSERT, UPDATE, DELETE, UNION, DROP, etc.) no longer
+  // trigger removal because they false-positive on natural English
+  // ("please select an option", "I'll update you tomorrow"). The
+  // current SQL_PATTERNS rule requires multi-token attack shapes
+  // (UNION SELECT, DROP TABLE, INTO OUTFILE, etc.).
+  describe('Multi-token SQL attack shapes', () => {
+    it('should block DROP TABLE shape', () => {
       const result = sanitizeSql("'; DROP TABLE users; --");
-      expect(result.toUpperCase()).not.toContain('DROP');
+      expect(result.toUpperCase()).not.toContain('DROP TABLE');
     });
 
-    it('should block SELECT keyword', () => {
-      const result = sanitizeSql('SELECT * FROM users');
-      expect(result.toUpperCase()).not.toContain('SELECT');
+    it('should block TRUNCATE TABLE shape', () => {
+      const result = sanitizeSql('1; TRUNCATE TABLE logs --');
+      expect(result.toUpperCase()).not.toContain('TRUNCATE TABLE');
     });
 
-    it('should block DELETE keyword', () => {
-      const result = sanitizeSql('DELETE FROM users WHERE 1=1');
-      expect(result.toUpperCase()).not.toContain('DELETE');
-    });
-
-    it('should block INSERT keyword', () => {
-      const result = sanitizeSql("INSERT INTO users VALUES ('hacker')");
-      expect(result.toUpperCase()).not.toContain('INSERT');
-    });
-
-    it('should block UPDATE keyword', () => {
-      const result = sanitizeSql("UPDATE users SET admin=1 WHERE 1=1");
-      expect(result.toUpperCase()).not.toContain('UPDATE');
-    });
-
-    it('should block UNION keyword', () => {
+    it('should block UNION SELECT shape', () => {
       const result = sanitizeSql('1 UNION SELECT password FROM users');
-      expect(result.toUpperCase()).not.toContain('UNION');
+      expect(result.toUpperCase()).not.toContain('UNION SELECT');
     });
 
-    it('should block EXEC/EXECUTE keywords', () => {
-      const result = sanitizeSql('EXEC xp_cmdshell');
-      expect(result.toUpperCase()).not.toContain('EXEC');
+    it('should block UNION ALL SELECT shape', () => {
+      const result = sanitizeSql('1 UNION ALL SELECT * FROM users');
+      expect(result.toUpperCase()).not.toContain('UNION ALL SELECT');
+    });
+
+    it('should block INTO OUTFILE shape', () => {
+      const result = sanitizeSql("1 UNION SELECT 'pwn' INTO OUTFILE '/var/www/shell.php'");
+      expect(result.toUpperCase()).not.toContain('INTO OUTFILE');
+    });
+
+    it('should block ATTACH DATABASE (SQLite)', () => {
+      const result = sanitizeSql("1; ATTACH DATABASE '/tmp/evil.db' AS evil --");
+      expect(result.toUpperCase()).not.toContain('ATTACH DATABASE');
+    });
+
+    it('should block CREATE USER (privilege escalation)', () => {
+      const result = sanitizeSql("'; CREATE USER hacker --");
+      expect(result.toUpperCase()).not.toContain('CREATE USER');
+    });
+
+    it('should block GRANT ALL', () => {
+      const result = sanitizeSql("'; GRANT ALL ON *.* TO 'hacker'");
+      expect(result.toUpperCase()).not.toContain('GRANT ALL');
+    });
+
+    it('should block xp_cmdshell (SQL Server RCE)', () => {
+      const result = sanitizeSql('1; EXEC xp_cmdshell');
+      expect(result.toLowerCase()).not.toContain('xp_cmdshell');
+    });
+
+    it('should block sp_executesql', () => {
+      const result = sanitizeSql("EXEC sp_executesql @sql");
+      expect(result.toLowerCase()).not.toContain('sp_executesql');
+    });
+
+    it('should block SHUTDOWN', () => {
+      const result = sanitizeSql("'; SHUTDOWN --");
+      expect(result.toUpperCase()).not.toContain('SHUTDOWN');
+    });
+  });
+
+  describe('Benign SQL-shaped content is preserved (FP regression — B3)', () => {
+    it('does not strip the word "select" in plain English', () => {
+      const input = 'please select an option from the dropdown';
+      expect(sanitizeSql(input)).toBe(input);
+    });
+
+    it('does not strip "update" in plain English', () => {
+      const input = "I'll update you tomorrow about the meeting";
+      expect(sanitizeSql(input)).toBe(input);
+    });
+
+    it('does not strip "delete" in plain English', () => {
+      const input = 'You can delete this file from the trash folder';
+      expect(sanitizeSql(input)).toBe(input);
+    });
+
+    it('does not strip code-snippet SELECT * FROM (shared as content)', () => {
+      // User pastes example SQL in a chat/issue/comment. App uses
+      // parameterized queries — middleware shouldn't fight the content.
+      const input = 'SELECT * FROM users WHERE id = ?';
+      expect(sanitizeSql(input)).toBe(input);
+    });
+
+    it('does not strip DROP shipping notification', () => {
+      // Real-world string from logistics apps.
+      const input = 'Please drop off the package at the location.';
+      expect(sanitizeSql(input)).toBe(input);
     });
   });
 
@@ -50,13 +106,32 @@ describe('sanitizeSql', () => {
       expect(result).not.toContain('--');
     });
 
-    // Note: # comments are NOT in current SQL_PATTERNS
-    // Current comment pattern: /(--|\/\*|\*\/)/g
-    // Add /#/g to SQL_PATTERNS in constants.ts if needed
-
     it('should block /* */ comments', () => {
       const result = sanitizeSql('1 /* comment */ OR 1=1');
       expect(result).not.toContain('/*');
+    });
+
+    it('does NOT block markdown # heading (FP regression — B1)', () => {
+      // MySQL # comment was removed from SQL_PATTERNS 2026-06-07
+      // because it false-positived on every hex color, hashtag,
+      // issue ref, and markdown heading.
+      const input = '# Heading';
+      expect(sanitizeSql(input)).toBe(input);
+    });
+
+    it('does NOT block hex colors (FP regression — B1)', () => {
+      const input = '#FF5300 is the primary brand color';
+      expect(sanitizeSql(input)).toBe(input);
+    });
+
+    it('does NOT block hashtags (FP regression — B1)', () => {
+      const input = 'Just shipped v1.7 #releaseday #buildinpublic';
+      expect(sanitizeSql(input)).toBe(input);
+    });
+
+    it('does NOT block issue references (FP regression — B1)', () => {
+      const input = 'see issue #123 and PR-456';
+      expect(sanitizeSql(input)).toBe(input);
     });
   });
 
@@ -125,20 +200,31 @@ describe('sanitizeSql', () => {
       expect(result).toBe('John Doe');
     });
 
-    it('should handle mixed case keywords', () => {
-      const result = sanitizeSql('SeLeCt * FrOm users');
-      expect(result.toUpperCase()).not.toContain('SELECT');
+    it('should handle mixed case attack shapes', () => {
+      // Updated 2026-06-07 (B3): bare `SeLeCt * FrOm` is no longer
+      // treated as injection. Use a real multi-token attack shape.
+      const result = sanitizeSql('1 uNiOn SeLeCt password FROM users');
+      expect(result.toUpperCase()).not.toContain('UNION SELECT');
     });
   });
 });
 
 describe('detectSql', () => {
-  it('should detect DROP keyword', () => {
+  it('should detect DROP TABLE shape', () => {
     expect(detectSql('DROP TABLE users')).toBe(true);
   });
 
-  it('should detect SELECT keyword', () => {
-    expect(detectSql('SELECT * FROM users')).toBe(true);
+  it('should detect UNION SELECT shape', () => {
+    // Updated 2026-06-07 (B3): bare `SELECT * FROM` no longer flagged.
+    // UNION SELECT remains the canonical SQLi exfiltration shape.
+    expect(detectSql('1 UNION SELECT password FROM users')).toBe(true);
+  });
+
+  it('should NOT detect bare SELECT * FROM (FP regression — B3)', () => {
+    // Pasting example SQL in a chat/issue/comment shouldn't trigger.
+    // App responsibility: use parameterized queries. Middleware
+    // responsibility: catch obvious attacker shapes, not all SQL syntax.
+    expect(detectSql('SELECT * FROM users WHERE id = ?')).toBe(false);
   });
 
   it('should detect comment syntax', () => {

--- a/packages/arcis-node/tests/setup.ts
+++ b/packages/arcis-node/tests/setup.ts
@@ -104,12 +104,16 @@ export const XSS_VECTORS = [
   { input: 'data:text/html,<script>', check: (s: string) => !s.includes('data:') },
 ];
 
-/** Common SQL injection vectors for testing */
+// Updated 2026-06-07 (benchmark FP class B3): bare-keyword payloads
+// (`SELECT * FROM`, `1; DELETE FROM`) replaced with multi-token attack
+// shapes. Standalone SELECT/INSERT/UPDATE/DELETE no longer trigger
+// sanitization because they false-positive on code snippets and
+// natural English. UNION SELECT, DROP TABLE, INTO OUTFILE etc. stay.
 export const SQL_VECTORS = [
   "'; DROP TABLE users; --",
   "1 OR 1=1",
-  "SELECT * FROM users",
-  "1; DELETE FROM users",
+  "1 UNION SELECT password FROM users",
+  "1; TRUNCATE TABLE logs",
   "admin'--",
   "1 /* comment */ UNION SELECT",
 ];

--- a/packages/arcis-python/arcis/fastapi.py
+++ b/packages/arcis-python/arcis/fastapi.py
@@ -33,6 +33,12 @@ from .utils.ip import detect_client_ip
 logger = logging.getLogger(__name__)
 
 
+# Sentinel for "param not supplied" so ArcisMiddleware can distinguish
+# rate_limiter=None (explicit disable) from rate_limiter not passed
+# (fall through to the rate_limit bool default). Benchmark E2, 2026-06-07.
+_RL_UNSET = object()
+
+
 # ============================================================================
 # ASYNC RATE LIMITER STORE PROTOCOL
 # ============================================================================
@@ -419,10 +425,14 @@ class ArcisMiddleware(BaseHTTPMiddleware):
         # Error handler options
         error_handling: bool = True,
         is_dev: bool = False,
-        # Pre-built components (for Arcis class)
+        # Pre-built components (for Arcis class).
+        # rate_limiter / async_rate_limiter use the `_RL_UNSET` sentinel
+        # so callers can distinguish "not supplied" (use default if
+        # rate_limit=True) from "supplied as None" (explicit disable —
+        # benchmark E2 fix, 2026-06-07).
         sanitizer: Optional[Sanitizer] = None,
-        rate_limiter: Optional[RateLimiter] = None,
-        async_rate_limiter: Optional[AsyncRateLimiter] = None,  # NEW
+        rate_limiter=_RL_UNSET,
+        async_rate_limiter=_RL_UNSET,
         security_headers: Optional[SecurityHeaders] = None,
         error_handler: Optional[ErrorHandler] = None,
         # Telemetry: dict, TelemetryOptions, or pre-built AsyncTelemetryClient.
@@ -442,13 +452,23 @@ class ArcisMiddleware(BaseHTTPMiddleware):
             path=sanitize_path,
         ) if sanitize else None)
         
-        # Determine which rate limiter to use
+        # Determine which rate limiter to use.
+        # Three states per param (`rate_limiter` / `async_rate_limiter`):
+        #   _RL_UNSET — caller didn't pass — fall through to bool default
+        #   None      — caller explicitly disabled (benchmark E2, 2026-06-07)
+        #   object    — caller supplied a custom limiter — use it
         self.async_rate_limiter = None
         self.rate_limiter = None
-        
-        if async_rate_limiter:
+
+        explicit_disable = (rate_limiter is None) or (async_rate_limiter is None)
+        if explicit_disable:
+            # Explicit None for either slot disables rate limiting entirely.
+            # Matches the principle of least surprise: passing `None` to a
+            # parameter that accepts an Optional should mean "no value."
+            pass
+        elif async_rate_limiter is not _RL_UNSET:
             self.async_rate_limiter = async_rate_limiter
-        elif rate_limiter:
+        elif rate_limiter is not _RL_UNSET:
             self.rate_limiter = rate_limiter
         elif rate_limit:
             if use_async_rate_limiter:

--- a/packages/arcis-python/arcis/middleware/main.py
+++ b/packages/arcis-python/arcis/middleware/main.py
@@ -36,6 +36,13 @@ class Arcis:
         sanitize_sql: bool = True,
         sanitize_nosql: bool = True,
         sanitize_path: bool = True,
+        # Block mode: return 403 on detected attack instead of silently
+        # sanitizing. FastAPI / Starlette only — Flask path keeps
+        # sanitize-on-read semantics. Mirrors Node's `block:true`.
+        # Added 2026-06-07 (benchmark T3): previously block mode was
+        # only reachable by bypassing this wrapper and using
+        # ArcisMiddleware + Sanitizer() directly.
+        block: bool = False,
         # Rate limiter options
         rate_limit: bool = True,
         rate_limit_max: int = DEFAULT_MAX_REQUESTS,
@@ -49,6 +56,7 @@ class Arcis:
         error_handler: bool = True,
         is_dev: bool = False,
     ):
+        self.block = block
         self.sanitizer = Sanitizer(
             xss=sanitize_xss,
             sql=sanitize_sql,
@@ -156,4 +164,5 @@ class Arcis:
             rate_limiter=self.rate_limiter,
             security_headers=self.security_headers,
             error_handler=self.error_handler,
+            block=self.block,
         )

--- a/packages/arcis-python/tests/conformance/test_conformance.py
+++ b/packages/arcis-python/tests/conformance/test_conformance.py
@@ -79,21 +79,27 @@ class TestConformanceSanitizeXSS:
 # ---------------------------------------------------------------------------
 
 class TestConformanceSanitizeSQL:
+    # Updated 2026-06-07 (benchmark FP class B3): bare SQL keywords
+    # (SELECT, INSERT, UPDATE, DELETE) no longer flagged in isolation
+    # because they false-positive on natural English and code snippets.
+    # Multi-token attack shapes (UNION SELECT, DROP TABLE, INTO OUTFILE)
+    # remain blocked. Sister update: arcis-node/tests/sanitizers/sql.test.ts.
+
     def test_removes_drop_table(self):
         result = sanitize_string("'; DROP TABLE users; --")
-        assert "DROP" not in result.upper()
+        assert "DROP TABLE" not in result.upper()
 
     def test_removes_or_1_equals_1(self):
         result = sanitize_string("1 OR 1=1")
         assert "OR 1" not in result.upper() or "1=1" not in result
 
-    def test_removes_select(self):
-        result = sanitize_string("SELECT * FROM users")
-        assert "SELECT" not in result.upper()
+    def test_removes_union_select(self):
+        result = sanitize_string("1 UNION SELECT password FROM users")
+        assert "UNION SELECT" not in result.upper()
 
-    def test_removes_delete(self):
-        result = sanitize_string("1; DELETE FROM users")
-        assert "DELETE" not in result.upper()
+    def test_removes_into_outfile(self):
+        result = sanitize_string("1 UNION SELECT 'x' INTO OUTFILE '/var/www/x.php'")
+        assert "INTO OUTFILE" not in result.upper()
 
     def test_removes_comments(self):
         result = sanitize_string("admin'--")
@@ -102,6 +108,20 @@ class TestConformanceSanitizeSQL:
     def test_removes_union_and_block_comments(self):
         result = sanitize_string("1 /* comment */ UNION SELECT")
         assert "UNION" not in result.upper()
+
+    # B3 FP-regression guards.
+    def test_preserves_bare_select_from(self):
+        # Sharing SQL example in chat/issue/comment should not trigger.
+        text = "SELECT * FROM users WHERE id = ?"
+        assert sanitize_string(text) == text
+
+    def test_preserves_please_select(self):
+        text = "please select an option from the dropdown"
+        assert sanitize_string(text) == text
+
+    def test_preserves_update_in_english(self):
+        text = "I'll update you tomorrow about the meeting"
+        assert sanitize_string(text) == text
 
 
 # ---------------------------------------------------------------------------

--- a/packages/arcis-python/tests/integration/test_flask.py
+++ b/packages/arcis-python/tests/integration/test_flask.py
@@ -236,12 +236,23 @@ class TestFlaskSanitization:
         result = response.get_json()
         assert 'DROP' not in result['received'].get('query', '').upper()
     
-    def test_sanitizes_sql_select(self, client):
-        data = {"query": "SELECT * FROM users"}
+    def test_sanitizes_sql_into_outfile(self, client):
+        # Updated 2026-06-07 (benchmark FP class B3): bare `SELECT * FROM`
+        # no longer flagged because the SDK allows benign code snippets.
+        # INTO OUTFILE is the exclusive attacker file-write primitive.
+        data = {"query": "1 UNION SELECT 'x' INTO OUTFILE '/var/www/x.php'"}
         response = client.post('/echo', json=data)
-        
+
         result = response.get_json()
-        assert 'SELECT' not in result['received'].get('query', '').upper()
+        assert 'INTO OUTFILE' not in result['received'].get('query', '').upper()
+
+    def test_preserves_bare_select_from_b3_fp(self, client):
+        # Sharing example SQL in a comment / chat / issue is benign.
+        # Real injection has additional shape that other patterns catch.
+        text = "SELECT * FROM users WHERE id = ?"
+        response = client.post('/echo', json={"query": text})
+        result = response.get_json()
+        assert result['received'].get('query') == text
     
     def test_sanitizes_sql_union(self, client):
         data = {"query": "1 UNION SELECT password FROM users"}

--- a/packages/arcis-python/tests/sanitizers/test_mutation_resistance.py
+++ b/packages/arcis-python/tests/sanitizers/test_mutation_resistance.py
@@ -145,7 +145,11 @@ SQL_CASES = [
     ("'; DROP TABLE users--", ["drop"]),
     ("UNION SELECT * FROM users", ["union", "select"]),
     ("admin'--", ["--"]),
-    ("1; DELETE FROM users", ["delete"]),
+    # 2026-06-07 (benchmark FP class B3): bare `DELETE FROM` no longer
+    # flagged because the SDK also allows benign `SELECT * FROM` content.
+    # Real DELETE injection has `;`, `--`, or quote shape that other
+    # patterns catch. Replaced with INTO OUTFILE (attacker file-write).
+    ("1 UNION SELECT 'x' INTO OUTFILE '/var/www/x.php'", ["into outfile"]),
     ("SLEEP(5)", ["sleep("]),
     # improvements.md §1.1.e Q3: Oracle DBMS_* packages.
     ("foo; DBMS_LOCK.SLEEP(5)", ["dbms_"]),

--- a/packages/arcis-python/tests/sanitizers/test_sanitize.py
+++ b/packages/arcis-python/tests/sanitizers/test_sanitize.py
@@ -44,23 +44,33 @@ class TestSanitizeStringXSS:
 
 
 class TestSanitizeStringSQL:
-    """Test SQL injection prevention in sanitize_string."""
+    """Test SQL injection prevention in sanitize_string.
+
+    Updated 2026-06-07 (benchmark FP class B3): bare SQL keywords
+    (SELECT, INSERT, UPDATE, DELETE) no longer flagged in isolation.
+    Multi-token attack shapes (UNION SELECT, DROP TABLE, INTO OUTFILE,
+    ATTACH DATABASE, etc.) remain blocked. See findings-v1.6.4.md.
+    """
 
     def test_removes_drop_table(self):
         result = sanitize_string("'; DROP TABLE users; --")
-        assert 'DROP' not in result.upper()
+        assert 'DROP TABLE' not in result.upper()
 
     def test_removes_or_1_equals_1(self):
         result = sanitize_string("1 OR 1=1")
         assert 'OR 1' not in result.upper() or '1=1' not in result
 
-    def test_removes_select(self):
-        result = sanitize_string("SELECT * FROM users")
-        assert 'SELECT' not in result.upper()
+    def test_removes_union_select(self):
+        result = sanitize_string("1 UNION SELECT password FROM users")
+        assert 'UNION SELECT' not in result.upper()
 
-    def test_removes_delete(self):
-        result = sanitize_string("1; DELETE FROM users")
-        assert 'DELETE' not in result.upper()
+    def test_removes_into_outfile(self):
+        result = sanitize_string("1 UNION SELECT 'x' INTO OUTFILE '/var/www/x.php'")
+        assert 'INTO OUTFILE' not in result.upper()
+
+    def test_removes_attach_database(self):
+        result = sanitize_string("1; ATTACH DATABASE '/tmp/evil.db' AS evil --")
+        assert 'ATTACH DATABASE' not in result.upper()
 
     def test_removes_sql_comments(self):
         result = sanitize_string("admin'--")
@@ -69,6 +79,19 @@ class TestSanitizeStringSQL:
     def test_removes_union_and_block_comments(self):
         result = sanitize_string("1 /* comment */ UNION SELECT")
         assert 'UNION' not in result.upper()
+
+    # B3 false-positive regression guards.
+    def test_preserves_bare_select_from(self):
+        text = "SELECT * FROM users WHERE id = ?"
+        assert sanitize_string(text) == text
+
+    def test_preserves_please_select(self):
+        text = "please select an option from the dropdown"
+        assert sanitize_string(text) == text
+
+    def test_preserves_delete_from_english(self):
+        text = "You can delete this file from the trash folder"
+        assert sanitize_string(text) == text
 
 
 class TestSanitizeStringTimingSQL:

--- a/packages/core/patterns.json
+++ b/packages/core/patterns.json
@@ -175,16 +175,17 @@
       "rules": [
         {
           "id": "sqli-keywords",
-          "pattern": "\\b(SELECT|INSERT|UPDATE|DELETE|DROP|UNION|ALTER|CREATE|TRUNCATE|EXEC|EXECUTE)\\b",
+          "pattern": "(\\bUNION\\s+(?:ALL\\s+)?SELECT\\b)|(\\b(?:DROP|TRUNCATE)\\s+(?:TABLE|DATABASE|INDEX|VIEW|SCHEMA)\\b)|(\\bINTO\\s+(?:OUTFILE|DUMPFILE)\\b)|(\\bATTACH\\s+DATABASE\\b)|(\\bCREATE\\s+(?:USER|FUNCTION|TRIGGER|PROCEDURE)\\b)|(\\bGRANT\\s+(?:ALL|SELECT|INSERT|UPDATE|DELETE)\\b)|(\\bSHUTDOWN\\b)|(\\bxp_cmdshell\\b)|(\\bsp_executesql\\b)",
           "flags": "gi",
-          "description": "Detects SQL keywords",
-          "redos_safe": true
+          "description": "Multi-token SQL attack shapes (UNION SELECT, DROP TABLE, INTO OUTFILE, etc.) that real attackers use and benign users essentially never type. Replaces older bare-keyword rule that false-positived on 'please select an option', 'I'll update you tomorrow'. Benchmark FP class B3, 2026-06-07.",
+          "redos_safe": true,
+          "request_boundary_safe": true
         },
         {
           "id": "sqli-comments",
           "pattern": "(--|/\\*|\\*/)",
           "flags": "g",
-          "description": "Detects SQL comments",
+          "description": "Detects SQL comments. MySQL `#` line comment intentionally excluded to avoid FP on hex colors / hashtags / issue refs; real `admin' #` injections are still caught by the quote + keyword combo patterns.",
           "redos_safe": true
         },
         {
@@ -375,6 +376,27 @@
           "pattern": "\\x00",
           "flags": "g",
           "description": "Detects literal NUL byte in path inputs",
+          "redos_safe": true
+        },
+        {
+          "id": "path-mixed-encoded",
+          "pattern": "\\.\\.%2[fF]",
+          "flags": "g",
+          "description": "Detects mixed encoding: literal `..` followed by URL-encoded slash (%2F). Benchmark B6 — Python had no coverage; Node had this pattern. 2026-06-07.",
+          "redos_safe": true
+        },
+        {
+          "id": "path-overlong-utf8-dot",
+          "pattern": "%[Cc]0%[Aa][Ee]",
+          "flags": "g",
+          "description": "Detects overlong UTF-8 encoding of '.' (%C0%AE). Historic IIS/Apache decoder bypass. Real char `.` is %2E; overlong encoding only appears in evasion attempts. Benchmark B6 gap — neither SDK caught this before. 2026-06-07.",
+          "redos_safe": true
+        },
+        {
+          "id": "path-windows-unc",
+          "pattern": "\\\\\\\\[A-Za-z0-9_.-]+\\\\",
+          "flags": "g",
+          "description": "Detects Windows UNC paths (\\\\\\\\server\\\\share) in user input. Legitimate web-app inputs never contain UNC references; attacker UNC payloads leak SMB auth or pull remote payloads. Benchmark B6. 2026-06-07.",
           "redos_safe": true
         }
       ]


### PR DESCRIPTION
## Why

Closes a class of false positives in v1.6.4 where common user input got blocked: markdown headings (`# Heading`), hex colors (`#FF5300`), hashtags (`#trending`), issue refs (`#123`), markdown bold (`**bold**`), parentheticals like `(uid=user)`, the word `select` in plain English ("please select an option"), and shared SQL example snippets in comments.

Also closes three path-traversal coverage gaps (`..%2F` mixed encoding, `%C0%AE` overlong UTF-8, `\server\share` UNC paths) and a couple of Python middleware ergonomics issues.

## What changed (user-facing)

| Change | Impact |
|---|---|
| `SQL_PATTERNS` no longer matches a bare `#` | Markdown headings, hex colors, hashtags, issue refs flow through unchanged |
| `SQL_PATTERNS` `sqli-keywords` rewritten to multi-token shapes (`UNION SELECT`, `DROP TABLE`, `INTO OUTFILE`, etc.) | Bare `SELECT`, `UPDATE`, `DELETE`, `INSERT` no longer trigger by themselves. Real injection shapes (`UNION SELECT password FROM users`) still blocked |
| `detectLdapInjection` no longer flags bare `*`, `(`, or `)` | Markdown bold, math expressions, parentheticals pass through. LDAP filter break-out shapes (`)(`, `=*`, `\x00`) still blocked |
| Three new path-traversal patterns: `path-mixed-encoded`, `path-overlong-utf8-dot`, `path-windows-unc` | Closes encoding bypass + Windows UNC detection in both SDKs |
| Python `Arcis(app, block=True)` now works | Previously `block` was only reachable via `ArcisMiddleware` direct construction |
| Python `ArcisMiddleware(rate_limiter=None)` now actually disables rate limiting | Previously the bool default kept building a default limiter |

## Tests

- Node: 2174 passed (was 2153)
- Python: 1715 passed, 1 skipped (was 1707)
- All bare-keyword tests replaced with multi-token attack-shape assertions plus explicit regression guards for the false-positive inputs.

## Migration notes

No breaking API change. Pattern-level behavior shifts only:

- Apps that relied on `arcis()` blocking bare SELECT/INSERT/UPDATE/DELETE keywords in user input will see those allowed through now. Real injection patterns are still caught. The recommended defense remains parameterized queries at the data layer.
- Apps that explicitly pass `rate_limiter=None` to Python `ArcisMiddleware` will now have rate limiting disabled instead of silently getting the default limiter.