### PR TITLE
fix: complete v1.7.0 publish (PyPI Summary under 512)

### DIFF
--- a/packages/arcis-python/pyproject.toml
+++ b/packages/arcis-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "arcis"
 version = "1.7.0"
-description = "Inside-the-app security middleware for Python. FastAPI, Django, Litestar run the full sanitizer pipeline (XSS, SQL, NoSQL, path, command, SSTI, XXE, LDAP, XPath, email-header, prototype). Flask is sanitize-only. Default-on in the framework middleware: 695-pattern bot screening, scanner-path + per-IP correlation, SSRF body checks, mass-assignment detection, GraphQL guard, and prompt-injection (V32 toolcall) + deserialization (V33) signatures. Opt-in: CSRF, HPP, LLM token-budget. Same API as the Node and Go SDKs. CLI ships at npm install -g @arcis/cli."
+description = "Inside-the-app security middleware for Python. FastAPI, Django, and Litestar run the full sanitizer pipeline (XSS, SQL, NoSQL, path, command, SSTI, XXE, LDAP, XPath, header, prototype); Flask is sanitize-only. Bot detection, scanner and per-IP correlation, SSRF body checks, mass-assignment detection, GraphQL limits, and prompt-injection screening run by default. Same API as the Node and Go SDKs. CLI: npm install -g @arcis/cli."
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
Completes the v1.7.0 release. The publish run failed only on PyPI: `twine upload` returned HTTP 400 because the package description (PyPI's `Summary` field) was 556 characters, over PyPI's 512 limit. `@arcis/node@1.7.0` published to npm successfully; the GitHub Release was skipped only because it depends on the Python job.

This shortens the Summary to 430 chars (verified with `twine check`). No code change, version stays 1.7.0.

On merge, publish.yml re-runs: npm skips (1.7.0 already published), PyPI publishes `arcis@1.7.0`, and the `v1.7.0` GitHub Release is created from `release-notes/v1.7.0.md`.
