### PR TITLE
chore: release v1.7.0

### DIFF
--- a/packages/arcis-cli-npm/package.json
+++ b/packages/arcis-cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/cli",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Arcis security CLI — scan running apps, audit source, and check dependencies. Native Rust binary distributed via npm.",
   "keywords": [
     "security",

--- a/packages/arcis-node/package.json
+++ b/packages/arcis-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcis/node",
-  "version": "1.6.6",
+  "version": "1.7.0",
   "description": "Inside-the-app security middleware for Node.js. Express and NestJS run the full sanitizer pipeline (XSS, SQL, NoSQL, SSTI, XXE, path, command, prompt injection, prototype pollution, LDAP, XPath, header injection, plus 20+ more attack types). Fastify, Koa, Hono, Next.js, SvelteKit, Astro, Nuxt, and Bun ship rate-limit + bot detection + security headers as v1 adapters; pair them with `sanitizeObject` from @arcis/node/sanitizers for body inspection. v1.6 ships interactive REPL, NFKC + multi-decode hardening, deserialization markers (V33), GraphQL alias-bomb guard (V34), and a stateful per-IP correlation window. Includes prompt-injection signature library, LLM token-budget middleware, 695-pattern bot corpus, and the @arcis/cli native CLI.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/arcis-python/arcis/__init__.py
+++ b/packages/arcis-python/arcis/__init__.py
@@ -213,7 +213,7 @@ try:
 except ImportError:
     _HAS_ASYNC = False
 
-__version__ = "1.6.6"
+__version__ = "1.7.0"
 __all__ = [
     # Main class
     "Arcis",

--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arcis"
-version = "1.6.6"
+version = "1.7.0"
 description = "Inside-the-app security middleware for Python. FastAPI, Django, Litestar run the full sanitizer pipeline (XSS, SQL, NoSQL, path, command, SSTI, XXE, LDAP, XPath, email-header, prototype). Flask is sanitize-only. Default-on in the framework middleware: 695-pattern bot screening, scanner-path + per-IP correlation, SSRF body checks, mass-assignment detection, GraphQL guard, and prompt-injection (V32 toolcall) + deserialization (V33) signatures. Opt-in: CSRF, HPP, LLM token-budget. Same API as the Node and Go SDKs. CLI ships at npm install -g @arcis/cli."
 readme = "README.md"
 license = "MIT"

--- a/packages/arcis-rust/Cargo.toml
+++ b/packages/arcis-rust/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Gagan CM <cm.g@northeastern.edu>"]

--- a/release-notes/v1.7.0.md
+++ b/release-notes/v1.7.0.md
@@ -1,0 +1,26 @@
+## Features
+
+- Default-on protection. Bot detection, scanner-path and per-IP correlation tracking, GraphQL abuse limits, mass-assignment detection, SSRF checks on URL body fields, prompt-injection screening, and forwarded-header inspection now run by default in the core middleware and the Express, FastAPI, Django, Litestar, gin, echo, chi, fiber, and net/http adapters. These previously required opt-in calls.
+- New SECURITY_SCANNER bot category. Offensive scanners (sqlmap, nikto, nuclei, nmap, masscan, wpscan, Acunetix, Nessus, dirbuster) are blocked by default. Generic non-browser clients (curl, wget, python-requests, monitoring agents) are classified as scrapers and allowed by default, so health checks and server-to-server traffic keep working. Block scrapers explicitly by adding SCRAPER to the bot deny list.
+- Composite protect helpers for FastAPI, Litestar, Django, and the Go adapters. protect_login, protect_signup, and protect_api wire a shared correlation window and pull the client IP and route automatically.
+- Interactive console. Tab completion for commands, flags, and paths; severity filtering of findings; opening a finding's advisory URL; and a clean fallback on non-interactive terminals.
+- Supply chain database grown to 104 curated advisories.
+
+## Fixes
+
+- Cross-SDK pattern hardening: LDAP null-byte, XPath substring, SSTI velocity, deserialization markers, and tighter command-injection matching to reduce false positives on ordinary text.
+- NFKC and multi-decode normalization now apply in block mode, closing fullwidth and encoded bypasses on the blocking path.
+
+## Compatibility
+
+- No breaking API changes. The new default-on detectors can be turned off per option (for example, bot: false) if you need the previous behavior.
+- @arcis/node and arcis (PyPI): 1.7.0. @arcis/cli: 1.2.0. arcis-go: v2.1.0.
+
+## Install
+
+```
+npm install @arcis/node@1.7.0
+pip install arcis==1.7.0
+npm install -g @arcis/cli@1.2.0
+go get github.com/getarcis/arcis-go@v2.1.0
+```


### PR DESCRIPTION
Release prep for v1.7.0. No code changes, version bumps + release notes only.

- `@arcis/node` and `arcis` (PyPI): 1.6.6 -> 1.7.0
- `@arcis/cli` + Rust workspace: 1.1.1 -> 1.2.0 (REPL finishers + supply-chain additions shipped in the Rust CLI this cycle)
- Adds `release-notes/v1.7.0.md`, which the publish workflow now reads for the GitHub Release body.

Merge to `nwl`, then the `nwl -> main` release PR triggers publish. `arcis-go` ships separately via its own v2.1.0 tag (PR getarcis/arcis-go#1).
