### PR TITLE
chore: bump version to 1.6.5

### DIFF
--- a/packages/arcis-node/package-lock.json
+++ b/packages/arcis-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcis/node",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcis/node",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/packages/arcis-node/package.json
+++ b/packages/arcis-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/node",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Inside-the-app security middleware for Node.js. Express and NestJS run the full sanitizer pipeline (XSS, SQL, NoSQL, SSTI, XXE, path, command, prompt injection, prototype pollution, LDAP, XPath, header injection, plus 20+ more attack types). Fastify, Koa, Hono, Next.js, SvelteKit, Astro, Nuxt, and Bun ship rate-limit + bot detection + security headers as v1 adapters; pair them with `sanitizeObject` from @arcis/node/sanitizers for body inspection. v1.6 ships interactive REPL, NFKC + multi-decode hardening, deserialization markers (V33), GraphQL alias-bomb guard (V34), and a stateful per-IP correlation window. Includes prompt-injection signature library, LLM token-budget middleware, 695-pattern bot corpus, and the @arcis/cli native CLI.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/arcis-python/arcis/__init__.py
+++ b/packages/arcis-python/arcis/__init__.py
@@ -197,7 +197,7 @@ try:
 except ImportError:
     _HAS_ASYNC = False
 
-__version__ = "1.6.4"
+__version__ = "1.6.5"
 __all__ = [
     # Main class
     "Arcis",

--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arcis"
-version = "1.6.4"
+version = "1.6.5"
 description = "Inside-the-app security middleware for Python. FastAPI, Django, Litestar run the full sanitizer pipeline (XSS, SQL, NoSQL, path, command, SSTI, XXE, LDAP, XPath, email-header, prototype). Flask is sanitize-only. Opt-in helpers: 695-bot corpus, CSRF, HPP, SSRF URL validation, prompt-injection signatures (V32 toolcall, V33 deserialization, V34 GraphQL), per-IP correlation window, LLM token-budget. Same API as the Node and Go SDKs. CLI ships at npm install -g @arcis/cli."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps @arcis/node and arcis (PyPI) from 1.6.4 to 1.6.5.

Carries the pattern updates merged in #180:

* removed bare hash from SQL comments (markdown headings, hex colors, hashtags, issue refs no longer blocked)
* sqli keywords now require multi-token attack shape context
* LDAP detection no longer flags bare asterisks or parens
* added three path-traversal patterns (mixed encoding, overlong UTF-8, UNC)
* Python Arcis() wrapper accepts block=True
* Python ArcisMiddleware rate_limiter=None now actually disables rate limiting

Next step after merge: release PR nwl to main triggers auto-publish.