### PR TITLE
Reposition @arcis/mcp as runtime security + anonymous opt-out CLI telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in the Arcis repository.
+
+## What this project is
+
+Arcis is one-line security middleware for web apps. It protects against 20+
+attack vectors with a consistent API across Node.js (`@arcis/node`), Python
+(`arcis`), and Go (`github.com/getarcis/arcis-go`), plus a Rust CLI scanner
+(`@arcis/cli`) and an MCP server (`@arcis/mcp`). Contract-first: a shared spec
+and a shared `packages/core/patterns.json` drive detection across every SDK.
+
+## Run Arcis on the code you are writing
+
+Arcis is itself a security tool. When working in any project, you can scan for
+vulnerabilities before committing:
+
+```bash
+npx @arcis/cli audit .     # static analysis for unsafe code patterns
+npx @arcis/cli sca .       # supply-chain scan against known-compromised packages
+```
+
+And add runtime protection in one line (Express shown):
+
+```js
+const { arcis } = require('@arcis/node');
+app.use(arcis({ block: true }));
+```
+
+## Build and test
+
+```bash
+# Node
+cd packages/arcis-node && npm ci && npm test && npm run typecheck
+# Python
+cd packages/arcis-python && pip install -e ".[dev]" && pytest
+# Rust CLI
+cd packages/arcis-rust && cargo test
+# Go SDK lives in its own repo: github.com/getarcis/arcis-go
+```
+
+## Rules that matter here
+
+- **Contract-first.** A feature starts in `spec/API_SPEC.md` +
+  `spec/TEST_VECTORS.json` + `packages/core/patterns.json`, then each SDK
+  implements it. Code in an SDK that is not in the spec is a smell.
+- **Cross-SDK parity.** The same input must produce the same result in Node,
+  Python, and Go. `patterns.json` is mirrored across SDK copies and must stay
+  byte-identical and RE2-safe (no backreferences or lookahead; Go uses RE2).
+- **Tests with every feature.** Both true positives (attacks caught) and true
+  negatives (safe input passes). Zero false positives is the brand promise.
+- **ReDoS-safe regex only.** No nested quantifiers; test against pathological
+  input.
+- **No em-dashes in user-facing strings** (README, docs, package descriptions,
+  blog, commit messages). Use periods or commas.
+
+## Docs
+
+Full documentation: https://github.com/getarcis/arcis and the docs site linked
+from the README. Security policy: `SECURITY.md`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+Arcis is security software, so we hold its own security to a high bar. Thank you
+for helping keep it and its users safe.
+
+## Reporting a vulnerability
+
+Please report security issues privately, not in public issues or pull requests.
+
+- Preferred: GitHub's private vulnerability reporting on this repository
+  (the "Report a vulnerability" button under the Security tab). This opens a
+  private advisory only the maintainers can see.
+
+Please include:
+
+- The affected package and version (`@arcis/node`, `arcis`, `arcis-go`,
+  `@arcis/cli`, or `@arcis/mcp`).
+- A description of the issue and its impact (for example, a bypass that lets a
+  payload reach the application, or a false negative in a detector).
+- A minimal reproduction: the input, the configuration, and the observed versus
+  expected behavior.
+
+## What to expect
+
+- We aim to acknowledge a report within 3 business days.
+- We will confirm the issue, assess severity, and share a remediation timeline.
+- Detection bypasses are treated as security issues across all SDKs at once,
+  since a bypass that works in one SDK is a bug in all of them.
+- With your consent, we credit reporters in the release notes for the fix.
+
+We do not run a paid bug-bounty program at this time. Responsible disclosure is
+genuinely appreciated regardless.
+
+## Scope
+
+In scope: the Arcis SDKs (Node, Python, Go), the CLI scanner, the MCP server,
+and the shared detection patterns. A detector that misses a real attack in a
+realistic shape, or a sanitizer that can be bypassed, is in scope.
+
+Out of scope: vulnerabilities in your own application that Arcis is not designed
+to cover (see "What Arcis Cannot Replace" in the documentation), denial of
+service via deliberately pathological input far above the configured size
+limits, and issues in third-party dependencies that have no impact through
+Arcis.
+
+## Supported versions
+
+Security fixes target the latest released minor of each package. Please upgrade
+to the current version before reporting, in case the issue is already fixed.

--- a/packages/arcis-mcp/README.md
+++ b/packages/arcis-mcp/README.md
@@ -1,11 +1,13 @@
 # @arcis/mcp
 
-> Model Context Protocol server for Arcis. Plugs Arcis security tools into Cursor and any MCP-aware AI agent.
+> Runtime application security for AI coding agents. An MCP server that lets Cursor and any MCP-aware client defend the app from the inside: screen prompts and inputs for injection, probe a running endpoint for live attack bypasses, and check code and dependencies.
 
 [![npm version](https://img.shields.io/npm/v/@arcis/mcp.svg?label=%40arcis%2Fmcp&color=00996D)](https://www.npmjs.com/package/@arcis/mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-`@arcis/mcp` is a tiny Node binary that speaks the [Model Context Protocol](https://modelcontextprotocol.io/) over stdio. It exposes four Arcis tools so an AI coding agent can ask Arcis to audit code, scan for compromised dependencies, probe a live endpoint, or check a prompt for injection signatures, all without leaving the agent.
+`@arcis/mcp` is a tiny Node binary that speaks the [Model Context Protocol](https://modelcontextprotocol.io/) over stdio. Most security MCP servers stop at static analysis. Arcis adds the runtime layer the scanners miss: it screens text headed for an LLM for prompt-injection and jailbreak signatures, and probes a live endpoint to confirm it actually blocks real attacks, alongside code audit and supply-chain checks. Four tools, no cloud round trip.
+
+This is the same thesis as the Arcis SDKs: a WAF guesses at the edge, Arcis defends from inside the app. The MCP server brings that to the agent, so the model can both write the code and verify the running app stops the attacks it cares about.
 
 ## Tools
 

--- a/packages/arcis-mcp/package.json
+++ b/packages/arcis-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arcis/mcp",
   "version": "1.6.1",
-  "description": "Arcis MCP server. Exposes Arcis CLI scanners (audit / scan / sca) and the prompt-injection detector as tools that Cursor and any other MCP-aware AI agent can call. One install, four tools, zero cloud round trip.",
+  "description": "Runtime application security for AI coding agents, as an MCP server. Lets Cursor and any MCP-aware client screen prompts and inputs for injection, probe a running endpoint for live attack bypasses, and check code and dependencies. Four tools, stdio, no cloud round trip.",
   "main": "dist/server.js",
   "bin": {
     "arcis-mcp": "dist/server.js"
@@ -22,10 +22,14 @@
     "model-context-protocol",
     "arcis",
     "security",
+    "runtime-security",
+    "application-security",
+    "ai-security",
+    "llm-security",
+    "agent-security",
+    "prompt-injection",
     "cursor",
-    "ai-agent",
-    "tool",
-    "prompt-injection"
+    "ai-agent"
   ],
   "author": "Gagan CM",
   "license": "MIT",

--- a/packages/arcis-mcp/server.json
+++ b/packages/arcis-mcp/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.getarcis/arcis",
+  "description": "Runtime application security for AI coding agents. Screen prompts and inputs for injection, probe a running endpoint for live attack bypasses, audit code, and check dependencies.",
+  "repository": {
+    "url": "https://github.com/getarcis/arcis",
+    "source": "github",
+    "subfolder": "packages/arcis-mcp"
+  },
+  "version": "1.6.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@arcis/mcp",
+      "version": "1.6.1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/arcis-mcp/src/server.ts
+++ b/packages/arcis-mcp/src/server.ts
@@ -275,7 +275,7 @@ export function createServer(): Server {
   const server = new Server(
     {
       name: 'arcis-mcp',
-      version: '1.5.0',
+      version: '1.6.1',
     },
     {
       capabilities: {

--- a/packages/arcis-rust/Cargo.lock
+++ b/packages/arcis-rust/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arcis-cli"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "arcis-data",
@@ -83,15 +83,17 @@ dependencies = [
  "clap",
  "crossterm",
  "ratatui",
+ "reqwest",
  "serde_json",
  "tempfile",
  "terminal_size",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
 name = "arcis-data"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -100,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "arcis-engine"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "arcis-data",
  "dirs",
@@ -471,6 +473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -478,6 +481,18 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -492,7 +507,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1260,7 +1278,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1878,6 +1898,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"

--- a/packages/arcis-rust/TELEMETRY.md
+++ b/packages/arcis-rust/TELEMETRY.md
@@ -1,0 +1,43 @@
+# Arcis CLI telemetry
+
+The `arcis` CLI sends anonymous usage statistics so development is steered by
+real usage. This page explains exactly what is collected and how to turn it off.
+
+## What is collected
+
+One event per command, containing only:
+
+| Field | Example | Why |
+|---|---|---|
+| `install_id` | random UUID v4 | Count distinct installs over time. Not tied to you. |
+| `cli_version` | `1.2.1` | Know which versions are in use. |
+| `command` | `audit` / `sca` / `scan` / `start` | Know which features are used. |
+| `os` | `linux` / `macos` / `windows` | Prioritize platform support. |
+| `arch` | `x86_64` / `aarch64` | Prioritize build targets. |
+| `ci` | `true` / `false` | Separate interactive use from automation. |
+
+## What is NOT collected
+
+No source code. No scanned file paths. No scan target URLs. No findings or
+vulnerability details. No request contents. No IP addresses (the collector does
+not log them). No usernames, emails, or any personal data. The `install_id` is a
+random UUID with no link to your identity or your code.
+
+## How to opt out
+
+Set either of these and the CLI sends nothing:
+
+```bash
+export ARCIS_TELEMETRY=0      # Arcis-specific kill switch
+export DO_NOT_TRACK=1         # cross-tool standard (https://consoledonottrack.com)
+```
+
+When telemetry is off, the command runs exactly as before. Telemetry is always
+fire-and-forget with a short timeout, so it never slows a command down or changes
+its exit code, even when on.
+
+## Where the data goes
+
+Events are POSTed to an Arcis-operated collector. The `install_id` file lives at
+`~/.arcis/install-id` (delete it any time to reset). A one-time notice is printed
+to stderr on first interactive use.

--- a/packages/arcis-rust/crates/arcis-cli/Cargo.toml
+++ b/packages/arcis-rust/crates/arcis-cli/Cargo.toml
@@ -31,6 +31,11 @@ terminal_size = "0.4"
 # crossterm (ratatui's default).
 ratatui = { workspace = true }
 crossterm = { workspace = true }
+# Anonymous, opt-out CLI telemetry (telemetry.rs). reqwest is already built
+# (async) via arcis-engine; we add the `blocking` feature for a fire-and-forget
+# POST on a detached thread. uuid generates the persistent anonymous install id.
+reqwest = { workspace = true, features = ["blocking"] }
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 # End-to-end CLI tests under `tests/` need scratch dirs for fixtures

--- a/packages/arcis-rust/crates/arcis-cli/src/main.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/main.rs
@@ -23,6 +23,7 @@ mod console;
 mod sca;
 mod scan;
 mod stub;
+mod telemetry;
 mod welcome;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -79,6 +80,10 @@ fn main() -> ExitCode {
     // which is rare but worth surfacing as a non-zero exit so wrapper
     // scripts can detect it.
     if argv.len() < 2 {
+        // Anonymous, opt-out (see telemetry.rs). Records that the CLI was run
+        // with no subcommand; the welcome/console/catalog choice below is a
+        // display detail we don't distinguish here.
+        telemetry::record("start");
         let stdout_is_tty = std::io::stdout().is_terminal();
         let stdin_is_tty = std::io::stdin().is_terminal();
         let in_ci = std::env::var("CI").is_ok();
@@ -140,9 +145,18 @@ fn main() -> ExitCode {
 
         // Phase B1 / B2 / B3: sca, audit, scan are ported. Only `update`
         // still falls through to the Python CLI stub.
-        "sca" => sca::run(&argv[2..]),
-        "audit" => audit::run(&argv[2..]),
-        "scan" => scan::run(&argv[2..]),
+        "sca" => {
+            telemetry::record("sca");
+            sca::run(&argv[2..])
+        }
+        "audit" => {
+            telemetry::record("audit");
+            audit::run(&argv[2..])
+        }
+        "scan" => {
+            telemetry::record("scan");
+            scan::run(&argv[2..])
+        }
         "update" => stub::dispatch(&argv[1..]),
 
         // Unknown command. Match Python's error style + exit 1. Python

--- a/packages/arcis-rust/crates/arcis-cli/src/telemetry.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/telemetry.rs
@@ -1,0 +1,191 @@
+//! Anonymous, opt-out usage telemetry for the Arcis CLI.
+//!
+//! Why this exists: we need to know how many people actually run the free CLI
+//! and which commands they use, so the product is steered by real usage instead
+//! of guesses. Every early open-source security tool hits the same wall (Snyk
+//! famously had a thousand users it could not identify); this is the fix.
+//!
+//! What we DO NOT collect: source code, scanned paths, scan targets/URLs,
+//! findings, request contents, IP addresses, usernames, or anything that could
+//! identify a person or a codebase. The full payload is: a random install id,
+//! the CLI version, the command name, OS, CPU arch, and whether it ran in CI.
+//!
+//! Posture: opt-out, on by default for the CLI only (the same posture used by
+//! Next.js, Astro, and Homebrew for interactive developer tools). The Arcis
+//! SDKs stay opt-in. Disable with `ARCIS_TELEMETRY=0` or the cross-tool
+//! `DO_NOT_TRACK` standard (https://consoledonottrack.com).
+//!
+//! Transport: one fire-and-forget POST on a detached thread with a 2s timeout.
+//! It never blocks the command, never changes its exit code, and swallows every
+//! error. If the collector is unreachable, the command behaves exactly as if
+//! telemetry were off.
+
+use std::io::{IsTerminal, Write};
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Collector endpoint. Override with `ARCIS_TELEMETRY_ENDPOINT` (used by the
+/// collector's own tests and if the URL moves without a CLI rebuild).
+///
+/// TODO(publish): replace this default with the deployed collector URL (the
+/// Cloudflare Worker in `arcis-telemetry/`) before the next `@arcis/cli`
+/// publish. Until then the POST fails open and no data is collected.
+const DEFAULT_ENDPOINT: &str = "https://telemetry.arcis.dev/v1/cli";
+
+/// Where the one-time notice points users to read more / opt out.
+const DOC_URL: &str =
+    "https://github.com/getarcis/arcis/blob/main/packages/arcis-rust/TELEMETRY.md";
+
+/// Decide opt-out purely from the two env values, so the privacy logic is
+/// unit-testable without mutating the process environment.
+fn opted_out(arcis_telemetry: Option<&str>, do_not_track: Option<&str>) -> bool {
+    // Explicit kill switch wins: ARCIS_TELEMETRY=0/false/off/no disables.
+    if let Some(v) = arcis_telemetry {
+        let v = v.trim().to_ascii_lowercase();
+        if matches!(v.as_str(), "0" | "false" | "off" | "no") {
+            return true;
+        }
+    }
+    // Cross-tool standard: any value that is not empty / "0" / "false" opts out.
+    if let Some(v) = do_not_track {
+        let v = v.trim();
+        if !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false") {
+            return true;
+        }
+    }
+    false
+}
+
+/// True unless the user opted out via `ARCIS_TELEMETRY` or `DO_NOT_TRACK`.
+pub fn enabled() -> bool {
+    let a = std::env::var("ARCIS_TELEMETRY").ok();
+    let d = std::env::var("DO_NOT_TRACK").ok();
+    !opted_out(a.as_deref(), d.as_deref())
+}
+
+/// `~/.arcis` (or `%USERPROFILE%\.arcis`), matching the history + OSV-cache
+/// convention the rest of the CLI already uses.
+fn arcis_home() -> Option<PathBuf> {
+    let home = std::env::var("HOME")
+        .ok()
+        .or_else(|| std::env::var("USERPROFILE").ok())?;
+    Some(PathBuf::from(home).join(".arcis"))
+}
+
+/// Stable anonymous install id, persisted at `~/.arcis/install-id` and generated
+/// once with a v4 UUID. If the home dir cannot be read or written (read-only
+/// home, locked-down CI), fall back to an ephemeral id so a single run still
+/// reports without accumulating a persistent identity.
+fn install_id() -> String {
+    if let Some(dir) = arcis_home() {
+        let path = dir.join("install-id");
+        if let Ok(existing) = std::fs::read_to_string(&path) {
+            let id = existing.trim().to_string();
+            if !id.is_empty() {
+                return id;
+            }
+        }
+        let id = uuid::Uuid::new_v4().to_string();
+        let _ = std::fs::create_dir_all(&dir);
+        let _ = std::fs::write(&path, &id);
+        return id;
+    }
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// Print the one-time telemetry notice to stderr, then drop a marker so it is
+/// never shown again. Only on an interactive stderr, so it never appears in
+/// piped output, CI logs, or the byte-for-byte parity harness (which reads
+/// stdout on non-TTY paths). If stderr is not a TTY we skip without writing the
+/// marker, so the next real terminal session still gets the notice once.
+fn maybe_print_notice() {
+    let Some(dir) = arcis_home() else { return };
+    let marker = dir.join(".telemetry-notified");
+    if marker.exists() {
+        return;
+    }
+    if !std::io::stderr().is_terminal() {
+        return;
+    }
+    let _ = std::fs::create_dir_all(&dir);
+    let mut err = std::io::stderr();
+    let _ = writeln!(
+        err,
+        "arcis collects anonymous usage stats (CLI version, command, OS) to guide \
+         development. No code, findings, paths, or personal data. Opt out any time \
+         with ARCIS_TELEMETRY=0. Details: {DOC_URL}"
+    );
+    let _ = std::fs::write(&marker, b"1");
+}
+
+fn endpoint() -> String {
+    std::env::var("ARCIS_TELEMETRY_ENDPOINT")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string())
+}
+
+/// Record one anonymous event for `command`. Fire-and-forget: spawns a detached
+/// thread that does a short-timeout POST and returns immediately. Never blocks
+/// the command, never affects its exit code, swallows every error.
+pub fn record(command: &str) {
+    if !enabled() {
+        return;
+    }
+    maybe_print_notice();
+
+    let body = serde_json::json!({
+        "install_id": install_id(),
+        "cli_version": env!("CARGO_PKG_VERSION"),
+        "command": command,
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "ci": std::env::var("CI").is_ok(),
+    })
+    .to_string();
+    let url = endpoint();
+
+    std::thread::spawn(move || {
+        if let Ok(client) = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+        {
+            let _ = client
+                .post(&url)
+                .header("content-type", "application/json")
+                .body(body)
+                .send();
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::opted_out;
+
+    #[test]
+    fn default_is_enabled() {
+        assert!(!opted_out(None, None));
+    }
+
+    #[test]
+    fn arcis_telemetry_kill_switch() {
+        for off in ["0", "false", "FALSE", "off", "No", " 0 "] {
+            assert!(opted_out(Some(off), None), "ARCIS_TELEMETRY={off:?} should opt out");
+        }
+        // A truthy / unrelated value does NOT opt out (only explicit off values).
+        assert!(!opted_out(Some("1"), None));
+        assert!(!opted_out(Some("on"), None));
+    }
+
+    #[test]
+    fn do_not_track_standard() {
+        for on in ["1", "true", "yes", "anything"] {
+            assert!(opted_out(None, Some(on)), "DO_NOT_TRACK={on:?} should opt out");
+        }
+        // The documented "tracking allowed" values do NOT opt out.
+        assert!(!opted_out(None, Some("0")));
+        assert!(!opted_out(None, Some("false")));
+        assert!(!opted_out(None, Some("")));
+    }
+}

--- a/packages/arcis-rust/crates/arcis-cli/src/telemetry.rs
+++ b/packages/arcis-rust/crates/arcis-cli/src/telemetry.rs
@@ -171,7 +171,10 @@ mod tests {
     #[test]
     fn arcis_telemetry_kill_switch() {
         for off in ["0", "false", "FALSE", "off", "No", " 0 "] {
-            assert!(opted_out(Some(off), None), "ARCIS_TELEMETRY={off:?} should opt out");
+            assert!(
+                opted_out(Some(off), None),
+                "ARCIS_TELEMETRY={off:?} should opt out"
+            );
         }
         // A truthy / unrelated value does NOT opt out (only explicit off values).
         assert!(!opted_out(Some("1"), None));
@@ -181,7 +184,10 @@ mod tests {
     #[test]
     fn do_not_track_standard() {
         for on in ["1", "true", "yes", "anything"] {
-            assert!(opted_out(None, Some(on)), "DO_NOT_TRACK={on:?} should opt out");
+            assert!(
+                opted_out(None, Some(on)),
+                "DO_NOT_TRACK={on:?} should opt out"
+            );
         }
         // The documented "tracking allowed" values do NOT opt out.
         assert!(!opted_out(None, Some("0")));


### PR DESCRIPTION
Two growth-groundwork changes plus repo hygiene.

## @arcis/mcp: reposition as runtime security
Reframes the package away from "another code scanner" toward runtime and request-layer security, the differentiated angle: it screens text headed for an LLM for prompt-injection and probes a running endpoint for live attack bypasses, alongside the existing code-audit and supply-chain tools.
- description + README + keywords rewritten
- `server.json` added (MCP registry manifest)
- stale internal server version fixed (1.5.0 -> 1.6.1)
- build + 12 tests green

## CLI: anonymous, opt-out telemetry
So usage data, not guesswork, steers the roadmap.
- One fire-and-forget event per command: install id, CLI version, command, os, arch, ci. No code, paths, findings, IPs, or personal data.
- Opt out with `ARCIS_TELEMETRY=0` or `DO_NOT_TRACK`. One-time stderr notice.
- Fail-open: never blocks the command or changes its exit code.
- Documented in `packages/arcis-rust/TELEMETRY.md`.
- `cargo test -p arcis-cli` green (267 tests).

## Hygiene
- `AGENTS.md` for AI coding agents working in the repo.
- `SECURITY.md` vulnerability-disclosure policy.

## Notes
- The CLI telemetry endpoint is a placeholder constant and fails open, so this is safe to merge before the collector is deployed. The real URL is set before the next CLI publish.
- The `@arcis/mcp` version bump + publish and the collector deployment are follow-ups.