### PR TITLE
fix(python): sync bundled patterns.json with packages/core source

### DIFF
--- a/packages/arcis-python/arcis/core/constants.py
+++ b/packages/arcis-python/arcis/core/constants.py
@@ -65,7 +65,11 @@ def get_embedded_patterns() -> Dict:
             },
             "sql_injection": {
                 "rules": [
-                    {"pattern": r"\b(SELECT|INSERT|UPDATE|DELETE|DROP|UNION|ALTER|CREATE|TRUNCATE|EXEC|EXECUTE)\b", "flags": "gi"},
+                    # Multi-token SQL attack shapes. Mirrors sqli-keywords in
+                    # packages/core/patterns.json. Replaces the older bare-keyword
+                    # rule that false-positived on "please select an option" and
+                    # shared code snippets. Benchmark FP class B3, 2026-06-07.
+                    {"pattern": r"(\bUNION\s+(?:ALL\s+)?SELECT\b)|(\b(?:DROP|TRUNCATE)\s+(?:TABLE|DATABASE|INDEX|VIEW|SCHEMA)\b)|(\bINTO\s+(?:OUTFILE|DUMPFILE)\b)|(\bATTACH\s+DATABASE\b)|(\bCREATE\s+(?:USER|FUNCTION|TRIGGER|PROCEDURE)\b)|(\bGRANT\s+(?:ALL|SELECT|INSERT|UPDATE|DELETE)\b)|(\bSHUTDOWN\b)|(\bxp_cmdshell\b)|(\bsp_executesql\b)", "flags": "gi"},
                     {"pattern": r"(--|/\*|\*/)", "flags": "g"},
                     {"pattern": r"(;|\|\||&&)", "flags": "g"},
                     {"pattern": r"\bOR\s+\d+\s*=\s*\d+", "flags": "gi"},

--- a/packages/arcis-python/arcis/data/patterns.json
+++ b/packages/arcis-python/arcis/data/patterns.json
@@ -1,6 +1,13 @@
 {
   "version": "1.1.0",
   "description": "Arcis Core Security Patterns - Language Agnostic",
+  "_pattern_convention": {
+    "description": "Pattern field naming convention for SDK implementers",
+    "pattern": "The primary regex pattern. May contain ReDoS-vulnerable constructs.",
+    "pattern_safe": "ReDoS-safe alternative pattern. SDKs MUST prefer this when available.",
+    "redos_safe": "Boolean indicating if 'pattern' is ReDoS-safe. If false, use 'pattern_safe'.",
+    "usage": "pattern_str = rule.get('pattern_safe') or rule.get('pattern')"
+  },
   "config": {
     "max_input_size": 1000000,
     "max_recursion_depth": 10,
@@ -13,53 +20,94 @@
       "owasp": "A03:2021",
       "rules": [
         {
-          "id": "xss-script-tag",
-          "pattern": "<script\\b[^<]*(?:(?!</script>)<[^<]*)*</script>",
-          "pattern_safe": "<script[^>]*>[\\s\\S]*?</script>",
+          "id": "xss-script-block",
+          "pattern": "<script[^>]*>[\\s\\S]*?</script>",
           "flags": "gi",
-          "description": "Detects script tags",
-          "redos_safe": false
-        },
-        {
-          "id": "xss-javascript-protocol",
-          "pattern": "javascript:",
-          "flags": "gi",
-          "description": "Detects javascript: protocol",
+          "description": "Detects full script blocks (open tag through close tag)",
           "redos_safe": true
         },
         {
-          "id": "xss-event-handler",
-          "pattern": "on\\w+\\s*=",
+          "id": "xss-script-tag",
+          "pattern": "<script[^>]*>",
           "flags": "gi",
-          "description": "Detects inline event handlers",
+          "description": "Detects standalone or unclosed script tags",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-javascript-protocol",
+          "pattern": "javascript\\s*:",
+          "flags": "gi",
+          "description": "Detects javascript: protocol (allows whitespace around colon)",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-event-handler-quoted",
+          "pattern": "(?:[\\s/])on\\w+\\s*=\\s*[\"'][^\"']*[\"']",
+          "flags": "gi",
+          "description": "Detects inline event handlers with quoted values (e.g. onclick=\"alert(1)\")",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-event-handler-unquoted",
+          "pattern": "(?:[\\s/])on\\w+\\s*=\\s*[^\\s>]*",
+          "flags": "gi",
+          "description": "Detects inline event handlers with unquoted values (e.g. onload=value)",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-iframe-block",
+          "pattern": "<iframe[^>]*>[\\s\\S]*?</iframe>",
+          "flags": "gi",
+          "description": "Detects full iframe blocks",
           "redos_safe": true
         },
         {
           "id": "xss-iframe",
-          "pattern": "<iframe",
+          "pattern": "<iframe[^>]*",
           "flags": "gi",
-          "description": "Detects iframe tags",
+          "description": "Detects iframe tags (partial or unclosed)",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-style-block",
+          "pattern": "<style[^>]*>[\\s\\S]*?</style>",
+          "flags": "gi",
+          "description": "Detects full style blocks (CSS injection, expression(), behavior: attacks)",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-style-tag",
+          "pattern": "<style[^>]*",
+          "flags": "gi",
+          "description": "Detects style tags (partial or unclosed)",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-object-block",
+          "pattern": "<object[^>]*>[\\s\\S]*?</object>",
+          "flags": "gi",
+          "description": "Detects full object blocks",
           "redos_safe": true
         },
         {
           "id": "xss-object",
-          "pattern": "<object",
+          "pattern": "<object[^>]*",
           "flags": "gi",
-          "description": "Detects object tags",
+          "description": "Detects object tags (partial or unclosed)",
           "redos_safe": true
         },
         {
           "id": "xss-embed",
-          "pattern": "<embed",
+          "pattern": "<embed[^>]*",
           "flags": "gi",
           "description": "Detects embed tags",
           "redos_safe": true
         },
         {
           "id": "xss-data-uri",
-          "pattern": "data:",
+          "pattern": "data\\s*:\\s*(?:text/html|image/svg)[^>\\s]*",
           "flags": "gi",
-          "description": "Detects data: URIs",
+          "description": "Detects data: URIs with HTML or SVG content (avoids 'metadata' false positives)",
           "redos_safe": true
         },
         {
@@ -78,9 +126,37 @@
         },
         {
           "id": "xss-svg-onload",
-          "pattern": "<svg[^>]*onload",
+          "pattern": "<svg[^>]*onload[^>]*>",
           "flags": "gi",
-          "description": "Detects SVG with onload",
+          "description": "Detects SVG with inline event handlers",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-form-injection",
+          "pattern": "<form[\\s>][^>]*",
+          "flags": "gi",
+          "description": "Detects form tags used for phishing/credential harvesting via action= redirection",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-meta-injection",
+          "pattern": "<meta[\\s>][^>]*",
+          "flags": "gi",
+          "description": "Detects meta tags used for http-equiv refresh redirects or CSP bypass",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-base-injection",
+          "pattern": "<base[\\s>][^>]*",
+          "flags": "gi",
+          "description": "Detects base href hijacking — redirects all relative URLs to attacker domain",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-link-injection",
+          "pattern": "<link[\\s>][^>]*",
+          "flags": "gi",
+          "description": "Detects link tag injection used for stylesheet or preload CSRF attacks",
           "redos_safe": true
         }
       ],
@@ -99,16 +175,17 @@
       "rules": [
         {
           "id": "sqli-keywords",
-          "pattern": "\\b(SELECT|INSERT|UPDATE|DELETE|DROP|UNION|ALTER|CREATE|TRUNCATE|EXEC|EXECUTE)\\b",
+          "pattern": "(\\bUNION\\s+(?:ALL\\s+)?SELECT\\b)|(\\b(?:DROP|TRUNCATE)\\s+(?:TABLE|DATABASE|INDEX|VIEW|SCHEMA)\\b)|(\\bINTO\\s+(?:OUTFILE|DUMPFILE)\\b)|(\\bATTACH\\s+DATABASE\\b)|(\\bCREATE\\s+(?:USER|FUNCTION|TRIGGER|PROCEDURE)\\b)|(\\bGRANT\\s+(?:ALL|SELECT|INSERT|UPDATE|DELETE)\\b)|(\\bSHUTDOWN\\b)|(\\bxp_cmdshell\\b)|(\\bsp_executesql\\b)",
           "flags": "gi",
-          "description": "Detects SQL keywords",
-          "redos_safe": true
+          "description": "Multi-token SQL attack shapes (UNION SELECT, DROP TABLE, INTO OUTFILE, etc.) that real attackers use and benign users essentially never type. Replaces older bare-keyword rule that false-positived on 'please select an option', 'I'll update you tomorrow'. Benchmark FP class B3, 2026-06-07.",
+          "redos_safe": true,
+          "request_boundary_safe": true
         },
         {
           "id": "sqli-comments",
           "pattern": "(--|/\\*|\\*/)",
           "flags": "g",
-          "description": "Detects SQL comments",
+          "description": "Detects SQL comments. MySQL `#` line comment intentionally excluded to avoid FP on hex colors / hashtags / issue refs; real `admin' #` injections are still caught by the quote + keyword combo patterns.",
           "redos_safe": true
         },
         {
@@ -159,6 +236,27 @@
           "flags": "gi",
           "description": "Detects time-based blind SQLi via BENCHMARK",
           "redos_safe": true
+        },
+        {
+          "id": "sqli-pg-sleep",
+          "pattern": "\\bpg_sleep\\s*\\(",
+          "flags": "gi",
+          "description": "Detects time-based blind SQLi via PostgreSQL pg_sleep",
+          "redos_safe": true
+        },
+        {
+          "id": "sqli-waitfor-delay",
+          "pattern": "\\bWAITFOR\\s+DELAY\\b",
+          "flags": "gi",
+          "description": "Detects time-based blind SQLi via MSSQL WAITFOR DELAY",
+          "redos_safe": true
+        },
+        {
+          "id": "sqli-oracle-dbms-packages",
+          "pattern": "\\bDBMS_(?:LOCK|PIPE|UTILITY|XSLPROCESSOR|JAVA|OUTPUT|SCHEDULER)\\b",
+          "flags": "gi",
+          "description": "Detects Oracle DBMS_* package references used in time-based blind SQLi (DBMS_LOCK.SLEEP, DBMS_PIPE.RECEIVE_MESSAGE) and other Oracle stdlib abuse paths. Broad match — no legitimate user input contains these (improvements.md §1.1.e Q3).",
+          "redos_safe": true
         }
       ]
     },
@@ -169,13 +267,13 @@
       "rules": [
         {
           "id": "nosql-operators",
-          "pattern": "\\$(?:gt|gte|lt|lte|ne|eq|in|nin|and|or|not|exists|type|regex|where|expr)",
+          "pattern": "\\$(?:gt|gte|lt|lte|ne|eq|in|nin|and|or|not|nor|exists|type|regex|where|expr|mod|text|jsonSchema|function|accumulator|elemMatch|all|size|lookup|match|project|group|sort|limit|skip|unwind|addFields|replaceRoot)",
           "flags": "i",
           "description": "Detects MongoDB operators",
           "redos_safe": true
         }
       ],
-      "dangerous_keys": ["$gt", "$gte", "$lt", "$lte", "$ne", "$eq", "$in", "$nin", "$and", "$or", "$not", "$exists", "$type", "$regex", "$where", "$expr"]
+      "dangerous_keys": ["$gt", "$gte", "$lt", "$lte", "$ne", "$eq", "$in", "$nin", "$and", "$or", "$not", "$nor", "$exists", "$type", "$regex", "$where", "$expr", "$mod", "$text", "$jsonSchema", "$function", "$accumulator", "$elemMatch", "$all", "$size", "$lookup", "$match", "$project", "$group", "$sort", "$limit", "$skip", "$unwind", "$addFields", "$replaceRoot"]
     },
     "command_injection": {
       "name": "Command Injection",
@@ -184,23 +282,37 @@
       "rules": [
         {
           "id": "cmdi-shell-chars",
-          "pattern": "[;&|`$()]",
+          "pattern": "[;&|`]",
           "flags": "g",
-          "description": "Detects shell metacharacters",
+          "description": "Detects shell metacharacters that enable command chaining. Bare ( and ) are excluded — they appear in legitimate values (function calls in code fields, math expressions). Command substitution $(...) is caught by cmdi-command-substitution.",
           "redos_safe": true
         },
         {
-          "id": "cmdi-commands",
-          "pattern": "\\b(cat|ls|rm|mv|cp|wget|curl|nc|bash|sh|python|perl|ruby|php|node|powershell|cmd)\\b",
+          "id": "cmdi-command-substitution",
+          "pattern": "\\$\\(",
+          "flags": "g",
+          "description": "Detects command substitution syntax $( — paired form, fewer false positives than bare parens",
+          "redos_safe": true
+        },
+        {
+          "id": "cmdi-ifs-bypass",
+          "pattern": "\\$\\{IFS(?:%[^}]*)?\\}",
+          "flags": "g",
+          "description": "Detects POSIX shell IFS substitution like ${IFS} or ${IFS%??}. Attackers use this to inject spaces past metacharacter filters in commands like `;cat${IFS}/etc/passwd` (improvements.md §1.1.e Q5).",
+          "redos_safe": true
+        },
+        {
+          "id": "cmdi-control-chars",
+          "pattern": "%0[0-9a-fA-F]",
           "flags": "gi",
-          "description": "Detects common shell commands",
+          "description": "Detects URL-encoded control characters (%00-%0F) including null, tab, vertical tab, form feed, LF, CR",
           "redos_safe": true
         },
         {
           "id": "cmdi-redirection",
-          "pattern": "(>>|<<|>|<)\\s*[/\\w]",
+          "pattern": "(>>|<<|[<>]\\s+[/\\w])",
           "flags": "g",
-          "description": "Detects shell redirection",
+          "description": "Detects shell redirection operators. Requires whitespace before the path for single < or > to avoid false-positives on HTML tags like <b> or </b>.",
           "redos_safe": true
         }
       ]
@@ -239,10 +351,52 @@
           "redos_safe": true
         },
         {
+          "id": "path-double-encoded-slash",
+          "pattern": "%252f",
+          "flags": "gi",
+          "description": "Detects double URL-encoded forward slash",
+          "redos_safe": true
+        },
+        {
+          "id": "path-dotdotslash-bypass",
+          "pattern": "\\.{2,}[/\\\\]{2,}",
+          "flags": "g",
+          "description": "Detects ....// and ....\\\\ bypass variants",
+          "redos_safe": true
+        },
+        {
           "id": "path-null-byte",
           "pattern": "%00",
           "flags": "gi",
-          "description": "Detects null byte injection",
+          "description": "Detects URL-encoded null byte injection",
+          "redos_safe": true
+        },
+        {
+          "id": "path-null-byte-literal",
+          "pattern": "\\x00",
+          "flags": "g",
+          "description": "Detects literal NUL byte in path inputs",
+          "redos_safe": true
+        },
+        {
+          "id": "path-mixed-encoded",
+          "pattern": "\\.\\.%2[fF]",
+          "flags": "g",
+          "description": "Detects mixed encoding: literal `..` followed by URL-encoded slash (%2F). Benchmark B6 — Python had no coverage; Node had this pattern. 2026-06-07.",
+          "redos_safe": true
+        },
+        {
+          "id": "path-overlong-utf8-dot",
+          "pattern": "%[Cc]0%[Aa][Ee]",
+          "flags": "g",
+          "description": "Detects overlong UTF-8 encoding of '.' (%C0%AE). Historic IIS/Apache decoder bypass. Real char `.` is %2E; overlong encoding only appears in evasion attempts. Benchmark B6 gap — neither SDK caught this before. 2026-06-07.",
+          "redos_safe": true
+        },
+        {
+          "id": "path-windows-unc",
+          "pattern": "\\\\\\\\[A-Za-z0-9_.-]+\\\\",
+          "flags": "g",
+          "description": "Detects Windows UNC paths (\\\\\\\\server\\\\share) in user input. Legitimate web-app inputs never contain UNC references; attacker UNC payloads leak SMB auth or pull remote payloads. Benchmark B6. 2026-06-07.",
           "redos_safe": true
         }
       ]
@@ -252,7 +406,7 @@
       "severity": "high",
       "owasp": "A03:2021",
       "languages": ["javascript", "typescript"],
-      "dangerous_keys": ["__proto__", "constructor", "prototype"]
+      "dangerous_keys": ["__proto__", "constructor", "prototype", "__definegetter__", "__definesetter__", "__lookupgetter__", "__lookupsetter__"]
     },
     "ldap_injection": {
       "name": "LDAP Injection",
@@ -263,7 +417,119 @@
           "id": "ldap-special",
           "pattern": "[()\\\\*]",
           "flags": "g",
-          "description": "Detects LDAP special characters",
+          "description": "Detects LDAP special characters. Broad rule for sanitization context only; NOT safe for request-boundary scanning (every parenthesised string trips it). Use 'ldap-injection-strict' below at request boundary.",
+          "redos_safe": true
+        },
+        {
+          "id": "ldap-injection-strict",
+          "pattern": "\\)\\s*\\(|\\*\\s*\\)\\s*\\(",
+          "flags": "g",
+          "description": "Detects attack-specific LDAP filter-break shapes ')(' and '*)('. Safe to wire into request-boundary scanners. Catches '*)(uid=*))(|(uid=*' style payloads.",
+          "redos_safe": true,
+          "request_boundary_safe": true
+        },
+        {
+          "id": "ldap-not-bypass",
+          "pattern": "\\)\\s*\\(\\s*!|&\\s*\\(\\s*!|\\|\\s*\\(\\s*!",
+          "flags": "g",
+          "description": "Detects LDAP NOT-operator bypass shapes ')(!', '&(!', and '|(!'. Catches injections where attacker appends a NOT clause to enumerate or exclude specific entries, e.g. '*)(uid=*)(!(uid=admin))'. Companion to ldap-injection-strict; together they cover the OR-then-NOT enumeration corpus that legitimate LDAP queries never produce. (improvements.md Q8.)",
+          "redos_safe": true,
+          "request_boundary_safe": true
+        }
+      ]
+    },
+    "xpath_injection": {
+      "name": "XPath Injection",
+      "severity": "high",
+      "owasp": "A03:2021",
+      "rules": [
+        {
+          "id": "xpath-injection-strict",
+          "pattern": "('\\s*(or|and)\\s*'|\"\\s*(or|and)\\s*\"|\\)\\s*(or|and)\\s*\\(|\\|\\s*/)",
+          "flags": "gi",
+          "description": "Detects XPath injection patterns: boolean-injection (' or ' / \" or \"), function-arity tampering with closing+opening parens around or/and, and union operator before path step. Request-boundary safe.",
+          "redos_safe": true,
+          "request_boundary_safe": true
+        }
+      ]
+    },
+    "email_header_injection": {
+      "name": "Email Header Injection (SMTP CRLF)",
+      "severity": "high",
+      "owasp": "A03:2021",
+      "rules": [
+        {
+          "id": "email-header-smtp-keyword",
+          "pattern": "(\\r\\n|\\r|\\n)\\s*(bcc|cc|to|from|subject|reply-to|return-path|content-type|x-mailer)\\s*:",
+          "flags": "gi",
+          "description": "Detects SMTP header injection: CR/LF followed by a known SMTP header keyword. Narrow enough for request-boundary scanning because legitimate user input rarely contains '\\nBcc:' verbatim.",
+          "redos_safe": true,
+          "request_boundary_safe": true
+        },
+        {
+          "id": "email-header-bare-newline",
+          "pattern": "(\\r\\n|\\r|\\n)\\s*[a-z][a-z0-9-]{0,40}\\s*:",
+          "flags": "gi",
+          "description": "Detects bare CR/LF followed by ANY plausible header keyword (not just the SMTP allowlist). Catches MTAs that accept bare LF or bare CR as a header separator (qmail, sendmail variants), where attacker bypasses the strict keyword list by injecting a non-SMTP-keyword header (X-Custom, Authentication-Results, DKIM-Signature, ...). Companion to email-header-smtp-keyword; together they cover the bypass class. (improvements.md Q10.)",
+          "redos_safe": true,
+          "request_boundary_safe": true
+        }
+      ]
+    },
+    "ssti": {
+      "name": "Server-Side Template Injection (SSTI)",
+      "severity": "critical",
+      "owasp": "A03:2021",
+      "rules": [
+        {
+          "id": "ssti-jinja2-twig",
+          "pattern": "\\{\\{.*?\\}\\}",
+          "flags": "g",
+          "description": "Detects Jinja2/Twig/Nunjucks template expressions ({{ ... }})",
+          "redos_safe": true
+        },
+        {
+          "id": "ssti-freemarker-spring",
+          "pattern": "\\$\\{.*?\\}",
+          "pattern_safe": "\\$\\{[^}]*[?!()*+\\-/][^}]*\\}",
+          "flags": "g",
+          "description": "Detects Freemarker/Thymeleaf/Spring EL expressions. Detection uses broad pattern; sanitization uses pattern_safe which requires operators/method-calls to avoid false-positives on JS template literals like ${name}.",
+          "redos_safe": true
+        },
+        {
+          "id": "ssti-erb-ejs",
+          "pattern": "<%[=\\-]?.*?%>",
+          "flags": "gs",
+          "description": "Detects ERB/EJS template tags (<%= ... %>, <% ... %>)",
+          "redos_safe": true
+        },
+        {
+          "id": "ssti-pug-jade",
+          "pattern": "#\\{.*?\\}",
+          "pattern_safe": "#\\{[^}]*[?!()*+\\-/][^}]*\\}",
+          "flags": "g",
+          "description": "Detects Pug/Jade/Slim template expressions. Detection uses broad pattern; sanitization uses pattern_safe to avoid false-positives on Ruby/Pug output like #{name}.",
+          "redos_safe": true
+        },
+        {
+          "id": "ssti-python-class-chain",
+          "pattern": "__(?:class|mro|subclasses|globals|builtins|import)__",
+          "flags": "gi",
+          "description": "Detects Python sandbox escape via dunder attributes",
+          "redos_safe": true
+        },
+        {
+          "id": "ssti-config-leak",
+          "pattern": "\\{\\{\\s*config[.\\[]",
+          "flags": "gi",
+          "description": "Detects Jinja2 config/settings leak attempts",
+          "redos_safe": true
+        },
+        {
+          "id": "ssti-jinja2-functions",
+          "pattern": "\\{\\{\\s*(?:self|request|lipsum|cycler|joiner|namespace|range)\\b",
+          "flags": "gi",
+          "description": "Detects Jinja2 built-in object/function access",
           "redos_safe": true
         }
       ]

--- a/packages/arcis-rust/crates/arcis-data/data/patterns.json
+++ b/packages/arcis-rust/crates/arcis-data/data/patterns.json
@@ -1,6 +1,13 @@
 {
   "version": "1.1.0",
   "description": "Arcis Core Security Patterns - Language Agnostic",
+  "_pattern_convention": {
+    "description": "Pattern field naming convention for SDK implementers",
+    "pattern": "The primary regex pattern. May contain ReDoS-vulnerable constructs.",
+    "pattern_safe": "ReDoS-safe alternative pattern. SDKs MUST prefer this when available.",
+    "redos_safe": "Boolean indicating if 'pattern' is ReDoS-safe. If false, use 'pattern_safe'.",
+    "usage": "pattern_str = rule.get('pattern_safe') or rule.get('pattern')"
+  },
   "config": {
     "max_input_size": 1000000,
     "max_recursion_depth": 10,
@@ -13,53 +20,94 @@
       "owasp": "A03:2021",
       "rules": [
         {
-          "id": "xss-script-tag",
-          "pattern": "<script\\b[^<]*(?:(?!</script>)<[^<]*)*</script>",
-          "pattern_safe": "<script[^>]*>[\\s\\S]*?</script>",
+          "id": "xss-script-block",
+          "pattern": "<script[^>]*>[\\s\\S]*?</script>",
           "flags": "gi",
-          "description": "Detects script tags",
-          "redos_safe": false
-        },
-        {
-          "id": "xss-javascript-protocol",
-          "pattern": "javascript:",
-          "flags": "gi",
-          "description": "Detects javascript: protocol",
+          "description": "Detects full script blocks (open tag through close tag)",
           "redos_safe": true
         },
         {
-          "id": "xss-event-handler",
-          "pattern": "on\\w+\\s*=",
+          "id": "xss-script-tag",
+          "pattern": "<script[^>]*>",
           "flags": "gi",
-          "description": "Detects inline event handlers",
+          "description": "Detects standalone or unclosed script tags",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-javascript-protocol",
+          "pattern": "javascript\\s*:",
+          "flags": "gi",
+          "description": "Detects javascript: protocol (allows whitespace around colon)",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-event-handler-quoted",
+          "pattern": "(?:[\\s/])on\\w+\\s*=\\s*[\"'][^\"']*[\"']",
+          "flags": "gi",
+          "description": "Detects inline event handlers with quoted values (e.g. onclick=\"alert(1)\")",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-event-handler-unquoted",
+          "pattern": "(?:[\\s/])on\\w+\\s*=\\s*[^\\s>]*",
+          "flags": "gi",
+          "description": "Detects inline event handlers with unquoted values (e.g. onload=value)",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-iframe-block",
+          "pattern": "<iframe[^>]*>[\\s\\S]*?</iframe>",
+          "flags": "gi",
+          "description": "Detects full iframe blocks",
           "redos_safe": true
         },
         {
           "id": "xss-iframe",
-          "pattern": "<iframe",
+          "pattern": "<iframe[^>]*",
           "flags": "gi",
-          "description": "Detects iframe tags",
+          "description": "Detects iframe tags (partial or unclosed)",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-style-block",
+          "pattern": "<style[^>]*>[\\s\\S]*?</style>",
+          "flags": "gi",
+          "description": "Detects full style blocks (CSS injection, expression(), behavior: attacks)",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-style-tag",
+          "pattern": "<style[^>]*",
+          "flags": "gi",
+          "description": "Detects style tags (partial or unclosed)",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-object-block",
+          "pattern": "<object[^>]*>[\\s\\S]*?</object>",
+          "flags": "gi",
+          "description": "Detects full object blocks",
           "redos_safe": true
         },
         {
           "id": "xss-object",
-          "pattern": "<object",
+          "pattern": "<object[^>]*",
           "flags": "gi",
-          "description": "Detects object tags",
+          "description": "Detects object tags (partial or unclosed)",
           "redos_safe": true
         },
         {
           "id": "xss-embed",
-          "pattern": "<embed",
+          "pattern": "<embed[^>]*",
           "flags": "gi",
           "description": "Detects embed tags",
           "redos_safe": true
         },
         {
           "id": "xss-data-uri",
-          "pattern": "data:",
+          "pattern": "data\\s*:\\s*(?:text/html|image/svg)[^>\\s]*",
           "flags": "gi",
-          "description": "Detects data: URIs",
+          "description": "Detects data: URIs with HTML or SVG content (avoids 'metadata' false positives)",
           "redos_safe": true
         },
         {
@@ -78,9 +126,37 @@
         },
         {
           "id": "xss-svg-onload",
-          "pattern": "<svg[^>]*onload",
+          "pattern": "<svg[^>]*onload[^>]*>",
           "flags": "gi",
-          "description": "Detects SVG with onload",
+          "description": "Detects SVG with inline event handlers",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-form-injection",
+          "pattern": "<form[\\s>][^>]*",
+          "flags": "gi",
+          "description": "Detects form tags used for phishing/credential harvesting via action= redirection",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-meta-injection",
+          "pattern": "<meta[\\s>][^>]*",
+          "flags": "gi",
+          "description": "Detects meta tags used for http-equiv refresh redirects or CSP bypass",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-base-injection",
+          "pattern": "<base[\\s>][^>]*",
+          "flags": "gi",
+          "description": "Detects base href hijacking — redirects all relative URLs to attacker domain",
+          "redos_safe": true
+        },
+        {
+          "id": "xss-link-injection",
+          "pattern": "<link[\\s>][^>]*",
+          "flags": "gi",
+          "description": "Detects link tag injection used for stylesheet or preload CSRF attacks",
           "redos_safe": true
         }
       ],
@@ -99,16 +175,17 @@
       "rules": [
         {
           "id": "sqli-keywords",
-          "pattern": "\\b(SELECT|INSERT|UPDATE|DELETE|DROP|UNION|ALTER|CREATE|TRUNCATE|EXEC|EXECUTE)\\b",
+          "pattern": "(\\bUNION\\s+(?:ALL\\s+)?SELECT\\b)|(\\b(?:DROP|TRUNCATE)\\s+(?:TABLE|DATABASE|INDEX|VIEW|SCHEMA)\\b)|(\\bINTO\\s+(?:OUTFILE|DUMPFILE)\\b)|(\\bATTACH\\s+DATABASE\\b)|(\\bCREATE\\s+(?:USER|FUNCTION|TRIGGER|PROCEDURE)\\b)|(\\bGRANT\\s+(?:ALL|SELECT|INSERT|UPDATE|DELETE)\\b)|(\\bSHUTDOWN\\b)|(\\bxp_cmdshell\\b)|(\\bsp_executesql\\b)",
           "flags": "gi",
-          "description": "Detects SQL keywords",
-          "redos_safe": true
+          "description": "Multi-token SQL attack shapes (UNION SELECT, DROP TABLE, INTO OUTFILE, etc.) that real attackers use and benign users essentially never type. Replaces older bare-keyword rule that false-positived on 'please select an option', 'I'll update you tomorrow'. Benchmark FP class B3, 2026-06-07.",
+          "redos_safe": true,
+          "request_boundary_safe": true
         },
         {
           "id": "sqli-comments",
           "pattern": "(--|/\\*|\\*/)",
           "flags": "g",
-          "description": "Detects SQL comments",
+          "description": "Detects SQL comments. MySQL `#` line comment intentionally excluded to avoid FP on hex colors / hashtags / issue refs; real `admin' #` injections are still caught by the quote + keyword combo patterns.",
           "redos_safe": true
         },
         {
@@ -159,6 +236,27 @@
           "flags": "gi",
           "description": "Detects time-based blind SQLi via BENCHMARK",
           "redos_safe": true
+        },
+        {
+          "id": "sqli-pg-sleep",
+          "pattern": "\\bpg_sleep\\s*\\(",
+          "flags": "gi",
+          "description": "Detects time-based blind SQLi via PostgreSQL pg_sleep",
+          "redos_safe": true
+        },
+        {
+          "id": "sqli-waitfor-delay",
+          "pattern": "\\bWAITFOR\\s+DELAY\\b",
+          "flags": "gi",
+          "description": "Detects time-based blind SQLi via MSSQL WAITFOR DELAY",
+          "redos_safe": true
+        },
+        {
+          "id": "sqli-oracle-dbms-packages",
+          "pattern": "\\bDBMS_(?:LOCK|PIPE|UTILITY|XSLPROCESSOR|JAVA|OUTPUT|SCHEDULER)\\b",
+          "flags": "gi",
+          "description": "Detects Oracle DBMS_* package references used in time-based blind SQLi (DBMS_LOCK.SLEEP, DBMS_PIPE.RECEIVE_MESSAGE) and other Oracle stdlib abuse paths. Broad match — no legitimate user input contains these (improvements.md §1.1.e Q3).",
+          "redos_safe": true
         }
       ]
     },
@@ -169,13 +267,13 @@
       "rules": [
         {
           "id": "nosql-operators",
-          "pattern": "\\$(?:gt|gte|lt|lte|ne|eq|in|nin|and|or|not|exists|type|regex|where|expr)",
+          "pattern": "\\$(?:gt|gte|lt|lte|ne|eq|in|nin|and|or|not|nor|exists|type|regex|where|expr|mod|text|jsonSchema|function|accumulator|elemMatch|all|size|lookup|match|project|group|sort|limit|skip|unwind|addFields|replaceRoot)",
           "flags": "i",
           "description": "Detects MongoDB operators",
           "redos_safe": true
         }
       ],
-      "dangerous_keys": ["$gt", "$gte", "$lt", "$lte", "$ne", "$eq", "$in", "$nin", "$and", "$or", "$not", "$exists", "$type", "$regex", "$where", "$expr"]
+      "dangerous_keys": ["$gt", "$gte", "$lt", "$lte", "$ne", "$eq", "$in", "$nin", "$and", "$or", "$not", "$nor", "$exists", "$type", "$regex", "$where", "$expr", "$mod", "$text", "$jsonSchema", "$function", "$accumulator", "$elemMatch", "$all", "$size", "$lookup", "$match", "$project", "$group", "$sort", "$limit", "$skip", "$unwind", "$addFields", "$replaceRoot"]
     },
     "command_injection": {
       "name": "Command Injection",
@@ -184,23 +282,37 @@
       "rules": [
         {
           "id": "cmdi-shell-chars",
-          "pattern": "[;&|`$()]",
+          "pattern": "[;&|`]",
           "flags": "g",
-          "description": "Detects shell metacharacters",
+          "description": "Detects shell metacharacters that enable command chaining. Bare ( and ) are excluded — they appear in legitimate values (function calls in code fields, math expressions). Command substitution $(...) is caught by cmdi-command-substitution.",
           "redos_safe": true
         },
         {
-          "id": "cmdi-commands",
-          "pattern": "\\b(cat|ls|rm|mv|cp|wget|curl|nc|bash|sh|python|perl|ruby|php|node|powershell|cmd)\\b",
+          "id": "cmdi-command-substitution",
+          "pattern": "\\$\\(",
+          "flags": "g",
+          "description": "Detects command substitution syntax $( — paired form, fewer false positives than bare parens",
+          "redos_safe": true
+        },
+        {
+          "id": "cmdi-ifs-bypass",
+          "pattern": "\\$\\{IFS(?:%[^}]*)?\\}",
+          "flags": "g",
+          "description": "Detects POSIX shell IFS substitution like ${IFS} or ${IFS%??}. Attackers use this to inject spaces past metacharacter filters in commands like `;cat${IFS}/etc/passwd` (improvements.md §1.1.e Q5).",
+          "redos_safe": true
+        },
+        {
+          "id": "cmdi-control-chars",
+          "pattern": "%0[0-9a-fA-F]",
           "flags": "gi",
-          "description": "Detects common shell commands",
+          "description": "Detects URL-encoded control characters (%00-%0F) including null, tab, vertical tab, form feed, LF, CR",
           "redos_safe": true
         },
         {
           "id": "cmdi-redirection",
-          "pattern": "(>>|<<|>|<)\\s*[/\\w]",
+          "pattern": "(>>|<<|[<>]\\s+[/\\w])",
           "flags": "g",
-          "description": "Detects shell redirection",
+          "description": "Detects shell redirection operators. Requires whitespace before the path for single < or > to avoid false-positives on HTML tags like <b> or </b>.",
           "redos_safe": true
         }
       ]
@@ -239,10 +351,52 @@
           "redos_safe": true
         },
         {
+          "id": "path-double-encoded-slash",
+          "pattern": "%252f",
+          "flags": "gi",
+          "description": "Detects double URL-encoded forward slash",
+          "redos_safe": true
+        },
+        {
+          "id": "path-dotdotslash-bypass",
+          "pattern": "\\.{2,}[/\\\\]{2,}",
+          "flags": "g",
+          "description": "Detects ....// and ....\\\\ bypass variants",
+          "redos_safe": true
+        },
+        {
           "id": "path-null-byte",
           "pattern": "%00",
           "flags": "gi",
-          "description": "Detects null byte injection",
+          "description": "Detects URL-encoded null byte injection",
+          "redos_safe": true
+        },
+        {
+          "id": "path-null-byte-literal",
+          "pattern": "\\x00",
+          "flags": "g",
+          "description": "Detects literal NUL byte in path inputs",
+          "redos_safe": true
+        },
+        {
+          "id": "path-mixed-encoded",
+          "pattern": "\\.\\.%2[fF]",
+          "flags": "g",
+          "description": "Detects mixed encoding: literal `..` followed by URL-encoded slash (%2F). Benchmark B6 — Python had no coverage; Node had this pattern. 2026-06-07.",
+          "redos_safe": true
+        },
+        {
+          "id": "path-overlong-utf8-dot",
+          "pattern": "%[Cc]0%[Aa][Ee]",
+          "flags": "g",
+          "description": "Detects overlong UTF-8 encoding of '.' (%C0%AE). Historic IIS/Apache decoder bypass. Real char `.` is %2E; overlong encoding only appears in evasion attempts. Benchmark B6 gap — neither SDK caught this before. 2026-06-07.",
+          "redos_safe": true
+        },
+        {
+          "id": "path-windows-unc",
+          "pattern": "\\\\\\\\[A-Za-z0-9_.-]+\\\\",
+          "flags": "g",
+          "description": "Detects Windows UNC paths (\\\\\\\\server\\\\share) in user input. Legitimate web-app inputs never contain UNC references; attacker UNC payloads leak SMB auth or pull remote payloads. Benchmark B6. 2026-06-07.",
           "redos_safe": true
         }
       ]
@@ -252,7 +406,7 @@
       "severity": "high",
       "owasp": "A03:2021",
       "languages": ["javascript", "typescript"],
-      "dangerous_keys": ["__proto__", "constructor", "prototype"]
+      "dangerous_keys": ["__proto__", "constructor", "prototype", "__definegetter__", "__definesetter__", "__lookupgetter__", "__lookupsetter__"]
     },
     "ldap_injection": {
       "name": "LDAP Injection",
@@ -263,7 +417,119 @@
           "id": "ldap-special",
           "pattern": "[()\\\\*]",
           "flags": "g",
-          "description": "Detects LDAP special characters",
+          "description": "Detects LDAP special characters. Broad rule for sanitization context only; NOT safe for request-boundary scanning (every parenthesised string trips it). Use 'ldap-injection-strict' below at request boundary.",
+          "redos_safe": true
+        },
+        {
+          "id": "ldap-injection-strict",
+          "pattern": "\\)\\s*\\(|\\*\\s*\\)\\s*\\(",
+          "flags": "g",
+          "description": "Detects attack-specific LDAP filter-break shapes ')(' and '*)('. Safe to wire into request-boundary scanners. Catches '*)(uid=*))(|(uid=*' style payloads.",
+          "redos_safe": true,
+          "request_boundary_safe": true
+        },
+        {
+          "id": "ldap-not-bypass",
+          "pattern": "\\)\\s*\\(\\s*!|&\\s*\\(\\s*!|\\|\\s*\\(\\s*!",
+          "flags": "g",
+          "description": "Detects LDAP NOT-operator bypass shapes ')(!', '&(!', and '|(!'. Catches injections where attacker appends a NOT clause to enumerate or exclude specific entries, e.g. '*)(uid=*)(!(uid=admin))'. Companion to ldap-injection-strict; together they cover the OR-then-NOT enumeration corpus that legitimate LDAP queries never produce. (improvements.md Q8.)",
+          "redos_safe": true,
+          "request_boundary_safe": true
+        }
+      ]
+    },
+    "xpath_injection": {
+      "name": "XPath Injection",
+      "severity": "high",
+      "owasp": "A03:2021",
+      "rules": [
+        {
+          "id": "xpath-injection-strict",
+          "pattern": "('\\s*(or|and)\\s*'|\"\\s*(or|and)\\s*\"|\\)\\s*(or|and)\\s*\\(|\\|\\s*/)",
+          "flags": "gi",
+          "description": "Detects XPath injection patterns: boolean-injection (' or ' / \" or \"), function-arity tampering with closing+opening parens around or/and, and union operator before path step. Request-boundary safe.",
+          "redos_safe": true,
+          "request_boundary_safe": true
+        }
+      ]
+    },
+    "email_header_injection": {
+      "name": "Email Header Injection (SMTP CRLF)",
+      "severity": "high",
+      "owasp": "A03:2021",
+      "rules": [
+        {
+          "id": "email-header-smtp-keyword",
+          "pattern": "(\\r\\n|\\r|\\n)\\s*(bcc|cc|to|from|subject|reply-to|return-path|content-type|x-mailer)\\s*:",
+          "flags": "gi",
+          "description": "Detects SMTP header injection: CR/LF followed by a known SMTP header keyword. Narrow enough for request-boundary scanning because legitimate user input rarely contains '\\nBcc:' verbatim.",
+          "redos_safe": true,
+          "request_boundary_safe": true
+        },
+        {
+          "id": "email-header-bare-newline",
+          "pattern": "(\\r\\n|\\r|\\n)\\s*[a-z][a-z0-9-]{0,40}\\s*:",
+          "flags": "gi",
+          "description": "Detects bare CR/LF followed by ANY plausible header keyword (not just the SMTP allowlist). Catches MTAs that accept bare LF or bare CR as a header separator (qmail, sendmail variants), where attacker bypasses the strict keyword list by injecting a non-SMTP-keyword header (X-Custom, Authentication-Results, DKIM-Signature, ...). Companion to email-header-smtp-keyword; together they cover the bypass class. (improvements.md Q10.)",
+          "redos_safe": true,
+          "request_boundary_safe": true
+        }
+      ]
+    },
+    "ssti": {
+      "name": "Server-Side Template Injection (SSTI)",
+      "severity": "critical",
+      "owasp": "A03:2021",
+      "rules": [
+        {
+          "id": "ssti-jinja2-twig",
+          "pattern": "\\{\\{.*?\\}\\}",
+          "flags": "g",
+          "description": "Detects Jinja2/Twig/Nunjucks template expressions ({{ ... }})",
+          "redos_safe": true
+        },
+        {
+          "id": "ssti-freemarker-spring",
+          "pattern": "\\$\\{.*?\\}",
+          "pattern_safe": "\\$\\{[^}]*[?!()*+\\-/][^}]*\\}",
+          "flags": "g",
+          "description": "Detects Freemarker/Thymeleaf/Spring EL expressions. Detection uses broad pattern; sanitization uses pattern_safe which requires operators/method-calls to avoid false-positives on JS template literals like ${name}.",
+          "redos_safe": true
+        },
+        {
+          "id": "ssti-erb-ejs",
+          "pattern": "<%[=\\-]?.*?%>",
+          "flags": "gs",
+          "description": "Detects ERB/EJS template tags (<%= ... %>, <% ... %>)",
+          "redos_safe": true
+        },
+        {
+          "id": "ssti-pug-jade",
+          "pattern": "#\\{.*?\\}",
+          "pattern_safe": "#\\{[^}]*[?!()*+\\-/][^}]*\\}",
+          "flags": "g",
+          "description": "Detects Pug/Jade/Slim template expressions. Detection uses broad pattern; sanitization uses pattern_safe to avoid false-positives on Ruby/Pug output like #{name}.",
+          "redos_safe": true
+        },
+        {
+          "id": "ssti-python-class-chain",
+          "pattern": "__(?:class|mro|subclasses|globals|builtins|import)__",
+          "flags": "gi",
+          "description": "Detects Python sandbox escape via dunder attributes",
+          "redos_safe": true
+        },
+        {
+          "id": "ssti-config-leak",
+          "pattern": "\\{\\{\\s*config[.\\[]",
+          "flags": "gi",
+          "description": "Detects Jinja2 config/settings leak attempts",
+          "redos_safe": true
+        },
+        {
+          "id": "ssti-jinja2-functions",
+          "pattern": "\\{\\{\\s*(?:self|request|lipsum|cycler|joiner|namespace|range)\\b",
+          "flags": "gi",
+          "description": "Detects Jinja2 built-in object/function access",
           "redos_safe": true
         }
       ]


### PR DESCRIPTION
The Python wheel bundles its own patterns.json at arcis/data/patterns.json. The previous release updated the canonical packages/core/patterns.json but the bundled copy was not synced, so pip-installed users see no behavior change for the SQL keyword updates.

This PR re-syncs all three locations to a single hash:

* packages/arcis-python/arcis/data/patterns.json (wheel bundled)
* packages/arcis-rust/crates/arcis-data/data/patterns.json (Rust crate)
* packages/arcis-python/arcis/core/constants.py get_embedded_patterns()

After merging this and shipping the next release, pip install arcis will produce the same behavior as the development install for the SQL keyword and LDAP rules.